### PR TITLE
Document cascading triage review

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 
 - **4 review styles** — Strict, Balanced, Lenient, Roast
 - **6 focus areas** — Security, Performance, Bugs, Code Style, Test Coverage, Documentation
+- **Triage-driven cascading review** — cheap model classifies files as skip/skim/deep-review, each tier gets an appropriate level of scrutiny
 - **Tree-sitter context expansion** — hunks expand to enclosing function/class boundaries instead of fixed line counts (TS, JS, Python, Go, Java, Rust)
 - **Structured summary comments** — severity table, collapsible issue details, files reviewed
 - **Inline code comments** — findings posted directly on PR diff lines
@@ -53,6 +54,7 @@ packages/
 │   │   ├── agent/      # Mastra review agent, judge/filter pass, prompt templates, Zod output schema
 │   │   ├── diff/       # unified diff parser, tree-sitter context expansion, file filter, token-aware compression
 │   │   ├── formatter/  # summary comment + inline comment markdown renderers
+│   │   ├── triage/     # file classification for cascading review (skip/skim/deep-review)
 │   │   ├── tickets/    # ticket ref extraction, providers (GitHub/Jira/Linear/ADO)
 │   │   └── types.ts    # shared type definitions
 │   └── src/prompts/    # externalized prompt templates (styles + focus areas)
@@ -150,6 +152,8 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_JUDGE_ENABLED` | enable post-generation judge/filter pass | `false` |
 | `RUSTY_JUDGE_THRESHOLD` | minimum confidence score (0–10) to keep a finding | `6` |
 | `RUSTY_JUDGE_MODEL` | model for the judge (can be cheaper than reviewer) | same as `RUSTY_LLM_MODEL` |
+| `RUSTY_LLM_TRIAGE_MODEL` | LLM model for triage classification (enables cascading) | — |
+| `RUSTY_CASCADE_ENABLED` | explicitly enable/disable cascading (`true`/`false`) | auto (enabled when triage model is set) |
 
 ### LLM Provider Configuration
 
@@ -297,6 +301,46 @@ Configure via per-repo config:
 
 Set `consensusPasses` to `1` to disable consensus voting and get the original single-pass behavior with zero overhead.
 
+
+
+### Cascading Review (Triage)
+
+By default every file gets the same deep review treatment. When cascading is enabled, a cheap triage model first classifies each file as `skip`, `skim`, or `deep-review`. Each tier then gets an appropriate level of scrutiny:
+
+| Tier | What happens |
+|------|-------------|
+| **skip** | File is excluded entirely (lock files, auto-generated code, vendored deps) |
+| **skim** | Lightweight single-pass review — diff-only context, no tools, simplified output schema (no `suggestedFix`, no ticket compliance) |
+| **deep-review** | Full review pipeline — tree-sitter context expansion, code search tools, consensus voting, ticket compliance |
+
+Enable by setting a triage model:
+
+```bash
+RUSTY_LLM_TRIAGE_MODEL=anthropic/claude-3-5-haiku-20241022
+```
+
+Or toggle explicitly:
+
+```bash
+RUSTY_CASCADE_ENABLED=true   # force on (requires RUSTY_LLM_TRIAGE_MODEL)
+RUSTY_CASCADE_ENABLED=false  # force off even if triage model is set
+```
+
+**How it works:**
+
+1. The triage agent receives a truncated version of each file's diff (≤200 tokens per file, 30k token budget total) and classifies it
+2. Files that overflow the triage budget default to `deep-review`
+3. Files the triage model misses also default to `deep-review`
+4. Safety net: if triage classifies *all* files as `skip`, the top 20% by additions are force-promoted to `deep-review`
+5. Skim-tier and deep-tier files are reviewed in parallel via `runCascadeReview`
+6. Results from both tiers are merged, then passed through the judge (if enabled)
+7. If triage fails entirely, the bot falls back to the standard full-review pipeline
+
+**Summary comment:** When cascading is active, the PR comment includes a collapsible **Triage Summary** showing how many files were skipped, skimmed, and deep-reviewed, plus the triage model and token usage.
+
+**Dashboard:** The reviews table shows a triage column with the breakdown (e.g. `3s / 5k / 8d` for 3 skipped, 5 skimmed, 8 deep-reviewed).
+
+**Cost:** The triage call itself is cheap (truncated diffs, small output schema). The savings come from skipping context expansion and tool calls for skim-tier files. For a typical PR where ~40% of files are config/docs/tests, expect roughly 30–50% token reduction on the review calls.
 
 ### Tree-sitter Context Expansion
 


### PR DESCRIPTION
## Summary
- Added README documentation for the new triage-driven cascading review flow.
- Described the `skip` / `skim` / `deep-review` tiers and how each affects review depth.
- Documented the new triage-related environment variables and enable/disable behavior.
- Added notes on fallback behavior, summary comments, dashboard reporting, and expected cost savings.

## Testing
- Not run
- Verified the README diff updates only documentation content in `README.md`
- Checked that the new section explains the cascading flow, configuration, and fallback behavior