### PR TITLE
Add suggestedFix to skim review findings

### DIFF
--- a/packages/core/src/__tests__/schema.test.ts
+++ b/packages/core/src/__tests__/schema.test.ts
@@ -67,10 +67,10 @@ describe("SkimReviewOutputSchema strict mode compatibility", () => {
     expect(violations, violations.join("\n")).toEqual([]);
   });
 
-  it("does not include suggestedFix in findings", () => {
+  it("includes suggestedFix in findings", () => {
     const jsonSchema = z.toJSONSchema(SkimReviewOutputSchema) as JsonSchemaObject;
     const findingsItems = jsonSchema.properties?.findings?.items;
-    expect(findingsItems?.properties).not.toHaveProperty("suggestedFix");
+    expect(findingsItems?.properties).toHaveProperty("suggestedFix");
   });
 });
 

--- a/packages/core/src/agent/schema.ts
+++ b/packages/core/src/agent/schema.ts
@@ -32,6 +32,12 @@ export const SkimFindingSchema = z.object({
   severity: z.enum(["critical", "warning", "suggestion"]),
   category: z.enum(["security", "performance", "bugs", "style", "tests", "docs"]),
   message: z.string(),
+  suggestedFix: z
+    .string()
+    .nullable()
+    .describe(
+      "exact replacement code for the line(s) from `line` to `endLine` — raw code only, no markdown fences, no extra context lines; null when no localized fix is possible",
+    ),
 });
 
 export const ObservationSchema = z.object({


### PR DESCRIPTION
## Summary
- Adds the `suggestedFix` nullable field to `SkimFindingSchema`, allowing skim-tier reviews to produce GitHub `suggestion` blocks just like deep-review findings.
- The skim tier already receives full diff context — enough for the LLM to write localized fixes. The nullable field handles cases where no fix is possible.
- Revises the original design decision from #3 (user story 9) which assumed skim reviews lacked sufficient context for suggestions.

## Context

Discovered while investigating PR #31 review comments — 2 out of 3 findings had no code suggestion blocks because `SkimFindingSchema` didn't include `suggestedFix`. The LLM clearly understood the fix (described it in prose) but the schema prevented it from expressing it as code.

## Test plan
- [x] Updated `schema.test.ts` to assert `suggestedFix` is present in skim findings
- [x] Verified strict mode compatibility test still passes (all properties in `required`)
- [x] Full test suite passes (386 tests)