### PR TITLE
Derive TypeScript types from Zod schemas (single source of truth)

### DIFF
--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -130,6 +130,7 @@ describe("runMultiCallReview", () => {
             ticketId: "AUTH-42",
             requirement: "Protected routes validate JWT",
             status: "unclear",
+            evidence: null,
           },
         ],
       })

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,4 +1,15 @@
-export { ReviewOutputSchema, SkimReviewOutputSchema } from "./schema.js";
+export {
+  SeveritySchema,
+  FocusAreaSchema,
+  RecommendationSchema,
+  TicketComplianceStatusSchema,
+  FindingSchema,
+  SkimFindingSchema,
+  ObservationSchema,
+  TicketComplianceSchema,
+  ReviewOutputSchema,
+  SkimReviewOutputSchema,
+} from "./schema.js";
 export { buildSystemPrompt, buildUserMessage } from "./prompts.js";
 export { runReview } from "./review.js";
 export type { RunReviewOptions, ReviewTier } from "./review.js";

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -141,9 +141,9 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
   };
 }
 
-function normalizeEvidence(evidence?: string | null): string | undefined {
+function normalizeEvidence(evidence: string | null): string | null {
   const trimmed = evidence?.trim();
-  return trimmed ? trimmed : undefined;
+  return trimmed ? trimmed : null;
 }
 
 function normalizeComplianceKeyPart(value?: string | null): string {
@@ -189,7 +189,7 @@ function mergeTicketCompliance(results: ReviewResult[]): TicketComplianceItem[] 
 
   return [...merged.values()].map(({ evidenceParts, ...item }) => ({
     ...item,
-    evidence: evidenceParts.length > 0 ? evidenceParts.join(" | ") : undefined,
+    evidence: evidenceParts.length > 0 ? evidenceParts.join(" | ") : null,
   }));
 }
 

--- a/packages/core/src/agent/schema.ts
+++ b/packages/core/src/agent/schema.ts
@@ -1,5 +1,33 @@
 import { z } from "zod";
 
+export const SeveritySchema = z.enum(["critical", "warning", "suggestion"]);
+export type Severity = z.infer<typeof SeveritySchema>;
+
+export const FocusAreaSchema = z.enum([
+  "security",
+  "performance",
+  "bugs",
+  "style",
+  "tests",
+  "docs",
+]);
+export type FocusArea = z.infer<typeof FocusAreaSchema>;
+
+export const RecommendationSchema = z.enum([
+  "looks_good",
+  "address_before_merge",
+  "critical_issues",
+]);
+export type Recommendation = z.infer<typeof RecommendationSchema>;
+
+export const TicketComplianceStatusSchema = z.enum([
+  "addressed",
+  "partially_addressed",
+  "not_addressed",
+  "unclear",
+]);
+export type TicketComplianceStatus = z.infer<typeof TicketComplianceStatusSchema>;
+
 export const FindingSchema = z.object({
   file: z.string(),
   line: z.number(),
@@ -9,8 +37,8 @@ export const FindingSchema = z.object({
     .describe(
       "last line of the range when the fix spans multiple lines; null for single-line fixes",
     ),
-  severity: z.enum(["critical", "warning", "suggestion"]),
-  category: z.enum(["security", "performance", "bugs", "style", "tests", "docs"]),
+  severity: SeveritySchema,
+  category: FocusAreaSchema,
   message: z.string(),
   suggestedFix: z
     .string()
@@ -19,6 +47,11 @@ export const FindingSchema = z.object({
       "exact replacement code for the line(s) from `line` to `endLine` — raw code only, no markdown fences, no extra context lines; null when no localized fix is possible",
     ),
 });
+
+// extends LLM output with consensus pipeline metadata
+export type Finding = z.infer<typeof FindingSchema> & {
+  voteCount?: number;
+};
 
 export const SkimFindingSchema = z.object({
   file: z.string(),
@@ -29,18 +62,23 @@ export const SkimFindingSchema = z.object({
     .describe(
       "last line of the range when the issue spans multiple lines; null for single-line issues",
     ),
-  severity: z.enum(["critical", "warning", "suggestion"]),
-  category: z.enum(["security", "performance", "bugs", "style", "tests", "docs"]),
+  severity: SeveritySchema,
+  category: FocusAreaSchema,
   message: z.string(),
 });
 
 export const ObservationSchema = z.object({
   file: z.string(),
   line: z.number(),
-  severity: z.enum(["critical", "warning", "suggestion"]),
-  category: z.enum(["security", "performance", "bugs", "style", "tests", "docs"]),
+  severity: SeveritySchema,
+  category: FocusAreaSchema,
   message: z.string(),
 });
+
+// extends LLM output with consensus pipeline metadata
+export type Observation = z.infer<typeof ObservationSchema> & {
+  voteCount?: number;
+};
 
 export const TicketComplianceSchema = z.object({
   ticketId: z
@@ -48,20 +86,18 @@ export const TicketComplianceSchema = z.object({
     .nullable()
     .describe("linked ticket identifier when available, otherwise null"),
   requirement: z.string().describe("single ticket requirement or acceptance criterion"),
-  status: z
-    .enum(["addressed", "partially_addressed", "not_addressed", "unclear"])
-    .describe("whether the diff addresses the requirement"),
+  status: TicketComplianceStatusSchema.describe("whether the diff addresses the requirement"),
   evidence: z
     .string()
     .nullable()
     .describe("brief evidence from the diff supporting the compliance status, otherwise null"),
 });
 
+export type TicketComplianceItem = z.infer<typeof TicketComplianceSchema>;
+
 export const ReviewOutputSchema = z.object({
   summary: z.string().describe("concise summary of the PR and overall assessment"),
-  recommendation: z
-    .enum(["looks_good", "address_before_merge", "critical_issues"])
-    .describe("merge recommendation based on findings"),
+  recommendation: RecommendationSchema.describe("merge recommendation based on findings"),
   findings: z
     .array(FindingSchema)
     .describe("issues found in the changed code, tied to specific lines in the diff"),
@@ -76,11 +112,11 @@ export const ReviewOutputSchema = z.object({
   filesReviewed: z.array(z.string()).describe("list of file paths that were reviewed"),
 });
 
+export type ReviewOutput = z.infer<typeof ReviewOutputSchema>;
+
 export const SkimReviewOutputSchema = z.object({
   summary: z.string().describe("concise summary of the PR and overall assessment"),
-  recommendation: z
-    .enum(["looks_good", "address_before_merge", "critical_issues"])
-    .describe("merge recommendation based on findings"),
+  recommendation: RecommendationSchema.describe("merge recommendation based on findings"),
   findings: z
     .array(SkimFindingSchema)
     .describe("issues found in the changed code, tied to specific lines in the diff"),

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -9,6 +9,7 @@ export type {
   TriageStats,
   Finding,
   Observation,
+  ReviewOutput,
   ReviewResult,
   ReviewConfig,
   PRMetadata,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,40 +1,19 @@
+export type {
+  Severity,
+  FocusArea,
+  Recommendation,
+  TicketComplianceStatus,
+  Finding,
+  Observation,
+  TicketComplianceItem,
+  ReviewOutput,
+} from "./agent/schema.js";
+
+import type { Finding, Observation, FocusArea, ReviewOutput } from "./agent/schema.js";
+
 export type ReviewStyle = "strict" | "balanced" | "lenient" | "roast";
 
-export type FocusArea = "security" | "performance" | "bugs" | "style" | "tests" | "docs";
-
-export type Severity = "critical" | "warning" | "suggestion";
-
-export type Recommendation = "looks_good" | "address_before_merge" | "critical_issues";
-
 export type TriageClassification = "skip" | "skim" | "deep-review";
-
-export type TicketComplianceStatus =
-  | "addressed"
-  | "partially_addressed"
-  | "not_addressed"
-  | "unclear";
-
-export interface Finding {
-  file: string;
-  line: number;
-  endLine: number | null;
-  severity: Severity;
-  category: FocusArea;
-  message: string;
-  suggestedFix: string | null;
-  /** number of consensus passes that flagged this finding */
-  voteCount?: number;
-}
-
-export interface Observation {
-  file: string;
-  line: number;
-  severity: Severity;
-  category: FocusArea;
-  message: string;
-  /** number of consensus passes that flagged this observation */
-  voteCount?: number;
-}
 
 export interface TriageFileResult {
   path: string;
@@ -56,13 +35,9 @@ export interface TriageStats {
   triageTokenCount: number;
 }
 
-export interface ReviewResult {
-  summary: string;
-  recommendation: Recommendation;
+export interface ReviewResult extends ReviewOutput {
   findings: Finding[];
   observations: Observation[];
-  ticketCompliance: TicketComplianceItem[];
-  filesReviewed: string[];
   modelUsed: string;
   tokenCount: number;
   triageStats?: TriageStats;
@@ -115,13 +90,6 @@ export interface TicketInfo {
   acceptanceCriteria?: string;
   labels: string[];
   source: string;
-}
-
-export interface TicketComplianceItem {
-  ticketId?: string | null;
-  requirement: string;
-  status: TicketComplianceStatus;
-  evidence?: string | null;
 }
 
 export interface TicketResolutionStatus {


### PR DESCRIPTION
## Summary

Closes #37

- Zod schemas in `agent/schema.ts` are now the single source of truth for `Finding`, `Observation`, `TicketComplianceItem`, and enum types (`Severity`, `FocusArea`, `Recommendation`, `TicketComplianceStatus`)
- TypeScript types are derived via `z.infer<>` and re-exported from `types.ts`, eliminating duplicate definitions that had already drifted once (#36)
- `ReviewResult` is split into `ReviewOutput` (LLM output shape, Zod-derived) and `ReviewResult` (extends with pipeline metadata like `modelUsed`, `tokenCount`, `triageStats`)
- `SkimFindingSchema` / `SkimReviewOutputSchema` updated to use named enum schemas instead of inline `z.enum()` calls
- Fixed `evidence` nullability in `multi-call.ts` (`undefined` → `null`) to match the Zod-derived type

## Test plan

- [x] All 386 tests pass
- [x] All 4 packages build cleanly (`core`, `github`, `azure-devops`, `dashboard`)
- [x] Lint and prettier pass
- [x] OpenAI strict mode schema compatibility test passes
- [x] No functional changes to the review pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)