### PR TITLE
Improve consensus review output: numbered summaries, dropped findings log, richer metadata

### DIFF
--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -106,10 +106,17 @@ describe("runConsensusReview", () => {
     expect(result.findings).toHaveLength(0);
   });
 
-  it("includes consensus metadata", async () => {
+  it("includes consensus metadata with agreement rate and pass recommendations", async () => {
     const consensusConfig = { ...config, consensusPasses: 3 };
     const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
-    expect(result.consensusMetadata).toEqual({ passes: 3, threshold: 2 });
+    expect(result.consensusMetadata).toMatchObject({
+      passes: 3,
+      threshold: 2,
+      recommendationElevated: false,
+    });
+    expect(result.consensusMetadata?.agreementRate).toBeGreaterThanOrEqual(0);
+    expect(result.consensusMetadata?.agreementRate).toBeLessThanOrEqual(1);
+    expect(result.consensusMetadata?.passRecommendations).toHaveLength(3);
   });
 
   it("derives recommendation from filtered findings only", async () => {
@@ -129,6 +136,77 @@ describe("runConsensusReview", () => {
     const { runReview } = await import("../agent/review.js");
     expect(runReview).toHaveBeenCalledTimes(3);
     expect(result.consensusMetadata?.passes).toBe(3);
+  });
+
+  it("populates droppedFindings for clusters below threshold", async () => {
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    // uniqueFinding only appears in 1/3 passes → dropped
+    expect(result.droppedFindings).toBeDefined();
+    expect(result.droppedFindings).toHaveLength(1);
+    expect(result.droppedFindings![0].file).toBe("src/other.ts");
+    expect(result.droppedFindings![0].voteCount).toBe(1);
+  });
+
+  it("omits droppedFindings when all clusters meet threshold", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }));
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.droppedFindings).toBeUndefined();
+  });
+
+  it("produces numbered summaries for multi-pass reviews", async () => {
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.summary).toContain("1. ");
+    expect(result.summary).toContain("2. ");
+    expect(result.summary).toContain("3. ");
+    expect(result.summary).toMatch(/^Consensus review \(3 passes, threshold 2\)\./);
+  });
+
+  it("sets recommendationElevated when recommendation comes from pass votes not findings", async () => {
+    mockBehavior = "no-findings-but-flagged";
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.consensusMetadata?.recommendationElevated).toBe(true);
+  });
+
+  it("sets recommendationElevated=false when recommendation is derived from findings", async () => {
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.consensusMetadata?.recommendationElevated).toBe(false);
+  });
+
+  it("agreement rate is 1 when all clusters survive", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }));
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.consensusMetadata?.agreementRate).toBe(1);
+  });
+
+  it("agreement rate is 0 when no clusters survive strict threshold", async () => {
+    const strictConfig = { ...config, consensusPasses: 3, consensusThreshold: 3 };
+    const result = await runConsensusReview([], strictConfig, prMetadata, "diff content");
+    expect(result.consensusMetadata?.agreementRate).toBe(0);
+  });
+
+  it("agreement rate is 1 when there are zero finding clusters", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [], tokenCount: 100 }));
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    expect(result.consensusMetadata?.agreementRate).toBe(1);
   });
 
   it("uses per-pass recommendations when findings are empty but majority flags issues", async () => {

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -377,6 +377,135 @@ describe("formatInlineComment", () => {
   });
 });
 
+describe("formatSummaryComment with dropped findings", () => {
+  it("renders a collapsible dropped findings section", () => {
+    const review = makeReview({
+      droppedFindings: [
+        {
+          file: "src/parser.ts",
+          line: 42,
+          severity: "warning",
+          message: "potential resource leak in WASM cleanup",
+          voteCount: 1,
+        },
+        {
+          file: "src/utils.ts",
+          line: 15,
+          severity: "suggestion",
+          message: "consider extracting helper function",
+          voteCount: 1,
+        },
+      ],
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0.5,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "looks_good"],
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("Filtered findings (2 dropped by consensus, voted below threshold)");
+    expect(result).toContain("| `src/parser.ts` | 42 | warning |");
+    expect(result).toContain("| 1/3 |");
+    expect(result).toContain("| `src/utils.ts` | 15 | suggestion |");
+  });
+
+  it("omits dropped findings section when droppedFindings is undefined", () => {
+    const review = makeReview({ droppedFindings: undefined });
+    const result = formatSummaryComment(review);
+    expect(result).not.toContain("Filtered findings");
+  });
+
+  it("omits dropped findings section when droppedFindings is empty", () => {
+    const review = makeReview({
+      droppedFindings: [],
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "looks_good"],
+      },
+    });
+    const result = formatSummaryComment(review);
+    expect(result).not.toContain("Filtered findings");
+  });
+
+  it("sanitizes pipe characters in dropped finding messages", () => {
+    const review = makeReview({
+      droppedFindings: [
+        {
+          file: "src/a.ts",
+          line: 1,
+          severity: "warning",
+          message: "use a | b instead of a || b",
+          voteCount: 1,
+        },
+      ],
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0.5,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "looks_good"],
+      },
+    });
+
+    const result = formatSummaryComment(review);
+    expect(result).toContain("use a \\| b instead of a \\|\\| b");
+  });
+});
+
+describe("formatSummaryComment with consensus metadata in footer", () => {
+  it("includes consensus pass count and agreement rate in footer", () => {
+    const review = makeReview({
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0.67,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "address_before_merge"],
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("consensus 3 passes");
+    expect(result).toContain("67% agreement");
+    expect(result).not.toContain("recommendation elevated");
+  });
+
+  it("shows elevated recommendation note when recommendationElevated is true", () => {
+    const review = makeReview({
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 1,
+        recommendationElevated: true,
+        passRecommendations: [
+          "address_before_merge",
+          "address_before_merge",
+          "address_before_merge",
+        ],
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("recommendation elevated from pass votes");
+  });
+
+  it("omits consensus metadata from footer when not present", () => {
+    const review = makeReview();
+    const result = formatSummaryComment(review);
+    expect(result).not.toContain("consensus");
+    expect(result).not.toContain("agreement");
+  });
+});
+
 describe("formatSummaryComment with triage stats", () => {
   it("includes triage section when triageStats is present", () => {
     const review: ReviewResult = {

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -278,7 +278,7 @@ describe("runMultiCallReview", () => {
     const consensusConfig: ReviewConfig = { ...config, consensusPasses: 3 };
     const patches = [makePatch("small.ts", 10)];
     const result = await runMultiCallReview(patches, consensusConfig, prMetadata);
-    expect(result.consensusMetadata).toEqual({ passes: 3, threshold: 2 });
+    expect(result.consensusMetadata).toMatchObject({ passes: 3, threshold: 2 });
     expect(result.findings.length).toBeGreaterThanOrEqual(1);
   });
 

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -7,6 +7,7 @@ import type {
   Finding,
   Observation,
   Recommendation,
+  DroppedFinding,
 } from "../types.js";
 import { compressDiff } from "../diff/compress.js";
 import { shufflePatches } from "../diff/shuffle.js";
@@ -89,9 +90,21 @@ export async function runConsensusReview(
   const findingClusters = clusterFindings(findingsByPass);
   const observationClusters = clusterObservations(observationsByPass);
 
-  const survivingFindings: Finding[] = findingClusters
-    .filter((c) => c.voteCount >= threshold)
-    .map((c) => ({ ...c.representative, voteCount: c.voteCount }));
+  const survivingClusters = findingClusters.filter((c) => c.voteCount >= threshold);
+  const droppedClusters = findingClusters.filter((c) => c.voteCount < threshold);
+
+  const survivingFindings: Finding[] = survivingClusters.map((c) => ({
+    ...c.representative,
+    voteCount: c.voteCount,
+  }));
+
+  const droppedFindings: DroppedFinding[] = droppedClusters.map((c) => ({
+    file: c.representative.file,
+    line: c.representative.line,
+    severity: c.representative.severity,
+    message: c.representative.message,
+    voteCount: c.voteCount,
+  }));
 
   const survivingObservations: Observation[] = observationClusters
     .filter((c) => c.voteCount >= threshold)
@@ -100,8 +113,13 @@ export async function runConsensusReview(
   const allFiles = new Set(results.flatMap((r) => r.filesReviewed));
   const totalTokens = results.reduce((sum, r) => sum + r.tokenCount, 0);
 
-  const totalRawFindings = findingsByPass.reduce((sum, pass) => sum + pass.length, 0);
   const totalRawObservations = observationsByPass.reduce((sum, pass) => sum + pass.length, 0);
+
+  const recommendation = deriveRecommendation(survivingFindings, passRecommendations, threshold);
+  const recommendationElevated = survivingFindings.length === 0 && recommendation !== "looks_good";
+
+  const agreementRate =
+    findingClusters.length > 0 ? survivingClusters.length / findingClusters.length : 1;
 
   logger.info(
     {
@@ -109,8 +127,9 @@ export async function runConsensusReview(
       threshold,
       totalClusters: findingClusters.length,
       surviving: survivingFindings.length,
-      dropped: totalRawFindings - survivingFindings.length,
+      dropped: droppedFindings.length,
       droppedObservations: totalRawObservations - survivingObservations.length,
+      agreementRate,
       passRecommendations,
     },
     "consensus voting complete",
@@ -118,19 +137,26 @@ export async function runConsensusReview(
 
   const summaries = results.map((r) => r.summary).filter(Boolean);
   const summary =
-    summaries.length === 1
-      ? summaries[0]
-      : `Consensus review (${passes} passes, threshold ${threshold}).\n\n${summaries.join("\n\n")}`;
+    summaries.length <= 1
+      ? (summaries[0] ?? "")
+      : `Consensus review (${passes} passes, threshold ${threshold}).\n\n${summaries.map((s, i) => `${i + 1}. ${s}`).join("\n")}`;
 
   return {
     summary,
-    recommendation: deriveRecommendation(survivingFindings, passRecommendations, threshold),
+    recommendation,
     findings: survivingFindings,
     observations: survivingObservations,
     ticketCompliance: results[0]?.ticketCompliance ?? [],
     filesReviewed: [...allFiles],
     modelUsed: results[0]?.modelUsed ?? "unknown",
     tokenCount: totalTokens,
-    consensusMetadata: { passes, threshold },
+    consensusMetadata: {
+      passes,
+      threshold,
+      agreementRate,
+      recommendationElevated,
+      passRecommendations,
+    },
+    droppedFindings: droppedFindings.length > 0 ? droppedFindings : undefined,
   };
 }

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -3,6 +3,7 @@ import type {
   Severity,
   Finding,
   Observation,
+  DroppedFinding,
   TriageStats,
   TicketComplianceStatus,
   TicketResolutionStatus,
@@ -62,6 +63,26 @@ function buildTriageSection(stats: TriageStats): string {
   lines.push(`| Deep Reviewed | ${stats.filesDeepReviewed} |`);
   lines.push("");
   lines.push(`Triage model: \`${stats.triageModelUsed}\` · ${stats.triageTokenCount} tokens`);
+  lines.push("");
+  lines.push("</details>");
+  lines.push("");
+  return lines.join("\n");
+}
+
+function buildDroppedFindingsSection(dropped: DroppedFinding[], passes: number): string {
+  const lines: string[] = [];
+  lines.push("<details>");
+  lines.push(
+    `<summary>Filtered findings (${dropped.length} dropped by consensus, voted below threshold)</summary>`,
+  );
+  lines.push("");
+  lines.push("| File | Line | Severity | Message | Votes |");
+  lines.push("|------|------|----------|---------|-------|");
+  for (const f of dropped) {
+    lines.push(
+      `| \`${f.file}\` | ${f.line} | ${f.severity} | ${sanitizeTableCell(f.message)} | ${f.voteCount}/${passes} |`,
+    );
+  }
   lines.push("");
   lines.push("</details>");
   lines.push("");
@@ -153,6 +174,12 @@ export function formatSummaryComment(
   lines.push("</details>");
   lines.push("");
 
+  if (review.droppedFindings && review.droppedFindings.length > 0 && review.consensusMetadata) {
+    lines.push(
+      buildDroppedFindingsSection(review.droppedFindings, review.consensusMetadata.passes),
+    );
+  }
+
   if (options?.ticketResolution && options.ticketResolution.refsFound > 0) {
     lines.push("## Ticket Fetch");
     lines.push("");
@@ -222,6 +249,14 @@ export function formatSummaryComment(
   }
   if (review.filteredCount !== undefined) {
     parts.push(`${review.filteredCount} low-confidence findings filtered`);
+  }
+  if (review.consensusMetadata) {
+    const cm = review.consensusMetadata;
+    parts.push(`consensus ${cm.passes} passes`);
+    parts.push(`${Math.round(cm.agreementRate * 100)}% agreement`);
+    if (cm.recommendationElevated) {
+      parts.push("recommendation elevated from pass votes");
+    }
   }
   lines.push(parts.join(" · "));
   lines.push("");

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -24,6 +24,8 @@ export type {
   CodeSearchResult,
   GitProvider,
   TicketProvider,
+  DroppedFinding,
+  ConsensusMetadata,
 } from "./types.js";
 
 export { getMastra, getStorage } from "./mastra.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -9,7 +9,30 @@ export type {
   ReviewOutput,
 } from "./agent/schema.js";
 
-import type { Finding, Observation, FocusArea, ReviewOutput } from "./agent/schema.js";
+import type {
+  Finding,
+  Observation,
+  FocusArea,
+  Recommendation,
+  Severity,
+  ReviewOutput,
+} from "./agent/schema.js";
+
+export interface DroppedFinding {
+  file: string;
+  line: number;
+  severity: Severity;
+  message: string;
+  voteCount: number;
+}
+
+export interface ConsensusMetadata {
+  passes: number;
+  threshold: number;
+  agreementRate: number;
+  recommendationElevated: boolean;
+  passRecommendations: Recommendation[];
+}
 
 export type ReviewStyle = "strict" | "balanced" | "lenient" | "roast";
 
@@ -45,7 +68,8 @@ export interface ReviewResult extends ReviewOutput {
   filteredCount?: number;
   /** tokens consumed by the judge pass */
   judgeTokenCount?: number;
-  consensusMetadata?: { passes: number; threshold: number };
+  consensusMetadata?: ConsensusMetadata;
+  droppedFindings?: DroppedFinding[];
 }
 
 export interface ReviewConfig {


### PR DESCRIPTION
## Summary

- **Numbered pass summaries**: multi-pass consensus reviews now render summaries as a numbered list (`1.` / `2.` / `3.`) instead of raw concatenation, making it clear which pass said what
- **Dropped findings accordion**: findings filtered by consensus are now surfaced in a collapsible `<details>` section in the PR comment with file, line, severity, message, and vote ratio — no server log access needed to debug false negatives
- **Richer `ConsensusMetadata`**: extended with `agreementRate`, `recommendationElevated`, and `passRecommendations` so the formatter and dashboard have full consensus quality signals; footer now shows pass count, agreement %, and an elevation note when applicable

Closes #38

## Test plan

- [x] Consensus tests: dropped findings population, numbered summaries, `recommendationElevated` flag, agreement rate edge cases (all survive, none survive, zero clusters)
- [x] Formatter tests: dropped findings rendering, pipe character sanitization, empty/undefined guard, footer metadata with/without consensus, elevated recommendation note
- [x] Multi-call test: updated to use `toMatchObject` for the now-richer metadata shape
- [x] All 401 tests pass, TypeScript compiles cleanly, lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)