### PR TITLE
Add tree-sitter context expansion for diff hunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 
 - **4 review styles** — Strict, Balanced, Lenient, Roast
 - **6 focus areas** — Security, Performance, Bugs, Code Style, Test Coverage, Documentation
+- **Tree-sitter context expansion** — hunks expand to enclosing function/class boundaries instead of fixed line counts (TS, JS, Python, Go, Java, Rust)
 - **Structured summary comments** — severity table, collapsible issue details, files reviewed
 - **Inline code comments** — findings posted directly on PR diff lines
 - **Ticket compliance** — extracts linked tickets from PR description/branch name, checks if requirements are addressed
@@ -50,7 +51,7 @@ packages/
 ├── core/           # shared review engine
 │   ├── src/
 │   │   ├── agent/      # Mastra review agent, judge/filter pass, prompt templates, Zod output schema
-│   │   ├── diff/       # unified diff parser, file filter, token-aware compression
+│   │   ├── diff/       # unified diff parser, tree-sitter context expansion, file filter, token-aware compression
 │   │   ├── formatter/  # summary comment + inline comment markdown renderers
 │   │   ├── tickets/    # ticket ref extraction, providers (GitHub/Jira/Linear/ADO)
 │   │   └── types.ts    # shared type definitions
@@ -275,6 +276,23 @@ Configure via per-repo config:
 
 Set `consensusPasses` to `1` to disable consensus voting and get the original single-pass behavior with zero overhead.
 
+
+### Tree-sitter Context Expansion
+
+By default, when the LLM reviews a diff hunk, the surrounding context is expanded to the enclosing function, method, or class boundary using [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST parsing. This means the model sees complete semantic units — full functions instead of fragments cut mid-logic — which improves review accuracy and eliminates wasted tokens on unrelated adjacent code.
+
+**Supported languages:** TypeScript, TSX, JavaScript, Python, Go, Java, Rust
+
+**How it works:**
+
+1. Each changed file is parsed with a WASM-based tree-sitter grammar (no native compilation needed)
+2. For each changed line range, the smallest enclosing scope (function, method, class) is found in the AST
+3. The hunk expands to include the full enclosing scope
+4. Collapsed signatures of sibling functions/methods are prepended for orientation (e.g. `// ... export function otherFn()`)
+5. If the enclosing scope exceeds 200 lines, or if the language is unsupported, it falls back to the previous ±10 fixed-line expansion
+
+The feature is automatic and requires no configuration. Unsupported languages (CSS, JSON, YAML, etc.) gracefully fall back to fixed-line expansion with zero overhead.
+
 ### Ticket Integration
 
 Rusty Bot automatically extracts ticket references from PR descriptions and branch names:
@@ -296,7 +314,7 @@ pnpm install
 # build all packages
 pnpm -r build
 
-# run tests (292 tests)
+# run tests (325 tests)
 pnpm test
 
 # start dev server

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -24,6 +24,13 @@
     "picomatch": "^4.0.4",
     "pino": "^10.3.1",
     "tiktoken": "^1.0.0",
+    "tree-sitter-go": "^0.25.0",
+    "tree-sitter-java": "^0.23.5",
+    "tree-sitter-javascript": "^0.25.0",
+    "tree-sitter-python": "^0.25.0",
+    "tree-sitter-rust": "^0.24.0",
+    "tree-sitter-typescript": "^0.23.2",
+    "web-tree-sitter": "^0.26.8",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/core/src/__tests__/treesitter.test.ts
+++ b/packages/core/src/__tests__/treesitter.test.ts
@@ -1,0 +1,534 @@
+import { describe, expect, it } from "vitest";
+import { expandToScopeBoundaries, getGrammarForFile } from "../diff/treesitter.js";
+import { expandContext } from "../diff/context.js";
+import type { FilePatch } from "../types.js";
+
+describe("getGrammarForFile", () => {
+  it("maps .ts to typescript", () => {
+    expect(getGrammarForFile("src/index.ts")).toBe("typescript");
+  });
+
+  it("maps .tsx to tsx", () => {
+    expect(getGrammarForFile("App.tsx")).toBe("tsx");
+  });
+
+  it("maps .d.ts to typescript", () => {
+    expect(getGrammarForFile("types/global.d.ts")).toBe("typescript");
+  });
+
+  it("maps .py to python", () => {
+    expect(getGrammarForFile("app/main.py")).toBe("python");
+  });
+
+  it("maps .go to go", () => {
+    expect(getGrammarForFile("cmd/main.go")).toBe("go");
+  });
+
+  it("maps .rs to rust", () => {
+    expect(getGrammarForFile("src/lib.rs")).toBe("rust");
+  });
+
+  it("maps .java to java", () => {
+    expect(getGrammarForFile("Main.java")).toBe("java");
+  });
+
+  it("returns null for unsupported extensions", () => {
+    expect(getGrammarForFile("style.css")).toBeNull();
+    expect(getGrammarForFile("data.json")).toBeNull();
+  });
+
+  it("returns null for files without extension", () => {
+    expect(getGrammarForFile("Makefile")).toBeNull();
+    expect(getGrammarForFile("Dockerfile")).toBeNull();
+  });
+
+  it("is case-insensitive on extension", () => {
+    expect(getGrammarForFile("file.PY")).toBe("python");
+    expect(getGrammarForFile("file.TS")).toBe("typescript");
+  });
+});
+
+// line numbers verified against tree-sitter AST output:
+// function_declaration processData: L4-L8
+// function_declaration validateInput: L10-L14
+// class_declaration DataProcessor: L16-L26
+//   method_definition add: L19-L21
+//   method_definition process: L23-L25
+const tsFileContent = `import { foo } from "./foo";
+import { bar } from "./bar";
+
+export function processData(input: string): string {
+  const trimmed = input.trim();
+  const upper = trimmed.toUpperCase();
+  return upper;
+}
+
+export function validateInput(input: string): boolean {
+  if (!input) return false;
+  if (input.length > 100) return false;
+  return true;
+}
+
+export class DataProcessor {
+  private data: string[] = [];
+
+  add(item: string): void {
+    this.data.push(item);
+  }
+
+  process(): string[] {
+    return this.data.map((d) => d.trim());
+  }
+}`;
+
+const pyFileContent = `import os
+from typing import Optional
+
+def fetch_data(url: str) -> dict:
+    response = requests.get(url)
+    return response.json()
+
+def transform_data(data: dict) -> list:
+    result = []
+    for key, value in data.items():
+        result.append({"key": key, "value": value})
+    return result
+
+class DataPipeline:
+    def __init__(self, source: str):
+        self.source = source
+        self.steps = []
+
+    def add_step(self, step):
+        self.steps.append(step)
+
+    def run(self):
+        data = None
+        for step in self.steps:
+            data = step(data)
+        return data`;
+
+const jsFileContent = `const { readFile } = require("fs");
+
+function parseConfig(raw) {
+  const lines = raw.split("\\n");
+  const config = {};
+  for (const line of lines) {
+    const [key, value] = line.split("=");
+    config[key.trim()] = value.trim();
+  }
+  return config;
+}
+
+function validateConfig(config) {
+  if (!config.host) throw new Error("host required");
+  if (!config.port) throw new Error("port required");
+  return true;
+}
+
+class ConfigManager {
+  constructor(path) {
+    this.path = path;
+    this.config = null;
+  }
+
+  async load() {
+    const raw = await readFile(this.path, "utf8");
+    this.config = parseConfig(raw);
+  }
+}`;
+
+describe("expandToScopeBoundaries", () => {
+  it("expands to enclosing function for TypeScript", async () => {
+    // line 6 is inside processData (L4-L8)
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 6, endLine: 6 }],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toHaveLength(1);
+    expect(result!.scopes[0].startLine).toBe(4);
+    expect(result!.scopes[0].endLine).toBe(8);
+  });
+
+  it("includes sibling function signatures", async () => {
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 6, endLine: 6 }],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    // siblings: validateInput (L10) and DataProcessor (L16) at program level
+    expect(result!.siblingSignatures.length).toBeGreaterThan(0);
+    const sigTexts = result!.siblingSignatures.map((s) => s.text);
+    expect(sigTexts.some((t) => t.includes("validateInput"))).toBe(true);
+  });
+
+  it("expands to enclosing function for Python", async () => {
+    // line 10 is inside transform_data
+    const result = await expandToScopeBoundaries(
+      pyFileContent,
+      [{ startLine: 10, endLine: 10 }],
+      "utils/transform.py",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toHaveLength(1);
+    expect(result!.scopes[0].startLine).toBeLessThanOrEqual(8);
+  });
+
+  it("expands to enclosing function for JavaScript", async () => {
+    // line 5 is inside parseConfig
+    const result = await expandToScopeBoundaries(
+      jsFileContent,
+      [{ startLine: 5, endLine: 5 }],
+      "config.js",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toHaveLength(1);
+    expect(result!.scopes[0].startLine).toBeLessThanOrEqual(3);
+  });
+
+  it("deduplicates scopes when multiple ranges land in the same function", async () => {
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [
+        { startLine: 5, endLine: 5 },
+        { startLine: 6, endLine: 6 },
+      ],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toHaveLength(1);
+  });
+
+  it("returns multiple scopes for changes in different functions", async () => {
+    // line 6 in processData (L4-L8), line 12 in validateInput (L10-L14)
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [
+        { startLine: 6, endLine: 6 },
+        { startLine: 12, endLine: 12 },
+      ],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toHaveLength(2);
+  });
+
+  it("returns null for unsupported language", async () => {
+    const result = await expandToScopeBoundaries(
+      "body { color: red; }",
+      [{ startLine: 1, endLine: 1 }],
+      "style.css",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when scope exceeds maxScopeLines", async () => {
+    const lines = [
+      "function huge() {",
+      ...Array.from({ length: 300 }, (_, i) => `  const x${i} = ${i};`),
+      "}",
+    ];
+    const bigFile = lines.join("\n");
+
+    const result = await expandToScopeBoundaries(
+      bigFile,
+      [{ startLine: 150, endLine: 150 }],
+      "big.js",
+      200,
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("handles empty file content gracefully", async () => {
+    const result = await expandToScopeBoundaries("", [{ startLine: 1, endLine: 1 }], "empty.ts");
+
+    expect(result).toBeNull();
+  });
+
+  it("expands class method to the method scope, not the whole class", async () => {
+    // line 20 is inside the add method (L19-L21), not L22 which is between methods
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 20, endLine: 20 }],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    const scope = result!.scopes[0];
+    expect(scope.startLine).toBe(19);
+    expect(scope.endLine).toBe(21);
+  });
+
+  it("falls back to class scope when change is between methods", async () => {
+    // line 22 is empty space between methods — enclosing scope is class_declaration
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 22, endLine: 22 }],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes[0].startLine).toBe(16);
+    expect(result!.scopes[0].endLine).toBe(26);
+  });
+
+  it("returns null when change is at top level with no enclosing scope", async () => {
+    // line 1 is an import — no enclosing function/class
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 1, endLine: 1 }],
+      "src/processor.ts",
+    );
+
+    expect(result).toBeNull();
+  });
+
+  it("collects sibling method signatures within a class", async () => {
+    // line 20 is in add method — process should be a sibling
+    const result = await expandToScopeBoundaries(
+      tsFileContent,
+      [{ startLine: 20, endLine: 20 }],
+      "src/processor.ts",
+    );
+
+    expect(result).not.toBeNull();
+    const sigTexts = result!.siblingSignatures.map((s) => s.text);
+    expect(sigTexts.some((t) => t.includes("process"))).toBe(true);
+  });
+});
+
+describe("expandContext with tree-sitter", () => {
+  const fetcher = (_path: string) => Promise.resolve(tsFileContent);
+  const nullFetcher = (_path: string) => Promise.resolve<string | null>(null);
+
+  function makeTsPatch(overrides?: Partial<FilePatch>): FilePatch {
+    return {
+      path: "src/processor.ts",
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 6,
+          oldLines: 1,
+          newStart: 6,
+          newLines: 2,
+          content: " const upper = trimmed.toUpperCase();\n+  console.log(upper);",
+        },
+      ],
+      ...overrides,
+    };
+  }
+
+  it("expands to function boundaries for supported languages", async () => {
+    const result = await expandContext([makeTsPatch()], fetcher, 5);
+    expect(result).toHaveLength(1);
+    const hunk = result[0].hunks[0];
+    expect(hunk.content).toContain("export function processData");
+  });
+
+  it("falls back to fixed expansion for unsupported languages", async () => {
+    const cssPatch: FilePatch = {
+      path: "styles/main.css",
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 5,
+          oldLines: 1,
+          newStart: 5,
+          newLines: 2,
+          content: " color: blue;\n+  font-size: 14px;",
+        },
+      ],
+    };
+    const cssContent = Array.from({ length: 30 }, (_, i) => `line ${i + 1}`).join("\n");
+    const cssFetcher = (_path: string) => Promise.resolve(cssContent);
+
+    const result = await expandContext([cssPatch], cssFetcher, 3);
+    expect(result).toHaveLength(1);
+    const hunk = result[0].hunks[0];
+    expect(hunk.content).toContain(" line 2");
+    expect(hunk.newStart).toBe(2);
+  });
+
+  it("falls back when file content unavailable", async () => {
+    const patch = makeTsPatch();
+    const result = await expandContext([patch], nullFetcher, 5);
+    expect(result[0].hunks[0].content).toBe(patch.hunks[0].content);
+  });
+
+  it("skips binary files", async () => {
+    const patch = makeTsPatch({ isBinary: true, hunks: [] });
+    const result = await expandContext([patch], fetcher, 5);
+    expect(result[0]).toEqual(patch);
+  });
+
+  it("preserves original hunk content within expanded context", async () => {
+    const result = await expandContext([makeTsPatch()], fetcher, 5);
+    const hunk = result[0].hunks[0];
+    expect(hunk.content).toContain("+  console.log(upper);");
+    expect(hunk.content).toContain(" const upper = trimmed.toUpperCase();");
+  });
+
+  it("handles multi-file patches with mixed languages", async () => {
+    const patches: FilePatch[] = [
+      makeTsPatch({ path: "src/processor.ts" }),
+      {
+        path: "data.json",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 2,
+            oldLines: 1,
+            newStart: 2,
+            newLines: 2,
+            content: ' "key": "value",\n+ "new": "field",',
+          },
+        ],
+      },
+    ];
+
+    const mixedFetcher = (path: string) => {
+      if (path === "src/processor.ts") return Promise.resolve(tsFileContent);
+      return Promise.resolve('{\n  "key": "value",\n  "other": 1\n}');
+    };
+
+    const result = await expandContext(patches, mixedFetcher, 3);
+    expect(result).toHaveLength(2);
+    expect(result[0].hunks[0].content).toContain("export function processData");
+    expect(result[1].hunks[0].content).toContain('"key": "value"');
+  });
+
+  it("includes sibling signatures in expanded context", async () => {
+    const result = await expandContext([makeTsPatch()], fetcher, 5);
+    const hunk = result[0].hunks[0];
+    // sibling function signatures should appear as collapsed markers
+    expect(hunk.content).toContain("// ...");
+  });
+
+  it("falls back to fixed lines when change is at top level", async () => {
+    // change at import level — tree-sitter can't find enclosing scope
+    const importPatch: FilePatch = {
+      path: "src/processor.ts",
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 1,
+          newStart: 1,
+          newLines: 2,
+          content: ' import { foo } from "./foo";\n+import { baz } from "./baz";',
+        },
+      ],
+    };
+
+    const result = await expandContext([importPatch], fetcher, 3);
+    expect(result).toHaveLength(1);
+    // falls back to ±3 fixed lines
+    expect(result[0].hunks[0].newStart).toBe(1);
+    expect(result[0].hunks[0].content).toContain("export function processData");
+  });
+});
+
+describe("extractChangedLineRanges (deletion anchoring, via expandContext)", () => {
+  const fileAfterDeletion = [
+    'import { a } from "./a";',
+    "",
+    "export function foo() {",
+    "  const x = 1;",
+    "  return x;",
+    "}",
+    "",
+    "export function bar() {",
+    "  return 2;",
+    "}",
+    "",
+  ].join("\n");
+
+  it("anchors pure-deletion hunks to the surviving adjacent line, not to newStart of the next scope", async () => {
+    const patch: FilePatch = {
+      path: "src/mod.ts",
+      additions: 0,
+      deletions: 1,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 5,
+          oldLines: 2,
+          newStart: 5,
+          newLines: 1,
+          content: "-  const y = 2;\n  return x;",
+        },
+      ],
+    };
+    const fetcher = (_: string) => Promise.resolve(fileAfterDeletion);
+
+    const result = await expandContext([patch], fetcher, 3);
+    const hunk = result[0].hunks[0];
+    expect(hunk.content).toContain("export function foo()");
+    // bar appears only as a ~-prefixed annotation, not as real context
+    expect(
+      hunk.content
+        .split("\n")
+        .filter((l) => l.startsWith(" "))
+        .join("\n"),
+    ).not.toContain("export function bar()");
+  });
+});
+
+describe("sibling signature line numbering", () => {
+  const fetcher = (_: string) => Promise.resolve(tsFileContent);
+
+  it("does not shift line numbers of real source lines when signatures are prepended", async () => {
+    const patch: FilePatch = {
+      path: "src/processor.ts",
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 6,
+          oldLines: 1,
+          newStart: 6,
+          newLines: 2,
+          content: " const upper = trimmed.toUpperCase();\n+  console.log(upper);",
+        },
+      ],
+    };
+
+    const [expanded] = await expandContext([patch], fetcher, 5);
+    const hunk = expanded.hunks[0];
+
+    const signatureRows = hunk.content.split("\n").filter((l) => l.startsWith("~"));
+    expect(signatureRows.length).toBeGreaterThan(0);
+
+    expect(hunk.newStart).toBe(4);
+
+    const bodyRowCount = hunk.content.split("\n").filter((l) => !l.startsWith("~")).length;
+    expect(hunk.newLines).toBe(bodyRowCount);
+
+    const { compressDiff } = await import("../diff/compress.js");
+    const { compressed } = compressDiff([expanded], 10000);
+
+    const labelled = compressed.split("\n").find((l) => l.startsWith("6 "));
+    expect(labelled).toBeDefined();
+    expect(labelled).toContain("trimmed.toUpperCase()");
+  });
+});

--- a/packages/core/src/diff/compress.ts
+++ b/packages/core/src/diff/compress.ts
@@ -24,6 +24,10 @@ function formatHunks(patch: FilePatch): string {
       } else if (line.startsWith("\\")) {
         // no-newline marker, keep in whichever section was last
         continue;
+      } else if (line.startsWith("~")) {
+        // sibling signature annotation: emit without line number, do not advance counters
+        oldLines.push(line);
+        newLines.push(line);
       } else {
         oldLines.push(`${oldLine} ${line}`);
         newLines.push(`${newLine} ${line}`);

--- a/packages/core/src/diff/context.ts
+++ b/packages/core/src/diff/context.ts
@@ -1,16 +1,125 @@
 import type { FilePatch, Hunk } from "../types.js";
+import { expandToScopeBoundaries, type TreeSitterExpansion } from "./treesitter.js";
 
 const DEFAULT_CONTEXT_LINES = 10;
 
 export type FileContentFetcher = (path: string) => Promise<string | null>;
 
-function expandHunk(hunk: Hunk, fileLines: string[], extraLines: number): Hunk {
+function extractChangedLineRanges(hunk: Hunk): { startLine: number; endLine: number }[] {
+  const ranges: { startLine: number; endLine: number }[] = [];
+  let _oldLine = hunk.oldStart;
+  let newLine = hunk.newStart;
+  let rangeStart: number | null = null;
+  let rangeEnd: number | null = null;
+
+  const flush = () => {
+    if (rangeStart !== null && rangeEnd !== null) {
+      ranges.push({ startLine: rangeStart, endLine: rangeEnd });
+    }
+    rangeStart = null;
+    rangeEnd = null;
+  };
+
+  const extend = (start: number, end: number) => {
+    if (rangeStart === null || rangeEnd === null) {
+      rangeStart = start;
+      rangeEnd = end;
+    } else {
+      rangeStart = Math.min(rangeStart, start);
+      rangeEnd = Math.max(rangeEnd, end);
+    }
+  };
+
+  for (const line of hunk.content.split("\n")) {
+    if (line.startsWith("+")) {
+      extend(newLine, newLine);
+      newLine++;
+    } else if (line.startsWith("-")) {
+      // a deletion has no direct new-file line; anchor to surviving lines
+      // adjacent to the edit site so AST scope lookup is unambiguous
+      const anchorStart = Math.max(1, newLine - 1);
+      const anchorEnd = newLine;
+      extend(anchorStart, anchorEnd);
+      _oldLine++;
+    } else if (line.startsWith("\\")) {
+      continue;
+    } else {
+      flush();
+      _oldLine++;
+      newLine++;
+    }
+  }
+
+  flush();
+
+  if (ranges.length === 0) {
+    ranges.push({
+      startLine: hunk.newStart,
+      endLine: hunk.newStart + Math.max(0, hunk.newLines - 1),
+    });
+  }
+
+  return ranges;
+}
+
+function expandHunkToScope(hunk: Hunk, fileLines: string[], expansion: TreeSitterExpansion): Hunk {
+  let expandedStart = Infinity;
+  let expandedEnd = -Infinity;
+
+  for (const scope of expansion.scopes) {
+    expandedStart = Math.min(expandedStart, scope.startLine);
+    expandedEnd = Math.max(expandedEnd, scope.endLine);
+  }
+
+  expandedStart = Math.max(1, expandedStart);
+  expandedEnd = Math.min(fileLines.length, expandedEnd);
+
   const hunkContentLines = hunk.content.split("\n");
 
-  // find the range of new-file lines this hunk covers
+  const beforeLines: string[] = [];
+  for (let i = expandedStart; i < hunk.newStart; i++) {
+    beforeLines.push(` ${fileLines[i - 1]}`);
+  }
+
+  const newEnd = hunk.newStart + hunk.newLines - 1;
+  const afterLines: string[] = [];
+  for (let i = newEnd + 1; i <= expandedEnd; i++) {
+    afterLines.push(` ${fileLines[i - 1]}`);
+  }
+
+  // sibling signatures are rendered with a "~" marker so the diff formatter
+  // can emit them without advancing line counters; they are annotations, not
+  // real file rows, and must not shift subsequent line numbers
+  const signatureLines: string[] = [];
+  for (const sig of expansion.siblingSignatures) {
+    if (sig.line < expandedStart || sig.line > expandedEnd) {
+      signatureLines.push(`~ // ... ${sig.text}`);
+    }
+  }
+
+  const parts: string[] = [];
+  if (signatureLines.length > 0) {
+    parts.push(...signatureLines);
+  }
+  parts.push(...beforeLines, ...hunkContentLines, ...afterLines);
+
+  const expandedContent = parts.join("\n");
+  const addedContextBefore = hunk.newStart - expandedStart;
+  const addedContextAfter = expandedEnd - newEnd;
+
+  return {
+    oldStart: Math.max(1, hunk.oldStart - addedContextBefore),
+    oldLines: hunk.oldLines + addedContextBefore + addedContextAfter,
+    newStart: expandedStart,
+    newLines: hunk.newLines + addedContextBefore + addedContextAfter,
+    content: expandedContent,
+  };
+}
+
+function expandHunkFixed(hunk: Hunk, fileLines: string[], extraLines: number): Hunk {
+  const hunkContentLines = hunk.content.split("\n");
   const newEnd = hunk.newStart + hunk.newLines - 1;
 
-  // expand the window: extra lines before and after
   const expandedStart = Math.max(1, hunk.newStart - extraLines);
   const expandedEnd = Math.min(fileLines.length, newEnd + extraLines);
 
@@ -53,15 +162,42 @@ export async function expandContext(
 
     const content = await fetchContent(patch.path);
     if (!content) {
-      // can't expand context without the file — keep original
       results.push(patch);
       continue;
     }
 
     const fileLines = content.split("\n");
-    const expandedHunks = patch.hunks.map((hunk) => expandHunk(hunk, fileLines, extraLines));
 
-    results.push({ ...patch, hunks: expandedHunks });
+    const allChangedRanges = patch.hunks.flatMap(extractChangedLineRanges);
+
+    const expansion = await expandToScopeBoundaries(content, allChangedRanges, patch.path);
+
+    if (expansion) {
+      const expandedHunks = patch.hunks.map((hunk) => {
+        const hunkRanges = extractChangedLineRanges(hunk);
+        const hunkScopes = expansion.scopes.filter((scope) =>
+          hunkRanges.some((r) => r.startLine <= scope.endLine && r.endLine >= scope.startLine),
+        );
+
+        if (hunkScopes.length === 0) {
+          return expandHunkFixed(hunk, fileLines, extraLines);
+        }
+
+        const hunkSiblings = expansion.siblingSignatures.filter((sig) =>
+          hunkScopes.every((scope) => sig.line < scope.startLine || sig.line > scope.endLine),
+        );
+
+        return expandHunkToScope(hunk, fileLines, {
+          scopes: hunkScopes,
+          siblingSignatures: hunkSiblings,
+        });
+      });
+
+      results.push({ ...patch, hunks: expandedHunks });
+    } else {
+      const expandedHunks = patch.hunks.map((hunk) => expandHunkFixed(hunk, fileLines, extraLines));
+      results.push({ ...patch, hunks: expandedHunks });
+    }
   }
 
   return results;

--- a/packages/core/src/diff/index.ts
+++ b/packages/core/src/diff/index.ts
@@ -5,3 +5,5 @@ export { expandContext } from "./context.js";
 export type { FileContentFetcher } from "./context.js";
 export { detectLanguage, summarizeLanguages } from "./language.js";
 export { shufflePatches } from "./shuffle.js";
+export { expandToScopeBoundaries, getGrammarForFile } from "./treesitter.js";
+export type { TreeSitterExpansion, ExpandedScope } from "./treesitter.js";

--- a/packages/core/src/diff/treesitter.ts
+++ b/packages/core/src/diff/treesitter.ts
@@ -1,0 +1,255 @@
+import { Parser, Language, type Node } from "web-tree-sitter";
+import { readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+const SCOPE_NODE_TYPES: Record<string, string[]> = {
+  typescript: [
+    "function_declaration",
+    "method_definition",
+    "arrow_function",
+    "class_declaration",
+    "interface_declaration",
+  ],
+  tsx: [
+    "function_declaration",
+    "method_definition",
+    "arrow_function",
+    "class_declaration",
+    "interface_declaration",
+  ],
+  javascript: ["function_declaration", "method_definition", "arrow_function", "class_declaration"],
+  python: ["function_definition", "class_definition"],
+  go: ["function_declaration", "method_declaration", "type_declaration"],
+  java: [
+    "method_declaration",
+    "class_declaration",
+    "constructor_declaration",
+    "interface_declaration",
+  ],
+  rust: ["function_item", "impl_item", "struct_item", "enum_item", "trait_item"],
+};
+
+const EXTENSION_TO_GRAMMAR: Record<string, string> = {
+  ".ts": "typescript",
+  ".tsx": "tsx",
+  ".js": "javascript",
+  ".jsx": "javascript",
+  ".mjs": "javascript",
+  ".cjs": "javascript",
+  ".py": "python",
+  ".go": "go",
+  ".java": "java",
+  ".rs": "rust",
+};
+
+const GRAMMAR_TO_PACKAGE: Record<string, { pkg: string; wasm: string }> = {
+  typescript: { pkg: "tree-sitter-typescript", wasm: "tree-sitter-typescript.wasm" },
+  tsx: { pkg: "tree-sitter-typescript", wasm: "tree-sitter-tsx.wasm" },
+  javascript: { pkg: "tree-sitter-javascript", wasm: "tree-sitter-javascript.wasm" },
+  python: { pkg: "tree-sitter-python", wasm: "tree-sitter-python.wasm" },
+  go: { pkg: "tree-sitter-go", wasm: "tree-sitter-go.wasm" },
+  java: { pkg: "tree-sitter-java", wasm: "tree-sitter-java.wasm" },
+  rust: { pkg: "tree-sitter-rust", wasm: "tree-sitter-rust.wasm" },
+};
+
+const DEFAULT_MAX_SCOPE_LINES = 200;
+
+let parserInitialized = false;
+const languageCache = new Map<string, Language>();
+
+export interface ExpandedScope {
+  /** 1-based start line of the enclosing scope */
+  startLine: number;
+  /** 1-based end line of the enclosing scope */
+  endLine: number;
+}
+
+export interface TreeSitterExpansion {
+  scopes: ExpandedScope[];
+  /** collapsed signature lines from sibling scopes for orientation */
+  siblingSignatures: { line: number; text: string }[];
+}
+
+async function ensureInit(): Promise<void> {
+  if (parserInitialized) return;
+  await Parser.init();
+  parserInitialized = true;
+}
+
+async function loadLanguage(grammar: string): Promise<Language | null> {
+  const cached = languageCache.get(grammar);
+  if (cached) return cached;
+
+  const info = GRAMMAR_TO_PACKAGE[grammar];
+
+  try {
+    const pkgDir = require.resolve(`${info.pkg}/package.json`);
+    const wasmPath = pkgDir.replace("package.json", info.wasm);
+    const wasmBytes = await readFile(wasmPath);
+    const lang = await Language.load(wasmBytes);
+    languageCache.set(grammar, lang);
+    return lang;
+  } catch {
+    return null;
+  }
+}
+
+export function getGrammarForFile(filePath: string): string | null {
+  const lastDot = filePath.lastIndexOf(".");
+  if (lastDot === -1) return null;
+
+  if (filePath.endsWith(".d.ts")) return "typescript";
+
+  const ext = filePath.slice(lastDot).toLowerCase();
+  return EXTENSION_TO_GRAMMAR[ext] ?? null;
+}
+
+function findSmallestEnclosingScope(
+  node: Node,
+  startRow: number,
+  endRow: number,
+  scopeTypes: string[],
+): Node | null {
+  let best: Node | null = null;
+
+  if (node.startPosition.row <= startRow && node.endPosition.row >= endRow) {
+    if (scopeTypes.includes(node.type)) {
+      best = node;
+    }
+
+    for (const child of node.children) {
+      const childResult = findSmallestEnclosingScope(child, startRow, endRow, scopeTypes);
+      if (childResult) {
+        best = childResult;
+      }
+    }
+  }
+
+  return best;
+}
+
+function getSignatureLine(node: Node, fileLines: string[]): string {
+  const row = node.startPosition.row;
+  if (row < fileLines.length) {
+    return fileLines[row].trimEnd();
+  }
+  return "";
+}
+
+// collect scope-type nodes from a parent, peeking one level deeper
+// to see through wrappers like export_statement
+function findScopeChildren(node: Node, scopeTypes: string[]): Node[] {
+  const results: Node[] = [];
+  for (const child of node.namedChildren) {
+    if (scopeTypes.includes(child.type)) {
+      results.push(child);
+    } else {
+      for (const grandchild of child.namedChildren) {
+        if (scopeTypes.includes(grandchild.type)) {
+          results.push(grandchild);
+        }
+      }
+    }
+  }
+  return results;
+}
+
+function collectSiblingSignatures(
+  scopeNode: Node,
+  scopeTypes: string[],
+  fileLines: string[],
+): { line: number; text: string }[] {
+  // walk up until we find a parent whose scope children include siblings
+  let parent = scopeNode.parent;
+  while (parent) {
+    const scopeChildren = findScopeChildren(parent, scopeTypes);
+    if (scopeChildren.some((n) => n.id !== scopeNode.id)) {
+      const signatures: { line: number; text: string }[] = [];
+      for (const sibling of scopeChildren) {
+        if (sibling.id === scopeNode.id) continue;
+        const text = getSignatureLine(sibling, fileLines);
+        if (text) {
+          signatures.push({ line: sibling.startPosition.row + 1, text });
+        }
+      }
+      return signatures;
+    }
+    parent = parent.parent;
+  }
+
+  return [];
+}
+
+/**
+ * Try to expand changed line ranges to enclosing function/class boundaries
+ * using tree-sitter. Returns null if tree-sitter can't handle this file
+ * (unsupported language, parse failure, scope too large).
+ */
+export async function expandToScopeBoundaries(
+  fileContent: string,
+  changedRanges: { startLine: number; endLine: number }[],
+  filePath: string,
+  maxScopeLines: number = DEFAULT_MAX_SCOPE_LINES,
+): Promise<TreeSitterExpansion | null> {
+  const grammar = getGrammarForFile(filePath);
+  if (!grammar) return null;
+
+  const scopeTypes = SCOPE_NODE_TYPES[grammar];
+
+  try {
+    await ensureInit();
+    const language = await loadLanguage(grammar);
+    if (!language) return null;
+
+    const parser = new Parser();
+    parser.setLanguage(language);
+
+    const tree = parser.parse(fileContent);
+    if (!tree) return null;
+
+    const fileLines = fileContent.split("\n");
+    const scopes: ExpandedScope[] = [];
+    const allSiblingSignatures: { line: number; text: string }[] = [];
+    const seenScopeIds = new Set<number>();
+    const seenSignatureLines = new Set<number>();
+
+    for (const range of changedRanges) {
+      const startRow = range.startLine - 1;
+      const endRow = range.endLine - 1;
+
+      const scopeNode = findSmallestEnclosingScope(tree.rootNode, startRow, endRow, scopeTypes);
+
+      if (!scopeNode) return null;
+
+      const scopeLines = scopeNode.endPosition.row - scopeNode.startPosition.row + 1;
+      if (scopeLines > maxScopeLines) return null;
+
+      if (seenScopeIds.has(scopeNode.id)) continue;
+      seenScopeIds.add(scopeNode.id);
+
+      scopes.push({
+        startLine: scopeNode.startPosition.row + 1,
+        endLine: scopeNode.endPosition.row + 1,
+      });
+
+      for (const sig of collectSiblingSignatures(scopeNode, scopeTypes, fileLines)) {
+        if (!seenSignatureLines.has(sig.line)) {
+          seenSignatureLines.add(sig.line);
+          allSiblingSignatures.push(sig);
+        }
+      }
+    }
+
+    tree.delete();
+    parser.delete();
+
+    if (scopes.length === 0) return null;
+
+    allSiblingSignatures.sort((a, b) => a.line - b.line);
+    return { scopes, siblingSignatures: allSiblingSignatures };
+  } catch {
+    return null;
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,27 @@ importers:
       tiktoken:
         specifier: ^1.0.0
         version: 1.0.22
+      tree-sitter-go:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-java:
+        specifier: ^0.23.5
+        version: 0.23.5
+      tree-sitter-javascript:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-python:
+        specifier: ^0.25.0
+        version: 0.25.0
+      tree-sitter-rust:
+        specifier: ^0.24.0
+        version: 0.24.0
+      tree-sitter-typescript:
+        specifier: ^0.23.2
+        version: 0.23.2
+      web-tree-sitter:
+        specifier: ^0.26.8
+        version: 0.26.8
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -2176,6 +2197,7 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
+    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -2508,6 +2530,10 @@ packages:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
     engines: {node: '>= 0.6'}
 
+  node-addon-api@8.7.0:
+    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+    engines: {node: ^18 || ^20 || >= 21}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -2516,6 +2542,10 @@ packages:
   node-fetch@3.3.2:
     resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
 
   node-releases@2.0.37:
     resolution: {integrity: sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==}
@@ -2988,6 +3018,62 @@ packages:
   tokenx@1.3.0:
     resolution: {integrity: sha512-NLdXTEZkKiO0gZuLtMoZKjCXTREXeZZt8nnnNeyoXtNZAfG/GKGSbQtLU5STspc0rMSwcA+UJfWZkbNU01iKmQ==}
 
+  tree-sitter-go@0.25.0:
+    resolution: {integrity: sha512-APBc/Dq3xz/e35Xpkhb1blu5UgW+2E3RyGWawZSCNcbGwa7jhSQPS8KsUupuzBla8PCo8+lz9W/JDJjmfRa2tw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-java@0.23.5:
+    resolution: {integrity: sha512-Yju7oQ0Xx7GcUT01mUglPP+bYfvqjNCGdxqigTnew9nLGoII42PNVP3bHrYeMxswiCRM0yubWmN5qk+zsg0zMA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.23.1:
+    resolution: {integrity: sha512-/bnhbrTD9frUYHQTiYnPcxyHORIw157ERBa6dqzaKxvR/x3PC4Yzd+D1pZIMS6zNg2v3a8BZ0oK7jHqsQo9fWA==}
+    peerDependencies:
+      tree-sitter: ^0.21.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-javascript@0.25.0:
+    resolution: {integrity: sha512-1fCbmzAskZkxcZzN41sFZ2br2iqTYP3tKls1b/HKGNPQUVOpsUxpmGxdN/wMqAk3jYZnYBR1dd/y/0avMeU7dw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-python@0.25.0:
+    resolution: {integrity: sha512-eCmJx6zQa35GxaCtQD+wXHOhYqBxEL+bp71W/s3fcDMu06MrtzkVXR437dRrCrbrDbyLuUDJpAgycs7ncngLXw==}
+    peerDependencies:
+      tree-sitter: ^0.25.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-rust@0.24.0:
+    resolution: {integrity: sha512-NWemUDf629Tfc90Y0Z55zuwPCAHkLxWnMf2RznYu4iBkkrQl2o/CHGB7Cr52TyN5F1DAx8FmUnDtCy9iUkXZEQ==}
+    peerDependencies:
+      tree-sitter: ^0.22.1
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
+  tree-sitter-typescript@0.23.2:
+    resolution: {integrity: sha512-e04JUUKxTT53/x3Uq1zIL45DoYKVfHH4CZqwgZhPg5qYROl5nQjV+85ruFzFGZxu+QeFVbRTPDRnqL9UbU4VeA==}
+    peerDependencies:
+      tree-sitter: ^0.21.0
+    peerDependenciesMeta:
+      tree-sitter:
+        optional: true
+
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
@@ -3178,6 +3264,9 @@ packages:
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
+
+  web-tree-sitter@0.26.8:
+    resolution: {integrity: sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==}
 
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
@@ -5839,6 +5928,8 @@ snapshots:
 
   negotiator@1.0.0: {}
 
+  node-addon-api@8.7.0: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -5846,6 +5937,8 @@ snapshots:
       data-uri-to-buffer: 4.0.1
       fetch-blob: 3.2.0
       formdata-polyfill: 4.0.10
+
+  node-gyp-build@4.8.4: {}
 
   node-releases@2.0.37: {}
 
@@ -6358,6 +6451,42 @@ snapshots:
 
   tokenx@1.3.0: {}
 
+  tree-sitter-go@0.25.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-java@0.23.5:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-javascript@0.23.1:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-javascript@0.25.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-python@0.25.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-rust@0.24.0:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+
+  tree-sitter-typescript@0.23.2:
+    dependencies:
+      node-addon-api: 8.7.0
+      node-gyp-build: 4.8.4
+      tree-sitter-javascript: 0.23.1
+
   trough@2.2.0: {}
 
   ts-api-utils@2.5.0(typescript@5.9.3):
@@ -6554,6 +6683,8 @@ snapshots:
       - yaml
 
   web-streams-polyfill@3.3.3: {}
+
+  web-tree-sitter@0.26.8: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
Fixes #6

## Summary
- Expand review hunks to enclosing function, method, or class boundaries using tree-sitter for supported languages.
- Add sibling signature annotations so reviewers retain orientation without consuming extra line-number context.
- Fall back to fixed-line context expansion for unsupported languages, parse failures, or oversized scopes.
- Update docs and add tests covering scope detection, sibling signatures, deletion anchoring, and fallback behavior.

## Testing
- `pnpm test` not run.
- Added Vitest coverage for tree-sitter grammar mapping and scope expansion across TypeScript, JavaScript, Python, Go, Java, and Rust cases.
- Added checks for unsupported files, missing content, binary patches, and fixed-line fallback paths.