### PR TITLE
Filter PR-file observations in multi-call reviews

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -169,6 +169,36 @@ describe("buildUserMessage", () => {
     const msg = buildUserMessage("diff", prMetadata, []);
     expect(msg).not.toContain("Linked Tickets");
   });
+
+  it("includes other PR files section when provided", () => {
+    const msg = buildUserMessage("diff", prMetadata, undefined, undefined, [
+      "src/config.ts",
+      "src/utils.ts",
+    ]);
+    expect(msg).toContain("Other Files Changed in This PR");
+    expect(msg).toContain("`src/config.ts`");
+    expect(msg).toContain("`src/utils.ts`");
+    expect(msg).toContain("Do NOT report observations");
+  });
+
+  it("omits other PR files section when not provided", () => {
+    const msg = buildUserMessage("diff", prMetadata);
+    expect(msg).not.toContain("Other Files Changed");
+  });
+
+  it("omits other PR files section when empty array", () => {
+    const msg = buildUserMessage("diff", prMetadata, undefined, undefined, []);
+    expect(msg).not.toContain("Other Files Changed");
+  });
+
+  it("places other PR files section before the diff", () => {
+    const msg = buildUserMessage("diff content here", prMetadata, undefined, undefined, [
+      "other.ts",
+    ]);
+    const otherFilesIdx = msg.indexOf("Other Files Changed");
+    const diffIdx = msg.indexOf("## Diff");
+    expect(otherFilesIdx).toBeLessThan(diffIdx);
+  });
 });
 
 describe("ReviewOutputSchema", () => {

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -381,4 +381,39 @@ describe("filterObservationsForPrFiles", () => {
     const filtered = filterObservationsForPrFiles(observations, prFiles);
     expect(filtered).toHaveLength(1);
   });
+
+  it("matches observation with leading ./ against PR file without it", () => {
+    const observations = [makeObservation("./src/a.ts")];
+    const prFiles = new Set(["src/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("matches observation with trailing line number against PR file", () => {
+    const observations = [makeObservation("src/a.ts:42")];
+    const prFiles = new Set(["src/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("matches observation with trailing line:col against PR file", () => {
+    const observations = [makeObservation("src/a.ts:42:10")];
+    const prFiles = new Set(["src/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("matches observation with backslash separators against PR file", () => {
+    const observations = [makeObservation("src\\utils\\a.ts")];
+    const prFiles = new Set(["src/utils/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("handles mixed normalization between observation and PR files", () => {
+    const observations = [makeObservation("./src\\config.ts:15")];
+    const prFiles = new Set(["src/config.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
 });

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { countTokens } from "../diff/compress.js";
-import type { FilePatch, ReviewConfig, ReviewResult, TicketInfo } from "../types.js";
+import type { FilePatch, ReviewConfig, ReviewResult, TicketInfo, Observation } from "../types.js";
 
 function makeMockReview(diff: string): ReviewResult {
   return {
@@ -28,7 +28,7 @@ vi.mock("../agent/review.js", () => ({
   runReview: vi.fn(async (_config, diff, _prMeta, _tickets, _opts) => makeMockReview(diff)),
 }));
 
-const { runMultiCallReview } = await import("../agent/multi-call.js");
+const { runMultiCallReview, filterObservationsForPrFiles } = await import("../agent/multi-call.js");
 const { runReview } = await import("../agent/review.js");
 const runReviewMock = vi.mocked(runReview);
 
@@ -278,5 +278,107 @@ describe("runMultiCallReview", () => {
     const result = await runMultiCallReview(patches, consensusConfig, prMetadata);
     expect(result.consensusMetadata).toEqual({ passes: 3, threshold: 2 });
     expect(result.findings.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("passes otherPrFiles to each chunk in multi-call review", async () => {
+    const patches = [makePatch("big1.ts", 1000), makePatch("big2.ts", 1000)];
+    await runMultiCallReview(patches, config, prMetadata, undefined, {
+      maxTokens: 3000,
+    });
+
+    expect(runReviewMock.mock.calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of runReviewMock.mock.calls) {
+      const opts = call[4];
+      expect(opts?.otherPrFiles).toBeDefined();
+      expect(opts!.otherPrFiles!.length).toBeGreaterThan(0);
+    }
+
+    // first chunk sees big1.ts, so otherPrFiles should contain big2.ts
+    const firstCallOpts = runReviewMock.mock.calls[0][4];
+    const secondCallOpts = runReviewMock.mock.calls[1][4];
+    expect(firstCallOpts?.otherPrFiles).toContain("big2.ts");
+    expect(secondCallOpts?.otherPrFiles).toContain("big1.ts");
+  });
+
+  it("does not pass otherPrFiles in single-call mode", async () => {
+    const patches = [makePatch("small.ts", 10)];
+    await runMultiCallReview(patches, config, prMetadata);
+
+    expect(runReviewMock).toHaveBeenCalledTimes(1);
+    const opts = runReviewMock.mock.calls[0][4];
+    expect(opts?.otherPrFiles).toBeUndefined();
+  });
+
+  it("filters observations that target files changed in the PR", async () => {
+    runReviewMock.mockResolvedValueOnce({
+      ...makeMockReview("chunk"),
+      observations: [
+        {
+          file: "big1.ts",
+          line: 10,
+          severity: "warning" as const,
+          category: "bugs" as const,
+          message: "stale reference found via searchCode",
+        },
+        {
+          file: "unrelated-lib.ts",
+          line: 5,
+          severity: "suggestion" as const,
+          category: "style" as const,
+          message: "genuine observation about unchanged code",
+        },
+      ],
+    });
+
+    const patches = [makePatch("big1.ts", 10)];
+    const result = await runMultiCallReview(patches, config, prMetadata);
+
+    expect(result.observations).toHaveLength(1);
+    expect(result.observations[0].file).toBe("unrelated-lib.ts");
+  });
+});
+
+describe("filterObservationsForPrFiles", () => {
+  function makeObservation(file: string): Observation {
+    return {
+      file,
+      line: 1,
+      severity: "warning",
+      category: "bugs",
+      message: `observation in ${file}`,
+    };
+  }
+
+  it("removes observations whose file is in the PR", () => {
+    const observations = [makeObservation("src/a.ts"), makeObservation("src/b.ts")];
+    const prFiles = new Set(["src/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toEqual([makeObservation("src/b.ts")]);
+  });
+
+  it("keeps all observations when none match PR files", () => {
+    const observations = [makeObservation("lib/x.ts"), makeObservation("lib/y.ts")];
+    const prFiles = new Set(["src/a.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(2);
+  });
+
+  it("removes all observations when all match PR files", () => {
+    const observations = [makeObservation("src/a.ts"), makeObservation("src/b.ts")];
+    const prFiles = new Set(["src/a.ts", "src/b.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("returns empty array for empty observations", () => {
+    const filtered = filterObservationsForPrFiles([], new Set(["src/a.ts"]));
+    expect(filtered).toHaveLength(0);
+  });
+
+  it("requires exact path match (no partial matching)", () => {
+    const observations = [makeObservation("src/auth.ts")];
+    const prFiles = new Set(["src/auth.test.ts"]);
+    const filtered = filterObservationsForPrFiles(observations, prFiles);
+    expect(filtered).toHaveLength(1);
   });
 });

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -2,7 +2,7 @@ export { ReviewOutputSchema } from "./schema.js";
 export { buildSystemPrompt, buildUserMessage } from "./prompts.js";
 export { runReview } from "./review.js";
 export type { RunReviewOptions } from "./review.js";
-export { runMultiCallReview } from "./multi-call.js";
+export { runMultiCallReview, filterObservationsForPrFiles } from "./multi-call.js";
 export type { MultiCallReviewOptions } from "./multi-call.js";
 export { runConsensusReview } from "./consensus.js";
 export { resolveModelConfig, resolveModel, getModelDisplayName } from "./model.js";

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -75,6 +75,13 @@ function estimateTicketContextTokens(ticketContext?: TicketInfo[]): number {
   return countTokens(serialized);
 }
 
+export function filterObservationsForPrFiles(
+  observations: Observation[],
+  prFiles: Set<string>,
+): Observation[] {
+  return observations.filter((o) => !prFiles.has(o.file));
+}
+
 function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult {
   const allFindings: Finding[] = [];
   const allObservations: Observation[] = [];
@@ -232,8 +239,12 @@ export async function runMultiCallReview(
         );
       }
 
+      const allPaths = patches.map((p) => p.path);
+
       const results: ReviewResult[] = [];
       for (const group of groups) {
+        const groupPaths = new Set(group.map((p) => p.path));
+        const otherPrFiles = allPaths.filter((f) => !groupPaths.has(f));
         const groupCompressed = compressDiff(group, maxTokens).compressed;
         const groupResult = await runConsensusReview(
           group,
@@ -241,12 +252,23 @@ export async function runMultiCallReview(
           prMetadata,
           groupCompressed,
           ticketContext,
-          resolvedOptions,
+          { ...resolvedOptions, otherPrFiles },
         );
         results.push(groupResult);
       }
 
       result = mergeResults(results, results[0]?.modelUsed ?? "unknown");
+    }
+
+    const prFileSet = new Set(patches.map((p) => p.path));
+    const beforeCount = result.observations.length;
+    result.observations = filterObservationsForPrFiles(result.observations, prFileSet);
+    const droppedCount = beforeCount - result.observations.length;
+    if (droppedCount > 0) {
+      logger.info(
+        { dropped: droppedCount, total: beforeCount },
+        "filtered observations that targeted files changed in this PR",
+      );
     }
 
     const judgeConfig = resolveJudgeConfig();

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -75,11 +75,19 @@ function estimateTicketContextTokens(ticketContext?: TicketInfo[]): number {
   return countTokens(serialized);
 }
 
+function normalizePath(file: string): string {
+  return file
+    .replace(/\\/g, "/")
+    .replace(/^\.\//, "")
+    .replace(/:\d+(?::\d+)?$/, "");
+}
+
 export function filterObservationsForPrFiles(
   observations: Observation[],
   prFiles: Set<string>,
 ): Observation[] {
-  return observations.filter((o) => !prFiles.has(o.file));
+  const normalizedPrFiles = new Set(Array.from(prFiles, normalizePath));
+  return observations.filter((o) => !normalizedPrFiles.has(normalizePath(o.file)));
 }
 
 function mergeResults(results: ReviewResult[], modelUsed: string): ReviewResult {

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -40,6 +40,7 @@ export function buildUserMessage(
   prMetadata: PRMetadata,
   ticketContext?: TicketInfo[],
   languageSummary?: string,
+  otherPrFiles?: string[],
 ): string {
   const parts: string[] = [];
 
@@ -79,6 +80,17 @@ export function buildUserMessage(
         "only when the visible changes clearly do not satisfy the requirement, and use `unclear` " +
         "when the visible changes are insufficient to decide.",
     );
+  }
+
+  if (otherPrFiles && otherPrFiles.length > 0) {
+    parts.push("\n## Other Files Changed in This PR");
+    parts.push(
+      "The following files are also being modified in this PR but are not included in this review chunk. " +
+        'Do NOT report observations about these files as issues in "unchanged code" — they are actively changed in this PR ' +
+        "and will be reviewed in a separate chunk. If searchCode returns results in these files, " +
+        "note that the search results may be stale (pre-merge content).\n",
+    );
+    parts.push(otherPrFiles.map((f) => `- \`${f}\``).join("\n"));
   }
 
   parts.push("\n## Diff\n");

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -12,6 +12,8 @@ export interface RunReviewOptions {
   /** Additional tools to provide to the review agent (e.g. from MCP servers). */
   extraTools?: ToolsInput;
   languageSummary?: string;
+  /** Files changed in the PR but not present in the current review chunk. */
+  otherPrFiles?: string[];
 }
 
 function buildTools(options?: RunReviewOptions): ToolsInput {
@@ -33,7 +35,13 @@ export async function runReview(
   options?: RunReviewOptions,
 ): Promise<ReviewResult> {
   const systemPrompt = buildSystemPrompt(config);
-  const userMessage = buildUserMessage(diff, prMetadata, ticketContext, options?.languageSummary);
+  const userMessage = buildUserMessage(
+    diff,
+    prMetadata,
+    ticketContext,
+    options?.languageSummary,
+    options?.otherPrFiles,
+  );
   const modelConfig = resolveModelConfig();
   const model = resolveModel(modelConfig);
   const modelName = getModelDisplayName(modelConfig);

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -29,6 +29,7 @@ Important rules:
 - Do not speculate about broken imports or unused exports without using searchCode to verify.
 - Do not comment on formatting or trivial style issues unless specifically asked to review code style.
 - For ticket compliance, use "not_addressed" only when the visible changes clearly fail to satisfy a requirement; use "unclear" when the diff does not contain enough evidence to decide.
+- When an "Other Files Changed in This PR" section is present, those files are being modified in this PR and reviewed separately. Do not flag them as issues in unchanged code. Note that searchCode results for those files may reflect pre-merge content.
 {{style_instructions}}
 {{focus_instructions}}
 {{custom_instructions}}


### PR DESCRIPTION
Fixes #32

## Summary
- Passes the set of other PR files into each review chunk so the agent can distinguish changed files from unchanged code.
- Adds prompt guidance to treat those files as in-scope for the PR and avoid flagging them as issues in unchanged code.
- Filters out final observations that target files changed in the PR, with logging when observations are dropped.
- Exports the new observation filter helper and adds coverage for prompt behavior and multi-call filtering.

## Testing
- Added unit tests for `buildUserMessage` covering inclusion, omission, and placement of the new other-files section.
- Added multi-call review tests verifying `otherPrFiles` is passed to chunked reviews and omitted in single-call mode.
- Added tests for `filterObservationsForPrFiles` covering exact-match filtering and empty inputs.
- Not run: full test suite or integration checks.