### PR TITLE
Add 'thorough' review style with structured reasoning

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 
 ## Features
 
-- **4 review styles** — Strict, Balanced, Lenient, Roast
+- **5 review styles** — Strict, Balanced, Lenient, Roast, Thorough
 - **6 focus areas** — Security, Performance, Bugs, Code Style, Test Coverage, Documentation
 - **Tree-sitter context expansion** — hunks expand to enclosing function/class boundaries instead of fixed line counts (TS, JS, Python, Go, Java, Rust)
 - **Structured summary comments** — severity table, collapsible issue details, files reviewed
@@ -232,6 +232,7 @@ Example `.rusty-bot.md`:
 | **Balanced** | Focuses on confidence, balances thoroughness with practicality |
 | **Lenient** | Only critical bugs and security issues, encouraging tone |
 | **Roast** | Technically accurate feedback wrapped in sharp, witty commentary |
+| **Thorough** | Structured reasoning (intent → components → execution paths → invariants → edge cases → blast radius) before producing findings |
 
 ### Judge / Filter Pass
 

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -1,4 +1,5 @@
-import type { FocusArea, ReviewConfig, ReviewStyle } from "@rusty-bot/core";
+import type { FocusArea, ReviewConfig } from "@rusty-bot/core";
+import { ReviewStyleSchema } from "@rusty-bot/core";
 import {
   filterFiles,
   stripDeletionOnlyHunks,
@@ -22,7 +23,6 @@ import { AzureDevOpsProvider } from "./provider.js";
 
 const log = logger.child({ package: "azure-devops" });
 
-const VALID_STYLES = new Set(["strict", "balanced", "lenient", "roast", "thorough"]);
 const MAX_TOKENS = 120_000;
 
 export function parseConfig(): {
@@ -48,7 +48,8 @@ export function parseConfig(): {
   }
 
   const reviewStyle = process.env.RUSTY_REVIEW_STYLE ?? "balanced";
-  if (!VALID_STYLES.has(reviewStyle)) {
+  const parsedStyle = ReviewStyleSchema.safeParse(reviewStyle);
+  if (!parsedStyle.success) {
     throw new Error(`invalid review style: ${reviewStyle}`);
   }
 
@@ -66,7 +67,7 @@ export function parseConfig(): {
       accessToken,
     }),
     config: {
-      style: reviewStyle as ReviewStyle,
+      style: parsedStyle.data,
       focusAreas,
       ignorePatterns,
     },

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -22,7 +22,7 @@ import { AzureDevOpsProvider } from "./provider.js";
 
 const log = logger.child({ package: "azure-devops" });
 
-const VALID_STYLES = new Set(["strict", "balanced", "lenient", "roast"]);
+const VALID_STYLES = new Set(["strict", "balanced", "lenient", "roast", "thorough"]);
 const MAX_TOKENS = 120_000;
 
 export function parseConfig(): {

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -50,8 +50,26 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("witty");
   });
 
-  it("all 4 styles produce distinct prompts", () => {
-    const styles = ["strict", "balanced", "lenient", "roast"] as const;
+  it("includes thorough style instructions", () => {
+    const prompt = buildSystemPrompt({ ...baseConfig, style: "thorough" });
+    expect(prompt).toContain("THOROUGH");
+    expect(prompt).toContain("Summarize intent");
+    expect(prompt).toContain("Trace execution paths");
+    expect(prompt).toContain("Check invariants");
+    expect(prompt).toContain("Evaluate edge cases");
+    expect(prompt).toContain("Assess blast radius");
+  });
+
+  it("thorough style enforces reasoning before findings", () => {
+    const prompt = buildSystemPrompt({ ...baseConfig, style: "thorough" });
+    const reasoningIdx = prompt.indexOf("Step 1: Summarize intent");
+    const findingsIdx = prompt.indexOf("Step 7: Produce findings");
+    expect(reasoningIdx).toBeGreaterThan(-1);
+    expect(findingsIdx).toBeGreaterThan(reasoningIdx);
+  });
+
+  it("all 5 styles produce distinct prompts", () => {
+    const styles = ["strict", "balanced", "lenient", "roast", "thorough"] as const;
     const prompts = styles.map((style) => buildSystemPrompt({ ...baseConfig, style }));
     for (let i = 0; i < prompts.length; i++) {
       for (let j = i + 1; j < prompts.length; j++) {

--- a/packages/core/src/agent/schema.ts
+++ b/packages/core/src/agent/schema.ts
@@ -13,6 +13,9 @@ export const FocusAreaSchema = z.enum([
 ]);
 export type FocusArea = z.infer<typeof FocusAreaSchema>;
 
+export const ReviewStyleSchema = z.enum(["strict", "balanced", "lenient", "roast", "thorough"]);
+export type ReviewStyle = z.infer<typeof ReviewStyleSchema>;
+
 export const RecommendationSchema = z.enum([
   "looks_good",
   "address_before_merge",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+export { ReviewStyleSchema } from "./agent/schema.js";
 export type {
   ReviewStyle,
   FocusArea,

--- a/packages/core/src/prompts/styles/thorough.txt
+++ b/packages/core/src/prompts/styles/thorough.txt
@@ -1,0 +1,24 @@
+You are in THOROUGH mode. Before producing any findings, you MUST work through the structured reasoning steps below. Do not skip steps, and do not jump to conclusions. Each step builds on the previous — shallow analysis at any step leads to missed bugs.
+
+### Step 1: Summarize intent
+What is this change trying to accomplish? State the goal in one or two sentences. If the PR description is vague, infer from the code.
+
+### Step 2: Identify components
+Which functions, modules, and types are affected? What are their boundaries and contracts? Note any implicit coupling between changed components.
+
+### Step 3: Trace execution paths
+For each changed function, enumerate the possible execution paths. What inputs trigger each path? Pay special attention to early returns, thrown exceptions, async boundaries, and callback orderings.
+
+### Step 4: Check invariants
+What assumptions does the code make? Are those assumptions guaranteed by all callers? Look for implicit preconditions (non-null arguments, initialized state, specific ordering) that are not enforced.
+
+### Step 5: Evaluate edge cases
+What happens with null, undefined, empty, zero, negative, maximum, or concurrent inputs? For collections: empty arrays, single-element arrays, very large arrays. For strings: empty, whitespace-only, unicode, very long. For async: concurrent calls, cancellation, timeout.
+
+### Step 6: Assess blast radius
+What other code depends on these changes? Could downstream consumers break? Are there callers that rely on previous behavior? Check for changes to public APIs, shared types, exported functions, event contracts, or database schemas.
+
+### Step 7: Produce findings
+Only now — based on the analysis from steps 1 through 6 — produce your findings. Every finding must be grounded in a specific execution path, invariant violation, or edge case identified above. Do not report an issue unless you can trace it back to one of the earlier steps.
+
+Use a direct, thorough tone. Err on the side of reporting issues when you have traced a plausible failure path, but do not fabricate issues without evidence from your analysis. Prioritize correctness, then security, then robustness.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,7 +11,7 @@ export type {
 
 import type { Finding, Observation, FocusArea, ReviewOutput } from "./agent/schema.js";
 
-export type ReviewStyle = "strict" | "balanced" | "lenient" | "roast";
+export type ReviewStyle = "strict" | "balanced" | "lenient" | "roast" | "thorough";
 
 export type TriageClassification = "skip" | "skim" | "deep-review";
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,6 +1,7 @@
 export type {
   Severity,
   FocusArea,
+  ReviewStyle,
   Recommendation,
   TicketComplianceStatus,
   Finding,
@@ -13,6 +14,7 @@ import type {
   Finding,
   Observation,
   FocusArea,
+  ReviewStyle,
   Recommendation,
   Severity,
   ReviewOutput,
@@ -33,8 +35,6 @@ export interface ConsensusMetadata {
   recommendationElevated: boolean;
   passRecommendations: Recommendation[];
 }
-
-export type ReviewStyle = "strict" | "balanced" | "lenient" | "roast" | "thorough";
 
 export type TriageClassification = "skip" | "skim" | "deep-review";
 

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -3,7 +3,7 @@ const API_BASE: string = (import.meta.env.VITE_API_BASE as string | undefined) ?
 export interface RepoConfig {
   owner: string;
   repo: string;
-  style: "strict" | "balanced" | "lenient" | "roast";
+  style: "strict" | "balanced" | "lenient" | "roast" | "thorough";
   focusAreas: string[];
   ignorePatterns: string[];
 }

--- a/packages/dashboard/src/pages/RepoConfig.tsx
+++ b/packages/dashboard/src/pages/RepoConfig.tsx
@@ -20,6 +20,11 @@ const STYLES: { value: RepoConfig["style"]; label: string; description: string }
     description: "Only surface critical bugs and security issues",
   },
   { value: "roast", label: "Roast", description: "Brutally honest with dark humour" },
+  {
+    value: "thorough",
+    label: "Thorough",
+    description: "Structured reasoning with deep execution path analysis",
+  },
 ];
 
 const FOCUS_AREAS: { value: string; label: string; subtitle: string }[] = [

--- a/packages/dashboard/src/pages/Repos.tsx
+++ b/packages/dashboard/src/pages/Repos.tsx
@@ -8,6 +8,7 @@ const styleBadgeColor: Record<RepoConfig["style"], string> = {
   balanced: "bg-blue-900 text-blue-300",
   lenient: "bg-green-900 text-green-300",
   roast: "bg-orange-900 text-orange-300",
+  thorough: "bg-purple-900 text-purple-300",
 };
 
 function AddRepoForm({ onClose }: { onClose: () => void }) {

--- a/packages/github/src/__tests__/server.test.ts
+++ b/packages/github/src/__tests__/server.test.ts
@@ -263,6 +263,28 @@ describe("server", () => {
       expect((created.focusAreas as string[]).length).toBe(6);
       expect(created.ignorePatterns).toEqual([]);
     });
+
+    it("rejects invalid review style with 400", async () => {
+      const putRes = await app.request("/api/config/repos/org/repo", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ style: "yolo" }),
+      });
+      expect(putRes.status).toBe(400);
+      const body = (await putRes.json()) as Record<string, unknown>;
+      expect(body.error).toContain("invalid review style");
+    });
+
+    it("accepts the thorough review style", async () => {
+      const putRes = await app.request("/api/config/repos/org/repo", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ style: "thorough" }),
+      });
+      expect(putRes.status).toBe(200);
+      const created = (await putRes.json()) as Record<string, unknown>;
+      expect(created.style).toBe("thorough");
+    });
   });
 
   describe("settings", () => {

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -4,8 +4,8 @@ import { serve } from "@hono/node-server";
 import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile, stat } from "node:fs/promises";
-import type { FocusArea, ReviewStyle } from "@rusty-bot/core";
-import { logger } from "@rusty-bot/core";
+import type { FocusArea } from "@rusty-bot/core";
+import { ReviewStyleSchema, logger } from "@rusty-bot/core";
 import { validateWebhookSignature, parseWebhookEvent } from "./webhook.js";
 import { createAppOctokit } from "./auth.js";
 import { orchestrateReview } from "./orchestrator.js";
@@ -117,15 +117,20 @@ app.get("/api/config/repos/:owner/:repo", async (c) => {
 app.put("/api/config/repos/:owner/:repo", async (c) => {
   const { owner, repo } = c.req.param();
   const body: {
-    style?: ReviewStyle;
+    style?: string;
     focusAreas?: FocusArea[];
     ignorePatterns?: string[];
   } = await c.req.json();
 
+  const parsedStyle = ReviewStyleSchema.safeParse(body.style);
+  if (body.style !== undefined && !parsedStyle.success) {
+    return c.json({ error: `invalid review style: ${body.style}` }, 400);
+  }
+
   const config: RepoConfig = {
     owner,
     repo,
-    style: body.style ?? "balanced",
+    style: parsedStyle.success ? parsedStyle.data : "balanced",
     focusAreas: body.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
     ignorePatterns: body.ignorePatterns ?? [],
   };


### PR DESCRIPTION
## Summary
- Adds a new `thorough` review style that enforces a 7-step structured reasoning chain before producing findings: summarize intent → identify components → trace execution paths → check invariants → evaluate edge cases → assess blast radius → produce findings
- Wired up across the full stack: core types, prompt template, Azure DevOps CLI validation, dashboard UI (purple badge, style selector), and README docs
- Added tests verifying prompt content, reasoning step ordering, and distinct-styles check updated from 4→5

Closes #7

## Test plan
- [x] All 388 tests pass (18 test files)
- [x] Lint clean
- [x] Build succeeds across all 4 packages
- [ ] Manual: select "Thorough" in dashboard, verify review output includes structured reasoning steps
- [ ] Manual: set `RUSTY_REVIEW_STYLE=thorough` in Azure DevOps pipeline, verify accepted