### PR TITLE
Add repo convention files for review guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,9 +197,30 @@ curl -X PUT http://localhost:3000/api/config/repos/owner/repo \
   -d '{
     "style": "roast",
     "focusAreas": ["security", "bugs", "performance"],
-    "ignorePatterns": ["*.generated.ts", "vendor/**"],
-    "customInstructions": "This repo uses Effect-TS, review accordingly"
+    "ignorePatterns": ["*.generated.ts", "vendor/**"]
   }'
+```
+
+### Convention Files
+
+Check in a markdown file to your repo root to provide review instructions:
+
+| File | Priority |
+|------|----------|
+| `.rusty-bot.md` | Highest |
+| `REVIEW-BOT.md` | Medium |
+| `AGENTS.md` | Lowest |
+
+The bot picks up the first file found (winner-takes-all) and injects its content into the system prompt. The file is fetched from the **target branch** so PR authors cannot tamper with review rules.
+
+Example `.rusty-bot.md`:
+
+```markdown
+- We use Effect-TS, don't flag `.pipe()` chains as complexity issues
+- All API endpoints must have Zod validation — flag missing schemas as warnings
+- Ignore `generated/` and `__snapshots__/` directories
+- Security findings in `scripts/` are low priority, it's internal tooling
+- Be lenient on style, strict on security
 ```
 
 ### Review Styles

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -6,6 +6,7 @@ import {
   summarizeLanguages,
   extractTicketRefs,
   resolveTicketsWithStatus,
+  fetchConventionFile,
   AzureDevOpsTicketProvider,
   runMultiCallReview,
   formatSummaryComment,
@@ -50,7 +51,6 @@ export function parseConfig(): {
   const focusAreas = (process.env.RUSTY_FOCUS_AREAS?.split(",").filter(Boolean) ??
     []) as FocusArea[];
   const ignorePatterns = process.env.RUSTY_IGNORE_PATTERNS?.split(",").filter(Boolean) ?? [];
-  const customInstructions = process.env.RUSTY_CUSTOM_INSTRUCTIONS;
   const failOnCritical = process.env.RUSTY_FAIL_ON_CRITICAL !== "false";
 
   return {
@@ -65,7 +65,6 @@ export function parseConfig(): {
       style: reviewStyle as ReviewStyle,
       focusAreas,
       ignorePatterns,
-      ...(customInstructions ? { customInstructions } : {}),
     },
     failOnCritical,
     env: { orgUrl, project, accessToken },
@@ -80,6 +79,14 @@ async function main(): Promise<void> {
     { prId: metadata.id, source: metadata.sourceBranch, target: metadata.targetBranch },
     "reviewing PR",
   );
+
+  const conventionFile = await fetchConventionFile(
+    (path, ref) => provider.getFileContent(path, ref),
+    metadata.targetBranch,
+  );
+  if (conventionFile) {
+    config.conventionFile = conventionFile;
+  }
 
   await provider.deleteExistingBotComments();
 

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -93,16 +93,16 @@ describe("buildSystemPrompt", () => {
     }
   });
 
-  it("includes custom instructions when provided", () => {
+  it("includes convention file content when provided", () => {
     const prompt = buildSystemPrompt({
       ...baseConfig,
-      customInstructions: "Always check for SQL injection in raw queries",
+      conventionFile: "Always check for SQL injection in raw queries",
     });
     expect(prompt).toContain("Always check for SQL injection in raw queries");
     expect(prompt).toContain("repository maintainer");
   });
 
-  it("omits custom instructions section when not provided", () => {
+  it("omits convention instructions section when not provided", () => {
     const prompt = buildSystemPrompt(baseConfig);
     expect(prompt).not.toContain("repository maintainer");
   });

--- a/packages/core/src/__tests__/convention-file.test.ts
+++ b/packages/core/src/__tests__/convention-file.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, vi } from "vitest";
+import { fetchConventionFile } from "../convention-file.js";
+
+function makeFetcher(files: Record<string, string>) {
+  return vi.fn(async (path: string, _ref: string) => files[path] ?? null);
+}
+
+describe("fetchConventionFile", () => {
+  it("returns .rusty-bot.md when it exists", async () => {
+    const fetcher = makeFetcher({ ".rusty-bot.md": "be strict on security" });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe("be strict on security");
+    expect(fetcher).toHaveBeenCalledWith(".rusty-bot.md", "main");
+  });
+
+  it("falls back to REVIEW-BOT.md when .rusty-bot.md is missing", async () => {
+    const fetcher = makeFetcher({ "REVIEW-BOT.md": "ignore generated/" });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe("ignore generated/");
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls back to AGENTS.md when the first two are missing", async () => {
+    const fetcher = makeFetcher({ "AGENTS.md": "use effect-ts conventions" });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe("use effect-ts conventions");
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns null when no convention files exist", async () => {
+    const fetcher = makeFetcher({});
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+
+  it("uses the highest-priority file when multiple exist", async () => {
+    const fetcher = makeFetcher({
+      ".rusty-bot.md": "from rusty-bot",
+      "REVIEW-BOT.md": "from review-bot",
+      "AGENTS.md": "from agents",
+    });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe("from rusty-bot");
+  });
+
+  it("stops fetching after the first match", async () => {
+    const fetcher = makeFetcher({
+      ".rusty-bot.md": "found",
+      "REVIEW-BOT.md": "should not reach",
+    });
+    await fetchConventionFile(fetcher, "main");
+
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(fetcher).not.toHaveBeenCalledWith("REVIEW-BOT.md", "main");
+  });
+
+  it("passes the ref to getFileContent", async () => {
+    const fetcher = makeFetcher({ ".rusty-bot.md": "content" });
+    await fetchConventionFile(fetcher, "develop");
+
+    expect(fetcher).toHaveBeenCalledWith(".rusty-bot.md", "develop");
+  });
+
+  it("truncates content that exceeds the token limit", async () => {
+    // 5000 tokens * 4 chars/token = 20000 chars
+    const longContent = "x".repeat(25_000);
+    const fetcher = makeFetcher({ ".rusty-bot.md": longContent });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(20_000);
+  });
+
+  it("does not truncate content within the token limit", async () => {
+    const content = "a".repeat(19_000);
+    const fetcher = makeFetcher({ ".rusty-bot.md": content });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe(content);
+  });
+
+  it("truncates at newline boundaries", async () => {
+    const lines = Array.from({ length: 1000 }, (_, i) => `line ${i}: ${"x".repeat(20)}`);
+    const longContent = lines.join("\n");
+    const fetcher = makeFetcher({ ".rusty-bot.md": longContent });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).not.toBeNull();
+    expect(result!.endsWith("\n")).toBe(false);
+    // should end at a complete line, not mid-line
+    const lastChar = result!.at(-1);
+    expect(lastChar).not.toBe(undefined);
+    expect(result!.includes("\n")).toBe(true);
+  });
+
+  it("returns null and does not throw when fetcher throws", async () => {
+    const fetcher = vi.fn(async () => {
+      throw new Error("network timeout");
+    });
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBeNull();
+  });
+
+  it("skips erroring file and tries the next one", async () => {
+    let callCount = 0;
+    const fetcher = vi.fn(async (path: string, _ref: string) => {
+      callCount++;
+      if (path === ".rusty-bot.md") throw new Error("403 forbidden");
+      if (path === "REVIEW-BOT.md") return "fallback content";
+      return null;
+    });
+
+    const result = await fetchConventionFile(fetcher, "main");
+
+    expect(result).toBe("fallback content");
+    expect(callCount).toBe(2);
+  });
+});

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -25,14 +25,14 @@ export function buildSystemPrompt(config: ReviewConfig): string {
   const base = loadTemplate("base.txt");
   const styleInstructions = buildStyleInstructions(config.style);
   const focusInstructions = buildFocusInstructions(config.focusAreas);
-  const customInstructions = config.customInstructions
-    ? `\n\nAdditional instructions from the repository maintainer:\n${config.customInstructions}`
+  const conventionInstructions = config.conventionFile
+    ? `\n\nAdditional instructions from the repository maintainer:\n${config.conventionFile}`
     : "";
 
   return base
     .replace("{{style_instructions}}", styleInstructions)
     .replace("{{focus_instructions}}", focusInstructions)
-    .replace("{{custom_instructions}}", customInstructions);
+    .replace("{{convention_instructions}}", conventionInstructions);
 }
 
 export function buildUserMessage(

--- a/packages/core/src/convention-file.ts
+++ b/packages/core/src/convention-file.ts
@@ -1,0 +1,58 @@
+import { logger } from "./logger.js";
+
+const log = logger.child({ module: "convention-file" });
+
+const CONVENTION_FILENAMES = [".rusty-bot.md", "REVIEW-BOT.md", "AGENTS.md"] as const;
+
+const MAX_CONVENTION_TOKENS = 5_000;
+
+type FileContentFetcher = (path: string, ref: string) => Promise<string | null>;
+
+function countTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+function truncateToTokenLimit(content: string, maxTokens: number): string {
+  const tokens = countTokens(content);
+  if (tokens <= maxTokens) return content;
+
+  // rough char estimate: 4 chars per token
+  const maxChars = maxTokens * 4;
+  const truncated = content.slice(0, maxChars);
+  // cut at the last newline to avoid splitting mid-line
+  const lastNewline = truncated.lastIndexOf("\n");
+  const result = lastNewline > 0 ? truncated.slice(0, lastNewline) : truncated;
+
+  log.warn(
+    { tokens, maxTokens, truncatedLength: result.length },
+    "convention file exceeded token limit, truncated",
+  );
+
+  return result;
+}
+
+/**
+ * Fetch the first matching convention file from the repo root.
+ *
+ * Tries `.rusty-bot.md`, `REVIEW-BOT.md`, `AGENTS.md` in order and returns
+ * the content of the first one found, truncated to the token limit.
+ * Returns `null` if none exist. Swallows errors and logs a warning.
+ */
+export async function fetchConventionFile(
+  getFileContent: FileContentFetcher,
+  ref: string,
+): Promise<string | null> {
+  for (const filename of CONVENTION_FILENAMES) {
+    try {
+      const content = await getFileContent(filename, ref);
+      if (content != null) {
+        log.info({ filename, ref }, "loaded convention file");
+        return truncateToTokenLimit(content, MAX_CONVENTION_TOKENS);
+      }
+    } catch (err) {
+      log.warn({ filename, ref, err }, "failed to fetch convention file, skipping");
+    }
+  }
+
+  return null;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,3 +28,4 @@ export * from "./tickets/index.js";
 export * from "./diff/index.js";
 export * from "./agent/index.js";
 export * from "./mcp/index.js";
+export { fetchConventionFile } from "./convention-file.js";

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -31,4 +31,4 @@ Important rules:
 - For ticket compliance, use "not_addressed" only when the visible changes clearly fail to satisfy a requirement; use "unclear" when the diff does not contain enough evidence to decide.
 {{style_instructions}}
 {{focus_instructions}}
-{{custom_instructions}}
+{{convention_instructions}}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -54,7 +54,7 @@ export interface ReviewConfig {
   style: ReviewStyle;
   focusAreas: FocusArea[];
   ignorePatterns: string[];
-  customInstructions?: string;
+  conventionFile?: string;
   consensusPasses?: number;
   consensusThreshold?: number | null;
 }

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -6,7 +6,6 @@ export interface RepoConfig {
   style: "strict" | "balanced" | "lenient" | "roast";
   focusAreas: string[];
   ignorePatterns: string[];
-  customInstructions: string;
 }
 
 export interface Settings {
@@ -53,7 +52,7 @@ export const api = {
   updateRepo: (
     owner: string,
     repo: string,
-    body: Pick<RepoConfig, "style" | "focusAreas" | "ignorePatterns" | "customInstructions">,
+    body: Pick<RepoConfig, "style" | "focusAreas" | "ignorePatterns">,
   ) =>
     request<RepoConfig>(`/api/config/repos/${owner}/${repo}`, {
       method: "PUT",

--- a/packages/dashboard/src/pages/RepoConfig.tsx
+++ b/packages/dashboard/src/pages/RepoConfig.tsx
@@ -49,14 +49,12 @@ export function RepoConfig() {
   const [style, setStyle] = useState<RepoConfig["style"]>("balanced");
   const [focusAreas, setFocusAreas] = useState<string[]>([]);
   const [ignorePatterns, setIgnorePatterns] = useState("");
-  const [customInstructions, setCustomInstructions] = useState("");
 
   useEffect(() => {
     if (data) {
       setStyle(data.style);
       setFocusAreas(data.focusAreas);
       setIgnorePatterns(data.ignorePatterns.join("\n"));
-      setCustomInstructions(data.customInstructions);
     }
   }, [data]);
 
@@ -69,7 +67,6 @@ export function RepoConfig() {
           .split("\n")
           .map((s) => s.trim())
           .filter(Boolean),
-        customInstructions,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["repo", owner, repo] });
@@ -170,19 +167,6 @@ export function RepoConfig() {
           className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-amber-400 font-mono resize-y"
         />
         <p className="text-xs text-slate-500 mt-1">one pattern per line</p>
-      </section>
-
-      <section className="mb-8">
-        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wide mb-3">
-          Custom Instructions
-        </h2>
-        <textarea
-          rows={5}
-          value={customInstructions}
-          onChange={(e) => setCustomInstructions(e.target.value)}
-          placeholder="Any additional context or instructions for the reviewer…"
-          className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-amber-400 resize-y"
-        />
       </section>
 
       {mutation.isSuccess && <p className="text-green-400 text-sm mb-3">Saved successfully.</p>}

--- a/packages/dashboard/src/pages/Repos.tsx
+++ b/packages/dashboard/src/pages/Repos.tsx
@@ -21,7 +21,6 @@ function AddRepoForm({ onClose }: { onClose: () => void }) {
         style: "balanced",
         focusAreas: [],
         ignorePatterns: [],
-        customInstructions: "",
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["repos"] });

--- a/packages/github/src/__tests__/server.test.ts
+++ b/packages/github/src/__tests__/server.test.ts
@@ -230,7 +230,6 @@ describe("server", () => {
         style: "strict",
         focusAreas: ["security", "bugs"],
         ignorePatterns: ["*.test.ts"],
-        customInstructions: "be extra careful",
       };
 
       const putRes = await app.request("/api/config/repos/my-org/my-repo", {

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -10,6 +10,7 @@ import {
   resolveTicketsWithStatus,
   runMultiCallReview,
   formatSummaryComment,
+  fetchConventionFile,
   GitHubTicketProvider,
   JiraTicketProvider,
   LinearTicketProvider,
@@ -63,12 +64,6 @@ export async function orchestrateReview(params: {
 
   try {
     const repoConfig = await getRepoConfig(owner, repo);
-    const config = {
-      style: repoConfig?.style ?? ("balanced" as const),
-      focusAreas: repoConfig?.focusAreas ?? ALL_FOCUS_AREAS,
-      ignorePatterns: repoConfig?.ignorePatterns ?? [],
-      customInstructions: repoConfig?.customInstructions,
-    };
 
     const provider = new GitHubProvider({ octokit, owner, repo, pullNumber });
 
@@ -78,6 +73,18 @@ export async function orchestrateReview(params: {
       provider.getPRMetadata(),
       provider.getRawDiff(),
     ]);
+
+    const conventionFile = await fetchConventionFile(
+      (path, ref) => provider.getFileContent(path, ref),
+      metadata.targetBranch,
+    );
+
+    const config = {
+      style: repoConfig?.style ?? ("balanced" as const),
+      focusAreas: repoConfig?.focusAreas ?? ALL_FOCUS_AREAS,
+      ignorePatterns: repoConfig?.ignorePatterns ?? [],
+      ...(conventionFile ? { conventionFile } : {}),
+    };
 
     const patches = parseDiff(rawDiff);
     const filtered = filterFiles(patches, config.ignorePatterns);

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -120,7 +120,6 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     style?: ReviewStyle;
     focusAreas?: FocusArea[];
     ignorePatterns?: string[];
-    customInstructions?: string;
   } = await c.req.json();
 
   const config: RepoConfig = {
@@ -129,7 +128,6 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     style: body.style ?? "balanced",
     focusAreas: body.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
     ignorePatterns: body.ignorePatterns ?? [],
-    customInstructions: body.customInstructions,
   };
 
   await setRepoConfig(owner, repo, config);

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -8,7 +8,6 @@ export interface RepoConfig {
   style: ReviewStyle;
   focusAreas: FocusArea[];
   ignorePatterns: string[];
-  customInstructions?: string;
   consensusPasses?: number;
   consensusThreshold?: number | null;
 }


### PR DESCRIPTION
Fixes #18

## Summary
- Load review guidance from repo-root convention files, preferring `.rusty-bot.md`, then `REVIEW-BOT.md`, then `AGENTS.md`.
- Fetch convention files from the target branch and inject their contents into the review system prompt.
- Remove dashboard and API support for manual `customInstructions` repo settings in favor of checked-in convention files.
- Add tests for convention file discovery, priority, truncation, and prompt integration.

## Testing
- `Not run` automated tests in this environment.
- Added/updated unit coverage for convention file loading and prompt construction.
- Updated API/server tests to reflect removal of `customInstructions` from repo config payloads.