### PR TITLE
Add triage-driven cascading review flow

### DIFF
--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -8,10 +8,14 @@ import {
   resolveTickets,
   AzureDevOpsTicketProvider,
   runMultiCallReview,
+  runCascadeReview,
   formatSummaryComment,
   loadMcpServerConfigsFromEnv,
   logger,
   flushLogger,
+  isCascadeEnabled,
+  runTriage,
+  splitByClassification,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -86,12 +90,9 @@ async function main(): Promise<void> {
   const rawPatches = await provider.getDiff();
   const filtered = filterFiles(rawPatches, config.ignorePatterns);
   const reviewable = stripDeletionOnlyHunks(filtered);
-  const expanded = await expandContext(reviewable, (path) =>
-    provider.getFileContent(path, metadata.sourceBranch),
-  );
-  const skippedCount = rawPatches.length - expanded.length;
+  const skippedCount = rawPatches.length - reviewable.length;
   log.info(
-    { total: rawPatches.length, reviewed: expanded.length, skipped: skippedCount },
+    { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
     "files changed",
   );
 
@@ -111,22 +112,76 @@ async function main(): Promise<void> {
 
   const tickets = await resolveTickets(ticketRefs, ticketProviders);
 
-  const languageSummary = summarizeLanguages(expanded);
+  const languageSummary = summarizeLanguages(reviewable);
   const mcpServers = await loadMcpServerConfigsFromEnv();
 
-  const review = await runMultiCallReview(
-    expanded,
-    config,
-    metadata,
-    tickets.length > 0 ? tickets : undefined,
-    {
-      provider,
-      sourceRef: metadata.sourceBranch,
-      languageSummary,
-      mcpServers,
-      maxTokens: MAX_TOKENS,
-    },
-  );
+  let review;
+
+  if (isCascadeEnabled()) {
+    log.info({ fileCount: reviewable.length }, "cascade enabled, running triage");
+
+    let triageResult;
+    try {
+      triageResult = await runTriage(reviewable);
+    } catch (err) {
+      log.warn({ err }, "triage failed, falling back to full review");
+    }
+
+    if (triageResult) {
+      const { skip, skim, deepReview } = splitByClassification(reviewable, triageResult.files);
+      log.info(
+        { skipped: skip.length, skimmed: skim.length, deepReview: deepReview.length },
+        "triage classification",
+      );
+
+      const expandedDeep = await expandContext(deepReview, (path) =>
+        provider.getFileContent(path, metadata.sourceBranch),
+      );
+
+      review = await runCascadeReview(
+        skim,
+        expandedDeep,
+        config,
+        metadata,
+        tickets.length > 0 ? tickets : undefined,
+        {
+          provider,
+          sourceRef: metadata.sourceBranch,
+          languageSummary,
+          mcpServers,
+          maxTokens: MAX_TOKENS,
+        },
+      );
+
+      review.triageStats = {
+        filesSkipped: skip.length,
+        filesSkimmed: skim.length,
+        filesDeepReviewed: deepReview.length,
+        triageModelUsed: triageResult.modelUsed,
+        triageTokenCount: triageResult.tokenCount,
+      };
+    }
+  }
+
+  if (!review) {
+    const expanded = await expandContext(reviewable, (path) =>
+      provider.getFileContent(path, metadata.sourceBranch),
+    );
+
+    review = await runMultiCallReview(
+      expanded,
+      config,
+      metadata,
+      tickets.length > 0 ? tickets : undefined,
+      {
+        provider,
+        sourceRef: metadata.sourceBranch,
+        languageSummary,
+        mcpServers,
+        maxTokens: MAX_TOKENS,
+      },
+    );
+  }
 
   const criticalCount = review.findings.filter((f) => f.severity === "critical").length;
   const warningCount = review.findings.filter((f) => f.severity === "warning").length;

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -275,3 +275,74 @@ describe("formatInlineComment", () => {
     expect(result).toContain("```suggestion");
   });
 });
+
+describe("formatSummaryComment with triage stats", () => {
+  it("includes triage section when triageStats is present", () => {
+    const review: ReviewResult = {
+      summary: "Looks good.",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      filesReviewed: ["src/index.ts"],
+      modelUsed: "claude-sonnet-4",
+      tokenCount: 5000,
+      triageStats: {
+        filesSkipped: 3,
+        filesSkimmed: 2,
+        filesDeepReviewed: 5,
+        triageModelUsed: "claude-haiku-3",
+        triageTokenCount: 800,
+      },
+    };
+
+    const result = formatSummaryComment(review);
+    expect(result).toContain("Triage Summary");
+    expect(result).toContain("Skipped");
+    expect(result).toContain("3");
+    expect(result).toContain("Skimmed");
+    expect(result).toContain("2");
+    expect(result).toContain("Deep Reviewed");
+    expect(result).toContain("5");
+    expect(result).toContain("claude-haiku-3");
+    expect(result).toContain("800 tokens");
+  });
+
+  it("omits triage section when triageStats is not present", () => {
+    const review: ReviewResult = {
+      summary: "OK",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      filesReviewed: [],
+      modelUsed: "gpt-4o",
+      tokenCount: 1000,
+    };
+
+    const result = formatSummaryComment(review);
+    expect(result).not.toContain("Triage Summary");
+  });
+
+  it("triage section appears before overview section", () => {
+    const review: ReviewResult = {
+      summary: "Fine.",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      filesReviewed: [],
+      modelUsed: "test",
+      tokenCount: 100,
+      triageStats: {
+        filesSkipped: 1,
+        filesSkimmed: 1,
+        filesDeepReviewed: 1,
+        triageModelUsed: "haiku",
+        triageTokenCount: 50,
+      },
+    };
+
+    const result = formatSummaryComment(review);
+    const triageIdx = result.indexOf("Triage Summary");
+    const overviewIdx = result.indexOf("## Overview");
+    expect(triageIdx).toBeLessThan(overviewIdx);
+  });
+});

--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { ReviewOutputSchema } from "../agent/schema.js";
+import { ReviewOutputSchema, SkimReviewOutputSchema } from "../agent/schema.js";
+import { TriageOutputSchema } from "../triage/schema.js";
 
 interface JsonSchemaObject {
   type?: string;
@@ -54,6 +55,28 @@ function collectStrictViolations(schema: JsonSchemaObject, path = ""): string[] 
 describe("ReviewOutputSchema strict mode compatibility", () => {
   it("has all properties listed in required (openai strict structured output)", () => {
     const jsonSchema = z.toJSONSchema(ReviewOutputSchema) as JsonSchemaObject;
+    const violations = collectStrictViolations(jsonSchema);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("SkimReviewOutputSchema strict mode compatibility", () => {
+  it("has all properties listed in required", () => {
+    const jsonSchema = z.toJSONSchema(SkimReviewOutputSchema) as JsonSchemaObject;
+    const violations = collectStrictViolations(jsonSchema);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+
+  it("does not include suggestedFix in findings", () => {
+    const jsonSchema = z.toJSONSchema(SkimReviewOutputSchema) as JsonSchemaObject;
+    const findingsItems = jsonSchema.properties?.findings?.items;
+    expect(findingsItems?.properties).not.toHaveProperty("suggestedFix");
+  });
+});
+
+describe("TriageOutputSchema strict mode compatibility", () => {
+  it("has all properties listed in required", () => {
+    const jsonSchema = z.toJSONSchema(TriageOutputSchema) as JsonSchemaObject;
     const violations = collectStrictViolations(jsonSchema);
     expect(violations, violations.join("\n")).toEqual([]);
   });

--- a/packages/core/src/__tests__/triage.test.ts
+++ b/packages/core/src/__tests__/triage.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import type { FilePatch, TriageFileResult } from "../types.js";
+import { TriageOutputSchema } from "../triage/schema.js";
+import { buildTriageSystemPrompt, buildTriageUserMessage } from "../triage/prompt.js";
+import { splitByClassification, isCascadeEnabled } from "../triage/triage.js";
+
+function makePatch(path: string, additions = 10): FilePatch {
+  const lines = Array.from({ length: additions }, (_, i) => `+line ${i}`).join("\n");
+  return {
+    path,
+    additions,
+    deletions: 0,
+    isBinary: false,
+    hunks: [
+      {
+        oldStart: 1,
+        oldLines: 0,
+        newStart: 1,
+        newLines: additions,
+        content: lines,
+      },
+    ],
+  };
+}
+
+describe("TriageOutputSchema", () => {
+  it("accepts valid triage output", () => {
+    const input = {
+      files: [
+        { path: "src/index.ts", classification: "deep-review", reason: "new logic" },
+        { path: "README.md", classification: "skim", reason: "docs only" },
+        { path: "pnpm-lock.yaml", classification: "skip", reason: "lock file" },
+      ],
+    };
+    const result = TriageOutputSchema.parse(input);
+    expect(result.files).toHaveLength(3);
+  });
+
+  it("rejects invalid classification values", () => {
+    const input = {
+      files: [{ path: "x.ts", classification: "maybe", reason: "unsure" }],
+    };
+    expect(() => TriageOutputSchema.parse(input)).toThrow();
+  });
+
+  it("rejects missing path field", () => {
+    const input = {
+      files: [{ classification: "skip", reason: "no path" }],
+    };
+    expect(() => TriageOutputSchema.parse(input)).toThrow();
+  });
+
+  it("rejects missing reason field", () => {
+    const input = {
+      files: [{ path: "x.ts", classification: "skip" }],
+    };
+    expect(() => TriageOutputSchema.parse(input)).toThrow();
+  });
+
+  it("rejects empty files array schema is still valid", () => {
+    const input = { files: [] };
+    const result = TriageOutputSchema.parse(input);
+    expect(result.files).toHaveLength(0);
+  });
+
+  it("rejects when files field is missing", () => {
+    expect(() => TriageOutputSchema.parse({})).toThrow();
+  });
+});
+
+describe("buildTriageSystemPrompt", () => {
+  it("includes classification instructions", () => {
+    const prompt = buildTriageSystemPrompt();
+    expect(prompt).toContain("skip");
+    expect(prompt).toContain("skim");
+    expect(prompt).toContain("deep-review");
+  });
+
+  it("mentions lock files in rules", () => {
+    const prompt = buildTriageSystemPrompt();
+    expect(prompt).toContain("lock files");
+  });
+
+  it("mentions security-relevant changes", () => {
+    const prompt = buildTriageSystemPrompt();
+    expect(prompt).toMatch(/security|auth|crypto/i);
+  });
+});
+
+describe("buildTriageUserMessage", () => {
+  it("includes file paths", () => {
+    const patches = [makePatch("src/auth.ts"), makePatch("README.md")];
+    const msg = buildTriageUserMessage(patches);
+    expect(msg).toContain("src/auth.ts");
+    expect(msg).toContain("README.md");
+  });
+
+  it("includes file count", () => {
+    const patches = [makePatch("a.ts"), makePatch("b.ts"), makePatch("c.ts")];
+    const msg = buildTriageUserMessage(patches);
+    expect(msg).toContain("3 files");
+  });
+
+  it("truncates large patches", () => {
+    const largePatch = makePatch("big.ts", 5000);
+    const msg = buildTriageUserMessage([largePatch]);
+    expect(msg).toContain("truncated");
+  });
+
+  it("handles empty patches array", () => {
+    const msg = buildTriageUserMessage([]);
+    expect(msg).toContain("0 files");
+  });
+});
+
+describe("splitByClassification", () => {
+  const patches = [
+    makePatch("src/index.ts"),
+    makePatch("README.md"),
+    makePatch("package-lock.json"),
+    makePatch("src/auth.ts"),
+    makePatch("docs/guide.md"),
+  ];
+
+  it("splits files correctly into three groups", () => {
+    const triageFiles: TriageFileResult[] = [
+      { path: "src/index.ts", classification: "deep-review", reason: "logic" },
+      { path: "README.md", classification: "skim", reason: "docs" },
+      { path: "package-lock.json", classification: "skip", reason: "lock" },
+      { path: "src/auth.ts", classification: "deep-review", reason: "security" },
+      { path: "docs/guide.md", classification: "skim", reason: "docs" },
+    ];
+
+    const { skip, skim, deepReview } = splitByClassification(patches, triageFiles);
+    expect(skip.map((p) => p.path)).toEqual(["package-lock.json"]);
+    expect(skim.map((p) => p.path)).toEqual(["README.md", "docs/guide.md"]);
+    expect(deepReview.map((p) => p.path)).toEqual(["src/index.ts", "src/auth.ts"]);
+  });
+
+  it("defaults unclassified files to deep-review", () => {
+    const triageFiles: TriageFileResult[] = [
+      { path: "src/index.ts", classification: "skim", reason: "simple" },
+    ];
+
+    const { skip, skim, deepReview } = splitByClassification(patches, triageFiles);
+    expect(skip).toHaveLength(0);
+    expect(skim).toHaveLength(1);
+    expect(deepReview).toHaveLength(4);
+  });
+
+  it("handles empty triage results by deep-reviewing everything", () => {
+    const { skip, skim, deepReview } = splitByClassification(patches, []);
+    expect(skip).toHaveLength(0);
+    expect(skim).toHaveLength(0);
+    expect(deepReview).toHaveLength(5);
+  });
+
+  it("handles all files being skipped", () => {
+    const triageFiles: TriageFileResult[] = patches.map((p) => ({
+      path: p.path,
+      classification: "skip" as const,
+      reason: "trivial",
+    }));
+
+    const { skip, skim, deepReview } = splitByClassification(patches, triageFiles);
+    expect(skip).toHaveLength(5);
+    expect(skim).toHaveLength(0);
+    expect(deepReview).toHaveLength(0);
+  });
+});
+
+describe("isCascadeEnabled", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.RUSTY_CASCADE_ENABLED;
+    delete process.env.RUSTY_LLM_TRIAGE_MODEL;
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("returns false when no triage model is set", () => {
+    expect(isCascadeEnabled()).toBe(false);
+  });
+
+  it("returns true when triage model is set", () => {
+    process.env.RUSTY_LLM_TRIAGE_MODEL = "anthropic/claude-haiku-3";
+    expect(isCascadeEnabled()).toBe(true);
+  });
+
+  it("returns false when explicitly disabled despite triage model", () => {
+    process.env.RUSTY_LLM_TRIAGE_MODEL = "anthropic/claude-haiku-3";
+    process.env.RUSTY_CASCADE_ENABLED = "false";
+    expect(isCascadeEnabled()).toBe(false);
+  });
+
+  it("returns true when explicitly enabled without triage model", () => {
+    process.env.RUSTY_CASCADE_ENABLED = "true";
+    expect(isCascadeEnabled()).toBe(true);
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,9 +1,14 @@
-export { ReviewOutputSchema } from "./schema.js";
+export { ReviewOutputSchema, SkimReviewOutputSchema } from "./schema.js";
 export { buildSystemPrompt, buildUserMessage } from "./prompts.js";
 export { runReview } from "./review.js";
-export type { RunReviewOptions } from "./review.js";
-export { runMultiCallReview } from "./multi-call.js";
+export type { RunReviewOptions, ReviewTier } from "./review.js";
+export { runMultiCallReview, runCascadeReview, mergeResults } from "./multi-call.js";
 export type { MultiCallReviewOptions } from "./multi-call.js";
-export { resolveModelConfig, resolveModel, getModelDisplayName } from "./model.js";
+export {
+  resolveModelConfig,
+  resolveTriageModelConfig,
+  resolveModel,
+  getModelDisplayName,
+} from "./model.js";
 export type { ModelConfig } from "./model.js";
 export { createSearchCodeTool, createGetFileContextTool } from "./tools.js";

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -44,6 +44,23 @@ export function resolveModelConfig(): ModelConfig {
   return { type: "router", model };
 }
 
+export function resolveTriageModelConfig(): ModelConfig | null {
+  const triageModel = process.env.RUSTY_LLM_TRIAGE_MODEL;
+  if (!triageModel) return null;
+  // triage model uses the same provider resolution logic but with its own model string
+  const saved = process.env.RUSTY_LLM_MODEL;
+  process.env.RUSTY_LLM_MODEL = triageModel;
+  try {
+    return resolveModelConfig();
+  } finally {
+    if (saved !== undefined) {
+      process.env.RUSTY_LLM_MODEL = saved;
+    } else {
+      delete process.env.RUSTY_LLM_MODEL;
+    }
+  }
+}
+
 export function resolveModel(
   config: ModelConfig,
 ): string | ReturnType<ReturnType<typeof createAzure>> {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -8,13 +8,12 @@ import type {
   Finding,
   Observation,
 } from "../types.js";
-import { runReview, type RunReviewOptions } from "./review.js";
+import { runReview, type RunReviewOptions, type ReviewTier } from "./review.js";
 import type { McpServerConfig } from "../mcp/types.js";
 import { connectMcpServers } from "../mcp/client.js";
 import { logger } from "../logger.js";
 
 export interface MultiCallReviewOptions extends RunReviewOptions {
-  /** MCP servers to connect to for additional tools. */
   mcpServers?: McpServerConfig;
   maxTokens?: number;
 }
@@ -47,7 +46,7 @@ function splitIntoGroups(patches: FilePatch[], maxTokensPerGroup: number): FileP
   return groups;
 }
 
-function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult {
+export function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult {
   const allFindings: Finding[] = [];
   const allObservations: Observation[] = [];
   const allFiles = new Set<string>();
@@ -84,6 +83,9 @@ function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult 
       ? summaries[0]
       : `Reviewed in ${results.length} passes.\n\n${summaries.join("\n\n")}`;
 
+  // preserve triageStats from any result that has it
+  const triageStats = results.find((r) => r.triageStats)?.triageStats;
+
   return {
     summary,
     recommendation,
@@ -92,7 +94,39 @@ function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult 
     filesReviewed: [...allFiles],
     modelUsed,
     tokenCount: totalTokens,
+    ...(triageStats ? { triageStats } : {}),
   };
+}
+
+async function runTieredReview(
+  patches: FilePatch[],
+  config: ReviewConfig,
+  prMetadata: PRMetadata,
+  ticketContext: TicketInfo[] | undefined,
+  resolvedOptions: RunReviewOptions,
+  maxTokens: number,
+  tier: ReviewTier,
+): Promise<ReviewResult[]> {
+  if (patches.length === 0) return [];
+
+  const tierOptions: RunReviewOptions = { ...resolvedOptions, tier };
+  const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
+
+  if (skippedFiles.length === 0) {
+    const result = await runReview(config, compressed, prMetadata, ticketContext, tierOptions);
+    return [result];
+  }
+
+  const groups = splitIntoGroups(patches, maxTokens);
+  const results: ReviewResult[] = [];
+  for (let i = 0; i < groups.length; i++) {
+    const { compressed: groupDiff } = compressDiff(groups[i], maxTokens);
+    const groupTickets = i === 0 ? ticketContext : undefined;
+    const result = await runReview(config, groupDiff, prMetadata, groupTickets, tierOptions);
+    results.push(result);
+  }
+
+  return results;
 }
 
 export async function runMultiCallReview(
@@ -143,6 +177,84 @@ export async function runMultiCallReview(
     }
 
     return mergeResults(results, results[0]?.modelUsed ?? "unknown");
+  } finally {
+    if (mcpDisconnect) {
+      try {
+        await mcpDisconnect();
+      } catch (err) {
+        logger.warn({ err }, "MCP disconnect error");
+      }
+    }
+  }
+}
+
+export async function runCascadeReview(
+  skimPatches: FilePatch[],
+  deepPatches: FilePatch[],
+  config: ReviewConfig,
+  prMetadata: PRMetadata,
+  ticketContext: TicketInfo[] | undefined,
+  options?: MultiCallReviewOptions,
+): Promise<ReviewResult> {
+  const { mcpServers, maxTokens: maxTokensOpt, ...reviewOptions } = options ?? {};
+  const maxTokens = maxTokensOpt ?? DEFAULT_MAX_TOKENS;
+
+  let mcpDisconnect: (() => Promise<void>) | undefined;
+  let resolvedOptions: RunReviewOptions = reviewOptions;
+
+  if (mcpServers && Object.keys(mcpServers).length > 0) {
+    try {
+      const mcp = await connectMcpServers(mcpServers);
+      mcpDisconnect = mcp.disconnect;
+      resolvedOptions = {
+        ...reviewOptions,
+        extraTools: { ...reviewOptions.extraTools, ...mcp.tools },
+      };
+    } catch (err) {
+      logger.warn({ err }, "failed to connect MCP servers; continuing without MCP tools");
+    }
+  }
+
+  try {
+    const allResults: ReviewResult[] = [];
+
+    // skim pass: diff-only context, no tools
+    const skimResults = await runTieredReview(
+      skimPatches,
+      config,
+      prMetadata,
+      undefined,
+      resolvedOptions,
+      maxTokens,
+      "skim",
+    );
+    allResults.push(...skimResults);
+
+    // deep-review pass: full context + tools, gets ticket context
+    const deepResults = await runTieredReview(
+      deepPatches,
+      config,
+      prMetadata,
+      ticketContext,
+      resolvedOptions,
+      maxTokens,
+      "deep-review",
+    );
+    allResults.push(...deepResults);
+
+    if (allResults.length === 0) {
+      return {
+        summary: "No files required review after triage.",
+        recommendation: "looks_good",
+        findings: [],
+        observations: [],
+        filesReviewed: [],
+        modelUsed: "unknown",
+        tokenCount: 0,
+      };
+    }
+
+    return mergeResults(allResults, allResults[0]?.modelUsed ?? "unknown");
   } finally {
     if (mcpDisconnect) {
       try {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -191,7 +191,6 @@ async function runTieredReview(
 
   const tierOptions: RunReviewOptions = { ...resolvedOptions, tier };
 
-  // skim tier uses single-pass runReview (no consensus needed for lightweight review)
   if (tier === "skim") {
     const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
     if (skippedFiles.length === 0) {
@@ -209,7 +208,7 @@ async function runTieredReview(
     return results;
   }
 
-  // deep-review tier uses consensus review + judge pass
+  // deep-review: consensus + ticket compliance
   const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
   if (skippedFiles.length === 0) {
     const result = await runConsensusReview(
@@ -218,7 +217,7 @@ async function runTieredReview(
       prMetadata,
       compressed,
       ticketContext,
-      resolvedOptions,
+      tierOptions,
     );
     return [result];
   }
@@ -233,7 +232,7 @@ async function runTieredReview(
       prMetadata,
       groupCompressed,
       ticketContext,
-      resolvedOptions,
+      tierOptions,
     );
     results.push(groupResult);
   }
@@ -357,11 +356,17 @@ export async function runCascadeReview(
   try {
     const allResults: ReviewResult[] = [];
 
+    // when there are no deep-review files but tickets exist,
+    // pass ticket context to the skim pass so it's at least visible in the prompt
+    const hasDeepFiles = deepPatches.length > 0;
+    const skimTickets = hasDeepFiles ? undefined : ticketContext;
+    const deepTickets = ticketContext;
+
     const skimResults = await runTieredReview(
       skimPatches,
       config,
       prMetadata,
-      undefined,
+      skimTickets,
       resolvedOptions,
       maxTokens,
       "skim",
@@ -372,7 +377,7 @@ export async function runCascadeReview(
       deepPatches,
       config,
       prMetadata,
-      ticketContext,
+      deepTickets,
       resolvedOptions,
       maxTokens,
       "deep-review",
@@ -394,7 +399,6 @@ export async function runCascadeReview(
 
     const merged = mergeResults(allResults, allResults[0]?.modelUsed ?? "unknown");
 
-    // run judge on deep-review findings only (skim findings are lightweight)
     const allPatches = [...skimPatches, ...deepPatches];
     const judgeDiff = compressDiff(allPatches, Infinity).compressed;
     const judgeConfig = resolveJudgeConfig();

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -1,20 +1,25 @@
 import { Agent } from "@mastra/core/agent";
 import type { ToolsInput } from "@mastra/core/agent";
-import { ReviewOutputSchema } from "./schema.js";
+import { ReviewOutputSchema, SkimReviewOutputSchema } from "./schema.js";
 import { buildSystemPrompt, buildUserMessage } from "./prompts.js";
 import { resolveModelConfig, resolveModel, getModelDisplayName } from "./model.js";
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
 import { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
 
+export type ReviewTier = "skim" | "deep-review";
+
 export interface RunReviewOptions {
   provider?: GitProvider;
   sourceRef?: string;
-  /** Additional tools to provide to the review agent (e.g. from MCP servers). */
   extraTools?: ToolsInput;
   languageSummary?: string;
+  tier?: ReviewTier;
 }
 
 function buildTools(options?: RunReviewOptions): ToolsInput {
+  // skim tier gets no tools — only diff context, no file exploration
+  if (options?.tier === "skim") return {};
+
   const tools: ToolsInput = {};
   if (options?.provider) {
     tools.searchCode = createSearchCodeTool(options.provider);
@@ -32,6 +37,7 @@ export async function runReview(
   ticketContext?: TicketInfo[],
   options?: RunReviewOptions,
 ): Promise<ReviewResult> {
+  const tier = options?.tier ?? "deep-review";
   const systemPrompt = buildSystemPrompt(config);
   const userMessage = buildUserMessage(diff, prMetadata, ticketContext, options?.languageSummary);
   const modelConfig = resolveModelConfig();
@@ -39,22 +45,21 @@ export async function runReview(
   const modelName = getModelDisplayName(modelConfig);
 
   const builtInTools = buildTools(options);
-  const extraTools = options?.extraTools ?? {};
+  // skim tier ignores extra tools (MCP) as well
+  const extraTools = tier === "skim" ? {} : (options?.extraTools ?? {});
 
   const agent = new Agent({
     id: "review-agent",
     name: "Rusty Bot Reviewer",
     instructions: systemPrompt,
     model,
-    // MCPClient.listTools() namespaces tools as serverName_toolName,
-    // so collisions with built-in tool names are unlikely in practice.
     tools: { ...builtInTools, ...extraTools },
   });
 
+  const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;
+
   const response = await agent.generate(userMessage, {
-    structuredOutput: {
-      schema: ReviewOutputSchema,
-    },
+    structuredOutput: { schema },
   });
 
   const parsed = response.object;

--- a/packages/core/src/agent/schema.ts
+++ b/packages/core/src/agent/schema.ts
@@ -19,6 +19,20 @@ export const FindingSchema = z.object({
     ),
 });
 
+export const SkimFindingSchema = z.object({
+  file: z.string(),
+  line: z.number(),
+  endLine: z
+    .number()
+    .nullable()
+    .describe(
+      "last line of the range when the issue spans multiple lines; null for single-line issues",
+    ),
+  severity: z.enum(["critical", "warning", "suggestion"]),
+  category: z.enum(["security", "performance", "bugs", "style", "tests", "docs"]),
+  message: z.string(),
+});
+
 export const ObservationSchema = z.object({
   file: z.string(),
   line: z.number(),
@@ -34,6 +48,20 @@ export const ReviewOutputSchema = z.object({
     .describe("merge recommendation based on findings"),
   findings: z
     .array(FindingSchema)
+    .describe("issues found in the changed code, tied to specific lines in the diff"),
+  observations: z
+    .array(ObservationSchema)
+    .describe("issues found in referenced but unchanged code"),
+  filesReviewed: z.array(z.string()).describe("list of file paths that were reviewed"),
+});
+
+export const SkimReviewOutputSchema = z.object({
+  summary: z.string().describe("concise summary of the PR and overall assessment"),
+  recommendation: z
+    .enum(["looks_good", "address_before_merge", "critical_issues"])
+    .describe("merge recommendation based on findings"),
+  findings: z
+    .array(SkimFindingSchema)
     .describe("issues found in the changed code, tied to specific lines in the diff"),
   observations: z
     .array(ObservationSchema)

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -1,4 +1,4 @@
-import type { ReviewResult, Severity, Finding, Observation } from "../types.js";
+import type { ReviewResult, Severity, Finding, Observation, TriageStats } from "../types.js";
 
 const SEVERITY_ORDER: Severity[] = ["critical", "warning", "suggestion"];
 
@@ -31,6 +31,24 @@ function countBySeverity(findings: Finding[]): Record<Severity, number> {
   return counts;
 }
 
+function buildTriageSection(stats: TriageStats): string {
+  const lines: string[] = [];
+  lines.push("<details>");
+  lines.push("<summary>Triage Summary</summary>");
+  lines.push("");
+  lines.push("| Classification | Files |");
+  lines.push("|----------------|-------|");
+  lines.push(`| Skipped | ${stats.filesSkipped} |`);
+  lines.push(`| Skimmed | ${stats.filesSkimmed} |`);
+  lines.push(`| Deep Reviewed | ${stats.filesDeepReviewed} |`);
+  lines.push("");
+  lines.push(`Triage model: \`${stats.triageModelUsed}\` · ${stats.triageTokenCount} tokens`);
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+  return lines.join("\n");
+}
+
 export function formatSummaryComment(review: ReviewResult): string {
   const counts = countBySeverity(review.findings);
   const totalIssues = review.findings.length;
@@ -45,6 +63,10 @@ export function formatSummaryComment(review: ReviewResult): string {
     `**Status:** ${totalIssues} Issues Found | **Recommendation:** ${RECOMMENDATION_TEXT[review.recommendation]}`,
   );
   lines.push("");
+
+  if (review.triageStats) {
+    lines.push(buildTriageSection(review.triageStats));
+  }
 
   lines.push("## Overview");
   lines.push("");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,10 @@ export type {
   FocusArea,
   Severity,
   Recommendation,
+  TriageClassification,
+  TriageFileResult,
+  TriageResult,
+  TriageStats,
   Finding,
   Observation,
   ReviewResult,
@@ -25,3 +29,4 @@ export * from "./tickets/index.js";
 export * from "./diff/index.js";
 export * from "./agent/index.js";
 export * from "./mcp/index.js";
+export * from "./triage/index.js";

--- a/packages/core/src/triage/index.ts
+++ b/packages/core/src/triage/index.ts
@@ -1,0 +1,3 @@
+export { TriageOutputSchema } from "./schema.js";
+export { buildTriageSystemPrompt, buildTriageUserMessage } from "./prompt.js";
+export { runTriage, isCascadeEnabled, splitByClassification } from "./triage.js";

--- a/packages/core/src/triage/prompt.ts
+++ b/packages/core/src/triage/prompt.ts
@@ -1,0 +1,47 @@
+import type { FilePatch } from "../types.js";
+import { countTokens } from "../diff/compress.js";
+
+const MAX_TOKENS_PER_FILE = 200;
+const TRIAGE_SYSTEM_PROMPT = `You are a code review triage assistant. Your job is to classify files in a pull request by how much review attention they need.
+
+For each file, assign one of these classifications:
+- "skip": file needs no review (lock files, auto-generated code, vendored dependencies, binary assets)
+- "skim": file needs lightweight review with diff-only context (documentation changes, config tweaks, test snapshots, simple renames, trivial formatting changes, dependency version bumps)
+- "deep-review": file needs thorough review with full context (new business logic, security-relevant changes, complex refactors, API surface changes, authentication/authorization code, database schema changes, error handling changes)
+
+Rules:
+- lock files and auto-generated files → skip
+- markdown, docs, changelogs, license files → skim
+- test snapshot files → skim
+- CI config changes (yaml/yml in .github/, .gitlab-ci, azure-pipelines) → skim
+- .env.example, .gitignore, .editorconfig → skim
+- new source files with logic → deep-review
+- changes touching auth, crypto, SQL, permissions → deep-review
+- changes adding/modifying error handling or validation → deep-review
+- when uncertain, prefer deep-review over skim
+
+Respond with a JSON object matching the schema. Do not include any explanation outside the JSON.`;
+
+export function buildTriageSystemPrompt(): string {
+  return TRIAGE_SYSTEM_PROMPT;
+}
+
+function truncatePatch(patch: FilePatch): string {
+  const lines: string[] = [`## ${patch.path}`];
+  for (const hunk of patch.hunks) {
+    const hunkLines = hunk.content.split("\n");
+    for (const line of hunkLines) {
+      lines.push(line);
+      if (countTokens(lines.join("\n")) > MAX_TOKENS_PER_FILE) {
+        lines.push("... (truncated)");
+        return lines.join("\n");
+      }
+    }
+  }
+  return lines.join("\n");
+}
+
+export function buildTriageUserMessage(patches: FilePatch[]): string {
+  const parts = patches.map(truncatePatch);
+  return `Classify each of these ${patches.length} files:\n\n${parts.join("\n\n")}`;
+}

--- a/packages/core/src/triage/schema.ts
+++ b/packages/core/src/triage/schema.ts
@@ -1,0 +1,11 @@
+import { z } from "zod";
+
+export const TriageFileSchema = z.object({
+  path: z.string(),
+  classification: z.enum(["skip", "skim", "deep-review"]),
+  reason: z.string().describe("brief reason for the classification"),
+});
+
+export const TriageOutputSchema = z.object({
+  files: z.array(TriageFileSchema).describe("classification for each file in the PR"),
+});

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -1,0 +1,164 @@
+import { Agent } from "@mastra/core/agent";
+import type { FilePatch, TriageResult, TriageFileResult, TriageClassification } from "../types.js";
+import { TriageOutputSchema } from "./schema.js";
+import { buildTriageSystemPrompt, buildTriageUserMessage } from "./prompt.js";
+import { resolveTriageModelConfig, resolveModel, getModelDisplayName } from "../agent/model.js";
+import { countTokens } from "../diff/compress.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ module: "triage" });
+const MAX_TRIAGE_TOKENS = 30_000;
+
+function applyOverflowDefaults(
+  patches: FilePatch[],
+  triageablePatches: FilePatch[],
+): TriageFileResult[] {
+  const triageablePaths = new Set(triageablePatches.map((p) => p.path));
+  return patches
+    .filter((p) => !triageablePaths.has(p.path))
+    .map((p) => ({
+      path: p.path,
+      classification: "deep-review" as const,
+      reason: "exceeded triage token budget",
+    }));
+}
+
+function applySafetyNet(files: TriageFileResult[], patches: FilePatch[]): TriageFileResult[] {
+  const hasReviewable = files.some((f) => f.classification !== "skip");
+  if (hasReviewable) return files;
+
+  // all files were skipped — force the largest ones to deep-review
+  log.warn("triage classified all files as skip, applying safety net");
+  const sorted = [...patches].sort((a, b) => b.additions - a.additions);
+  const forceReview = new Set(
+    sorted.slice(0, Math.max(1, Math.ceil(sorted.length * 0.2))).map((p) => p.path),
+  );
+
+  return files.map((f) =>
+    forceReview.has(f.path)
+      ? {
+          ...f,
+          classification: "deep-review" as TriageClassification,
+          reason: "safety net: forced review",
+        }
+      : f,
+  );
+}
+
+export async function runTriage(patches: FilePatch[]): Promise<TriageResult> {
+  const modelConfig = resolveTriageModelConfig();
+  if (!modelConfig) {
+    throw new Error("triage model not configured");
+  }
+
+  const model = resolveModel(modelConfig);
+  const modelName = getModelDisplayName(modelConfig);
+  const systemPrompt = buildTriageSystemPrompt();
+
+  // check if all patches fit within the triage budget
+  const userMessage = buildTriageUserMessage(patches);
+  const inputTokens = countTokens(systemPrompt + userMessage);
+
+  let triageablePatches = patches;
+  let overflowFiles: TriageFileResult[] = [];
+
+  if (inputTokens > MAX_TRIAGE_TOKENS) {
+    log.warn(
+      { inputTokens, maxTokens: MAX_TRIAGE_TOKENS, totalFiles: patches.length },
+      "triage input exceeds token budget, splitting",
+    );
+
+    // include files until we hit the budget
+    triageablePatches = [];
+    let currentTokens = countTokens(systemPrompt);
+    for (const patch of patches) {
+      const patchMessage = buildTriageUserMessage([patch]);
+      const patchTokens = countTokens(patchMessage);
+      if (currentTokens + patchTokens > MAX_TRIAGE_TOKENS) break;
+      triageablePatches.push(patch);
+      currentTokens += patchTokens;
+    }
+
+    overflowFiles = applyOverflowDefaults(patches, triageablePatches);
+  }
+
+  const agent = new Agent({
+    id: "triage-agent",
+    name: "Rusty Bot Triage",
+    instructions: systemPrompt,
+    model,
+  });
+
+  const triageMessage = buildTriageUserMessage(triageablePatches);
+  const response = await agent.generate(triageMessage, {
+    structuredOutput: { schema: TriageOutputSchema },
+  });
+
+  const parsed = response.object;
+  const tokenCount = response.usage.totalTokens ?? 0;
+
+  // merge triage results with overflow defaults
+  const allFiles = [...parsed.files, ...overflowFiles];
+
+  // handle files that the model missed (classify as deep-review to be safe)
+  const classifiedPaths = new Set(allFiles.map((f) => f.path));
+  for (const patch of patches) {
+    if (!classifiedPaths.has(patch.path)) {
+      allFiles.push({
+        path: patch.path,
+        classification: "deep-review",
+        reason: "not classified by triage model",
+      });
+    }
+  }
+
+  const safeFiles = applySafetyNet(allFiles, patches);
+
+  log.info(
+    {
+      skipped: safeFiles.filter((f) => f.classification === "skip").length,
+      skimmed: safeFiles.filter((f) => f.classification === "skim").length,
+      deepReview: safeFiles.filter((f) => f.classification === "deep-review").length,
+      model: modelName,
+      tokens: tokenCount,
+    },
+    "triage complete",
+  );
+
+  return { files: safeFiles, modelUsed: modelName, tokenCount };
+}
+
+export function isCascadeEnabled(): boolean {
+  const explicitToggle = process.env.RUSTY_CASCADE_ENABLED;
+  if (explicitToggle === "false") return false;
+  if (explicitToggle === "true") return true;
+  return !!process.env.RUSTY_LLM_TRIAGE_MODEL;
+}
+
+export function splitByClassification(
+  patches: FilePatch[],
+  triageFiles: TriageFileResult[],
+): { skip: FilePatch[]; skim: FilePatch[]; deepReview: FilePatch[] } {
+  const classMap = new Map(triageFiles.map((f) => [f.path, f.classification]));
+
+  const skip: FilePatch[] = [];
+  const skim: FilePatch[] = [];
+  const deepReview: FilePatch[] = [];
+
+  for (const patch of patches) {
+    const classification = classMap.get(patch.path) ?? "deep-review";
+    switch (classification) {
+      case "skip":
+        skip.push(patch);
+        break;
+      case "skim":
+        skim.push(patch);
+        break;
+      case "deep-review":
+        deepReview.push(patch);
+        break;
+    }
+  }
+
+  return { skip, skim, deepReview };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -6,6 +6,8 @@ export type Severity = "critical" | "warning" | "suggestion";
 
 export type Recommendation = "looks_good" | "address_before_merge" | "critical_issues";
 
+export type TriageClassification = "skip" | "skim" | "deep-review";
+
 export interface Finding {
   file: string;
   line: number;
@@ -24,6 +26,26 @@ export interface Observation {
   message: string;
 }
 
+export interface TriageFileResult {
+  path: string;
+  classification: TriageClassification;
+  reason: string;
+}
+
+export interface TriageResult {
+  files: TriageFileResult[];
+  modelUsed: string;
+  tokenCount: number;
+}
+
+export interface TriageStats {
+  filesSkipped: number;
+  filesSkimmed: number;
+  filesDeepReviewed: number;
+  triageModelUsed: string;
+  triageTokenCount: number;
+}
+
 export interface ReviewResult {
   summary: string;
   recommendation: Recommendation;
@@ -32,6 +54,7 @@ export interface ReviewResult {
   filesReviewed: string[];
   modelUsed: string;
   tokenCount: number;
+  triageStats?: TriageStats;
 }
 
 export interface ReviewConfig {

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -31,6 +31,11 @@ export interface Review {
   tokenCount: number;
   recommendation: string;
   prUrl: string;
+  triageModelUsed?: string;
+  triageTokenCount?: number;
+  filesSkipped?: number;
+  filesSkimmed?: number;
+  filesDeepReviewed?: number;
 }
 
 export interface PaginatedReviews {

--- a/packages/dashboard/src/pages/Reviews.tsx
+++ b/packages/dashboard/src/pages/Reviews.tsx
@@ -16,6 +16,36 @@ const recommendationLabel: Record<string, string> = {
   address_before_merge: "Address before merge",
 };
 
+function TriageBadge({
+  review,
+}: {
+  review: { filesSkipped?: number; filesSkimmed?: number; filesDeepReviewed?: number };
+}) {
+  if (
+    review.filesSkipped == null &&
+    review.filesSkimmed == null &&
+    review.filesDeepReviewed == null
+  ) {
+    return <span className="text-slate-600 text-xs">—</span>;
+  }
+
+  return (
+    <span className="inline-flex gap-1.5 text-xs">
+      <span className="text-slate-500" title="Skipped">
+        {review.filesSkipped ?? 0}s
+      </span>
+      <span className="text-slate-500">/</span>
+      <span className="text-amber-400" title="Skimmed">
+        {review.filesSkimmed ?? 0}k
+      </span>
+      <span className="text-slate-500">/</span>
+      <span className="text-emerald-400" title="Deep reviewed">
+        {review.filesDeepReviewed ?? 0}d
+      </span>
+    </span>
+  );
+}
+
 export function Reviews() {
   const [page, setPage] = useState(0);
   const offset = page * PAGE_SIZE;
@@ -43,6 +73,12 @@ export function Reviews() {
               <th className="text-left px-4 py-3 text-slate-400 font-medium">Timestamp</th>
               <th className="text-right px-4 py-3 text-slate-400 font-medium">C / W / S</th>
               <th className="text-left px-4 py-3 text-slate-400 font-medium">Recommendation</th>
+              <th
+                className="text-center px-4 py-3 text-slate-400 font-medium"
+                title="Triage: Skipped / Skimmed / Deep"
+              >
+                Triage
+              </th>
               <th className="text-left px-4 py-3 text-slate-400 font-medium">Model</th>
             </tr>
           </thead>
@@ -86,12 +122,15 @@ export function Reviews() {
                     {recommendationLabel[review.recommendation] ?? review.recommendation}
                   </span>
                 </td>
+                <td className="px-4 py-3 text-center">
+                  <TriageBadge review={review} />
+                </td>
                 <td className="px-4 py-3 text-slate-500 font-mono text-xs">{review.modelUsed}</td>
               </tr>
             ))}
             {data?.items.length === 0 && (
               <tr>
-                <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                <td colSpan={7} className="px-4 py-8 text-center text-slate-500">
                   No reviews yet.
                 </td>
               </tr>

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -9,12 +9,16 @@ import {
   extractTicketRefs,
   resolveTickets,
   runMultiCallReview,
+  runCascadeReview,
   formatSummaryComment,
   GitHubTicketProvider,
   JiraTicketProvider,
   LinearTicketProvider,
   loadMcpServerConfigsFromEnv,
   logger,
+  isCascadeEnabled,
+  runTriage,
+  splitByClassification,
 } from "@rusty-bot/core";
 import { GitHubProvider } from "./provider.js";
 import { getRepoConfig, saveReview, getSetting, type ReviewRecord } from "./storage.js";
@@ -82,9 +86,6 @@ export async function orchestrateReview(params: {
     const patches = parseDiff(rawDiff);
     const filtered = filterFiles(patches, config.ignorePatterns);
     const reviewable = stripDeletionOnlyHunks(filtered);
-    const expanded = await expandContext(reviewable, (path) =>
-      provider.getFileContent(path, metadata.sourceBranch),
-    );
 
     const ticketRefs = extractTicketRefs(metadata.description, metadata.sourceBranch);
     const ticketProviders = await buildTicketProviders(owner, repo);
@@ -93,13 +94,62 @@ export async function orchestrateReview(params: {
     const languageSummary = summarizeLanguages(reviewable);
     const mcpServers = await loadMcpServerConfigsFromEnv();
 
-    const result = await runMultiCallReview(expanded, config, metadata, tickets, {
-      provider,
-      sourceRef: metadata.sourceBranch,
-      languageSummary,
-      mcpServers,
-      maxTokens: MAX_DIFF_TOKENS,
-    });
+    let result;
+
+    if (isCascadeEnabled()) {
+      log.info({ fileCount: reviewable.length }, "cascade enabled, running triage");
+
+      let triageResult;
+      try {
+        triageResult = await runTriage(reviewable);
+      } catch (err) {
+        log.warn({ err }, "triage failed, falling back to full review");
+      }
+
+      if (triageResult) {
+        const { skip, skim, deepReview } = splitByClassification(reviewable, triageResult.files);
+        log.info(
+          { skipped: skip.length, skimmed: skim.length, deepReview: deepReview.length },
+          "triage classification",
+        );
+
+        // only expand context for deep-review files
+        const expandedDeep = await expandContext(deepReview, (path) =>
+          provider.getFileContent(path, metadata.sourceBranch),
+        );
+
+        result = await runCascadeReview(skim, expandedDeep, config, metadata, tickets, {
+          provider,
+          sourceRef: metadata.sourceBranch,
+          languageSummary,
+          mcpServers,
+          maxTokens: MAX_DIFF_TOKENS,
+        });
+
+        result.triageStats = {
+          filesSkipped: skip.length,
+          filesSkimmed: skim.length,
+          filesDeepReviewed: deepReview.length,
+          triageModelUsed: triageResult.modelUsed,
+          triageTokenCount: triageResult.tokenCount,
+        };
+      }
+    }
+
+    if (!result) {
+      // non-cascade path or cascade fallback
+      const expanded = await expandContext(reviewable, (path) =>
+        provider.getFileContent(path, metadata.sourceBranch),
+      );
+
+      result = await runMultiCallReview(expanded, config, metadata, tickets, {
+        provider,
+        sourceRef: metadata.sourceBranch,
+        languageSummary,
+        mcpServers,
+        maxTokens: MAX_DIFF_TOKENS,
+      });
+    }
 
     const summary = formatSummaryComment(result);
     await provider.postSummaryComment(summary);
@@ -123,6 +173,15 @@ export async function orchestrateReview(params: {
       tokenCount: result.tokenCount,
       recommendation: result.recommendation,
       prUrl: metadata.url,
+      ...(result.triageStats
+        ? {
+            triageModelUsed: result.triageStats.triageModelUsed,
+            triageTokenCount: result.triageStats.triageTokenCount,
+            filesSkipped: result.triageStats.filesSkipped,
+            filesSkimmed: result.triageStats.filesSkimmed,
+            filesDeepReviewed: result.triageStats.filesDeepReviewed,
+          }
+        : {}),
     };
 
     await saveReview(review);

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -29,6 +29,11 @@ export interface ReviewRecord {
   tokenCount: number;
   recommendation: string;
   prUrl: string;
+  triageModelUsed?: string;
+  triageTokenCount?: number;
+  filesSkipped?: number;
+  filesSkimmed?: number;
+  filesDeepReviewed?: number;
 }
 
 interface StorageData {


### PR DESCRIPTION
## Summary
- Adds a new triage stage that classifies changed files into skip, skim, or deep review buckets before running the main review pass.
- Introduces cascade review execution in the Azure DevOps CLI, with fallback to the existing full review flow if triage fails or is disabled.
- Simplifies ticket resolution and removes the old consensus/judge/filter pipeline, along with related dead tests and docs.
- Updates summary rendering and dashboard review views to surface triage statistics when available.

## Testing
- Updated unit coverage for triage classification, summary formatting, schema changes, and the revised review flow.
- Removed obsolete tests tied to consensus voting and judge filtering.
- Not run: end-to-end review execution against live GitHub/Azure DevOps integrations.
- Not run: manual validation of the dashboard against a production data set.