### PR TITLE
Fix consensus clustering dilution and judge recommendation override

### DIFF
--- a/packages/core/src/__tests__/cluster.test.ts
+++ b/packages/core/src/__tests__/cluster.test.ts
@@ -239,6 +239,21 @@ describe("clusterFindings", () => {
     result.forEach((c) => expect(c.voteCount).toBe(2));
   });
 
+  it("does not dilute similarity when multiple variants join a cluster", () => {
+    const f1 = makeFinding({
+      message: "potential null pointer dereference in the request handler",
+    });
+    const f2 = makeFinding({
+      message: "possible null pointer dereference in request handler function",
+    });
+    const f3 = makeFinding({
+      message: "null pointer dereference risk in the request handler",
+    });
+    const result = clusterFindings([[f1], [f2], [f3]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].voteCount).toBe(3);
+  });
+
   it("handles findings at line proximity boundary (exactly ±5)", () => {
     const f1 = makeFinding({ line: 10 });
     const f2 = makeFinding({ line: 15 });

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -341,6 +341,57 @@ describe("judgeReviewResult", () => {
     expect(result.filteredCount).toBe(1);
   });
 
+  it("preserves elevated recommendation from consensus when no findings exist", async () => {
+    const review: ReviewResult = {
+      ...makeReviewResult([]),
+      recommendation: "address_before_merge",
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 1,
+        recommendationElevated: true,
+        passRecommendations: [
+          "address_before_merge",
+          "address_before_merge",
+          "address_before_merge",
+        ],
+      },
+    };
+
+    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    expect(result.findings).toHaveLength(0);
+    expect(result.recommendation).toBe("address_before_merge");
+  });
+
+  it("does not preserve recommendation when not elevated by consensus", async () => {
+    const review: ReviewResult = {
+      ...makeReviewResult([makeFinding({ severity: "warning" })]),
+      recommendation: "address_before_merge",
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: [
+          "address_before_merge",
+          "address_before_merge",
+          "address_before_merge",
+        ],
+      },
+    };
+
+    generateMock.mockResolvedValueOnce({
+      object: {
+        evaluations: [{ index: 0, confidence: 2, reasoning: "false positive" }],
+      },
+      usage: { totalTokens: 200 },
+    });
+
+    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    expect(result.findings).toHaveLength(0);
+    expect(result.recommendation).toBe("looks_good");
+  });
+
   it("preserves observations, filesReviewed, and other metadata", async () => {
     const review: ReviewResult = {
       ...makeReviewResult([makeFinding()]),

--- a/packages/core/src/agent/cluster.ts
+++ b/packages/core/src/agent/cluster.ts
@@ -82,7 +82,6 @@ function clusterItems<T extends Clusterable>(
 
         if (similarity >= threshold) {
           cluster.items.push({ item, passIndex });
-          for (const t of tokens) cluster.messageTokens.add(t);
           matched = true;
           break;
         }

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -205,10 +205,15 @@ export async function judgeReviewResult(
 
   const { accepted, rejected, tokenCount } = await judgeFindings(result.findings, diff, config);
 
-  // recalculate recommendation based on surviving findings
+  // when consensus elevated the recommendation based on pass votes (not findings),
+  // and there are no findings for the judge to evaluate, preserve it
+  const shouldPreserveElevated =
+    accepted.length === 0 && result.consensusMetadata?.recommendationElevated === true;
+
   const criticalCount = accepted.filter((f) => f.severity === "critical").length;
-  const recommendation =
-    criticalCount > 0
+  const recommendation = shouldPreserveElevated
+    ? result.recommendation
+    : criticalCount > 0
       ? ("critical_issues" as const)
       : accepted.length > 0
         ? ("address_before_merge" as const)


### PR DESCRIPTION
## Summary
- **Clustering fix**: removed token accumulation in `clusterItems()` that inflated the Jaccard denominator, causing similar findings across consensus passes to fragment into separate clusters (each with `voteCount=1`) and get dropped by the vote threshold. Similarity is now always measured against the representative's tokens.
- **Judge fix**: `judgeReviewResult()` unconditionally reset the recommendation to `looks_good` when no structured findings survived, discarding the elevated recommendation that consensus derived from pass-level votes. Now preserves it when `recommendationElevated` is set.

## Test plan
- [x] Added regression test: 3 slightly different phrasings across 3 passes cluster into 1 finding with `voteCount=3`
- [x] Added test: judge preserves elevated recommendation from consensus when no findings exist
- [x] Added test: judge still downgrades recommendation normally when not elevated
- [x] All 408 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)