### PR TITLE
add missing tests list to review output

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **6 focus areas** — Security, Performance, Bugs, Code Style, Test Coverage, Documentation
 - **Triage-driven cascading review** — cheap model classifies files as skip/skim/deep-review, each tier gets an appropriate level of scrutiny
 - **Tree-sitter context expansion** — hunks expand to enclosing function/class boundaries instead of fixed line counts (TS, JS, Python, Go, Java, Rust)
-- **Structured summary comments** — severity table, collapsible issue details, files reviewed
+- **Structured summary comments** — severity table, collapsible issue details, missing tests list, files reviewed
 - **Inline code comments** — findings posted directly on PR diff lines
 - **Ticket compliance** — discovers linked tickets from PR description, branch name, and platform APIs (GitHub linked issues, ADO work items), then checks if requirements are addressed
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
@@ -386,7 +386,7 @@ pnpm install
 # build all packages
 pnpm -r build
 
-# run tests (325 tests)
+# run tests (426 tests)
 pnpm test
 
 # start dev server

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -236,6 +236,7 @@ describe("ReviewOutputSchema", () => {
         },
       ],
       ticketCompliance: [],
+      missingTests: [],
       observations: [],
       filesReviewed: ["src/auth.ts"],
     };
@@ -266,6 +267,7 @@ describe("ReviewOutputSchema", () => {
           evidence: "Comparison now uses <=",
         },
       ],
+      missingTests: [],
       observations: [],
       filesReviewed: ["src/index.ts"],
     };
@@ -289,6 +291,7 @@ describe("ReviewOutputSchema", () => {
         },
       ],
       ticketCompliance: [],
+      missingTests: [],
       observations: [],
       filesReviewed: ["src/parser.ts"],
     };
@@ -362,6 +365,7 @@ describe("ReviewOutputSchema", () => {
       recommendation: "looks_good" as const,
       findings: [],
       ticketCompliance: [],
+      missingTests: [],
       observations: [],
       filesReviewed: ["src/index.ts"],
     };

--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -21,6 +21,7 @@ function makeResult(overrides: Partial<ReviewResult> = {}): ReviewResult {
     findings: [],
     observations: [],
     ticketCompliance: [],
+    missingTests: [],
     filesReviewed: ["src/index.ts"],
     modelUsed: "test-model",
     tokenCount: 100,

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -10,6 +10,7 @@ function makeReview(overrides: Partial<ReviewResult> = {}): ReviewResult {
     findings: [],
     observations: [],
     ticketCompliance: [],
+    missingTests: [],
     filesReviewed: [],
     modelUsed: "gpt-4o",
     tokenCount: 12345,
@@ -381,6 +382,90 @@ describe("formatInlineComment", () => {
   });
 });
 
+describe("formatSummaryComment with missing tests", () => {
+  it("renders a collapsible missing tests section", () => {
+    const review = makeReview({
+      missingTests: [
+        {
+          file: "src/auth.ts",
+          description: "edge case: empty credentials object should throw ValidationError",
+        },
+        {
+          file: "src/db.ts",
+          description: "error path: connection timeout should propagate a typed error",
+        },
+        {
+          file: "src/auth.ts",
+          description: "boundary: maxRetries=0 should skip retry logic entirely",
+        },
+      ],
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("Missing Tests (3 suggested test cases)");
+    expect(result).toContain("| File | Suggested Test Case |");
+    expect(result).toContain(
+      "| `src/auth.ts` | edge case: empty credentials object should throw ValidationError |",
+    );
+    expect(result).toContain(
+      "| `src/db.ts` | error path: connection timeout should propagate a typed error |",
+    );
+    expect(result).toContain(
+      "| `src/auth.ts` | boundary: maxRetries=0 should skip retry logic entirely |",
+    );
+  });
+
+  it("omits missing tests section when array is empty", () => {
+    const review = makeReview({ missingTests: [] });
+    const result = formatSummaryComment(review);
+    expect(result).not.toContain("Missing Tests");
+  });
+
+  it("sanitizes pipe characters in test descriptions", () => {
+    const review = makeReview({
+      missingTests: [
+        {
+          file: "src/parser.ts",
+          description: "union type A | B should be handled without narrowing error",
+        },
+      ],
+    });
+
+    const result = formatSummaryComment(review);
+    expect(result).toContain("union type A \\| B should be handled without narrowing error");
+  });
+
+  it("renders missing tests section after ticket compliance and before files reviewed", () => {
+    const review = makeReview({
+      ticketCompliance: [
+        {
+          ticketId: "FEAT-1",
+          requirement: "Add login",
+          status: "addressed",
+          evidence: "login.ts implemented",
+        },
+      ],
+      missingTests: [
+        {
+          file: "src/login.ts",
+          description: "error path: invalid password returns 401",
+        },
+      ],
+      filesReviewed: ["src/login.ts"],
+    });
+
+    const result = formatSummaryComment(review);
+
+    const complianceIdx = result.indexOf("Ticket Compliance");
+    const missingTestsIdx = result.indexOf("Missing Tests");
+    const filesIdx = result.indexOf("Files Reviewed");
+
+    expect(complianceIdx).toBeLessThan(missingTestsIdx);
+    expect(missingTestsIdx).toBeLessThan(filesIdx);
+  });
+});
+
 describe("formatSummaryComment with dropped findings", () => {
   it("renders a collapsible dropped findings section", () => {
     const review = makeReview({
@@ -518,6 +603,7 @@ describe("formatSummaryComment with triage stats", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["src/index.ts"],
       modelUsed: "claude-sonnet-4",
       tokenCount: 5000,
@@ -549,6 +635,7 @@ describe("formatSummaryComment with triage stats", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: [],
       modelUsed: "gpt-4o",
       tokenCount: 1000,
@@ -565,6 +652,7 @@ describe("formatSummaryComment with triage stats", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: [],
       modelUsed: "test",
       tokenCount: 100,

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -39,6 +39,7 @@ function makeReviewResult(findings: Finding[]): ReviewResult {
     findings,
     observations: [],
     ticketCompliance: [],
+    missingTests: [],
     filesReviewed: ["src/app.ts"],
     modelUsed: "test-model",
     tokenCount: 100,

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -19,6 +19,7 @@ function makeMockReview(diff: string): ReviewResult {
     ],
     observations: [],
     ticketCompliance: [],
+    missingTests: [],
     filesReviewed: ["a.ts"],
     modelUsed: "test-model",
     tokenCount: countTokens(diff),
@@ -260,6 +261,61 @@ describe("runMultiCallReview", () => {
     ]);
   });
 
+  it("merges and deduplicates missing tests across chunks", async () => {
+    runReviewMock
+      .mockResolvedValueOnce({
+        ...makeMockReview("chunk-1"),
+        missingTests: [
+          { file: "src/auth.ts", description: "edge case: empty token string" },
+          { file: "src/db.ts", description: "error path: connection refused" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        ...makeMockReview("chunk-2"),
+        missingTests: [
+          { file: "src/auth.ts", description: "edge case: empty token string" },
+          { file: "src/auth.ts", description: "boundary: token with 0 expiry" },
+        ],
+      });
+
+    const patches = [makePatch("big1.ts", 1000), makePatch("big2.ts", 1000)];
+    const result = await runMultiCallReview(patches, config, prMetadata, undefined, {
+      maxTokens: 3000,
+    });
+
+    expect(result.missingTests).toHaveLength(3);
+    expect(result.missingTests).toEqual([
+      { file: "src/auth.ts", description: "edge case: empty token string" },
+      { file: "src/db.ts", description: "error path: connection refused" },
+      { file: "src/auth.ts", description: "boundary: token with 0 expiry" },
+    ]);
+  });
+
+  it("deduplicates missing tests case-insensitively", async () => {
+    runReviewMock
+      .mockResolvedValueOnce({
+        ...makeMockReview("chunk-1"),
+        missingTests: [{ file: "src/Auth.ts", description: "Edge case: empty token" }],
+      })
+      .mockResolvedValueOnce({
+        ...makeMockReview("chunk-2"),
+        missingTests: [{ file: "src/auth.ts", description: "edge case: empty token" }],
+      });
+
+    const patches = [makePatch("big1.ts", 1000), makePatch("big2.ts", 1000)];
+    const result = await runMultiCallReview(patches, config, prMetadata, undefined, {
+      maxTokens: 3000,
+    });
+
+    expect(result.missingTests).toHaveLength(1);
+  });
+
+  it("returns empty missing tests when no chunks produce them", async () => {
+    const patches = [makePatch("small.ts", 10)];
+    const result = await runMultiCallReview(patches, config, prMetadata);
+    expect(result.missingTests).toEqual([]);
+  });
+
   it("handles empty patches", async () => {
     runReviewMock.mockResolvedValueOnce({
       summary: "Nothing to review",
@@ -267,6 +323,7 @@ describe("runMultiCallReview", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: [],
       modelUsed: "test",
       tokenCount: 0,
@@ -429,6 +486,7 @@ describe("mergeResults", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["a.ts"],
       modelUsed: "test-model",
       tokenCount: 100,
@@ -440,6 +498,7 @@ describe("mergeResults", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["b.ts"],
       modelUsed: "test-model",
       tokenCount: 500,
@@ -468,6 +527,7 @@ describe("mergeResults", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["a.ts"],
       modelUsed: "test-model",
       tokenCount: 100,
@@ -479,6 +539,7 @@ describe("mergeResults", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["b.ts"],
       modelUsed: "test-model",
       tokenCount: 100,

--- a/packages/core/src/__tests__/types.test.ts
+++ b/packages/core/src/__tests__/types.test.ts
@@ -32,6 +32,7 @@ describe("types", () => {
       findings: [],
       observations: [],
       ticketCompliance: [],
+      missingTests: [],
       filesReviewed: ["src/index.ts"],
       modelUsed: "anthropic/claude-sonnet-4-20250514",
       tokenCount: 1500,

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -147,6 +147,7 @@ export async function runConsensusReview(
     findings: survivingFindings,
     observations: survivingObservations,
     ticketCompliance: results[0]?.ticketCompliance ?? [],
+    missingTests: results.flatMap((r) => r.missingTests),
     filesReviewed: [...allFiles],
     modelUsed: results[0]?.modelUsed ?? "unknown",
     tokenCount: totalTokens,

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -13,6 +13,7 @@ import { compressDiff } from "../diff/compress.js";
 import { shufflePatches } from "../diff/shuffle.js";
 import { clusterFindings, clusterObservations } from "./cluster.js";
 import { runReview, type RunReviewOptions } from "./review.js";
+import { mergeMissingTests } from "./multi-call.js";
 import { logger } from "../logger.js";
 
 const DEFAULT_CONSENSUS_PASSES = 3;
@@ -147,7 +148,7 @@ export async function runConsensusReview(
     findings: survivingFindings,
     observations: survivingObservations,
     ticketCompliance: results[0]?.ticketCompliance ?? [],
-    missingTests: results.flatMap((r) => r.missingTests),
+    missingTests: mergeMissingTests(results),
     filesReviewed: [...allFiles],
     modelUsed: results[0]?.modelUsed ?? "unknown",
     tokenCount: totalTokens,

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -7,6 +7,7 @@ export {
   SkimFindingSchema,
   ObservationSchema,
   TicketComplianceSchema,
+  MissingTestSchema,
   ReviewOutputSchema,
   SkimReviewOutputSchema,
 } from "./schema.js";

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -18,6 +18,7 @@ export {
   runMultiCallReview,
   runCascadeReview,
   mergeResults,
+  mergeMissingTests,
   filterObservationsForPrFiles,
 } from "./multi-call.js";
 export type { MultiCallReviewOptions } from "./multi-call.js";

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -202,7 +202,7 @@ function mergeTicketCompliance(results: ReviewResult[]): TicketComplianceItem[] 
   }));
 }
 
-function mergeMissingTests(results: ReviewResult[]): MissingTestItem[] {
+export function mergeMissingTests(results: ReviewResult[]): MissingTestItem[] {
   const seen = new Set<string>();
   const merged: MissingTestItem[] = [];
 

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -9,6 +9,7 @@ import type {
   Observation,
   TicketComplianceItem,
   TicketComplianceStatus,
+  MissingTestItem,
 } from "../types.js";
 import { runReview, type RunReviewOptions, type ReviewTier } from "./review.js";
 import { runConsensusReview } from "./consensus.js";
@@ -140,6 +141,7 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
     findings: dedupedFindings,
     observations: allObservations,
     ticketCompliance: mergeTicketCompliance(results),
+    missingTests: mergeMissingTests(results),
     filesReviewed: [...allFiles],
     modelUsed,
     tokenCount: totalTokens,
@@ -198,6 +200,22 @@ function mergeTicketCompliance(results: ReviewResult[]): TicketComplianceItem[] 
     ...item,
     evidence: evidenceParts.length > 0 ? evidenceParts.join(" | ") : null,
   }));
+}
+
+function mergeMissingTests(results: ReviewResult[]): MissingTestItem[] {
+  const seen = new Set<string>();
+  const merged: MissingTestItem[] = [];
+
+  for (const result of results) {
+    for (const item of result.missingTests) {
+      const key = `${item.file.toLowerCase()}:${item.description.toLowerCase().trim()}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      merged.push(item);
+    }
+  }
+
+  return merged;
 }
 
 async function runTieredReview(
@@ -428,6 +446,7 @@ export async function runCascadeReview(
         findings: [],
         observations: [],
         ticketCompliance: [],
+        missingTests: [],
         filesReviewed: [],
         modelUsed: "unknown",
         tokenCount: 0,

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -82,6 +82,10 @@ export async function runReview(
       "ticketCompliance" in parsed
         ? ((parsed as Record<string, unknown>).ticketCompliance as ReviewResult["ticketCompliance"])
         : [],
+    missingTests:
+      "missingTests" in parsed
+        ? ((parsed as Record<string, unknown>).missingTests as ReviewResult["missingTests"])
+        : [],
     filesReviewed: parsed.filesReviewed,
     modelUsed: modelName,
     tokenCount: response.usage.totalTokens ?? 0,

--- a/packages/core/src/agent/schema.ts
+++ b/packages/core/src/agent/schema.ts
@@ -104,6 +104,17 @@ export const TicketComplianceSchema = z.object({
 
 export type TicketComplianceItem = z.infer<typeof TicketComplianceSchema>;
 
+export const MissingTestSchema = z.object({
+  file: z.string().describe("source file that lacks test coverage"),
+  description: z
+    .string()
+    .describe(
+      "concrete test case or scenario that should be added, e.g. 'edge case: empty input array' or 'error path: API returns 500'",
+    ),
+});
+
+export type MissingTestItem = z.infer<typeof MissingTestSchema>;
+
 export const ReviewOutputSchema = z.object({
   summary: z.string().describe("concise summary of the PR and overall assessment"),
   recommendation: RecommendationSchema.describe("merge recommendation based on findings"),
@@ -117,6 +128,11 @@ export const ReviewOutputSchema = z.object({
     .array(TicketComplianceSchema)
     .describe(
       "requirement-by-requirement compliance checklist for linked tickets; empty when no linked tickets are available",
+    ),
+  missingTests: z
+    .array(MissingTestSchema)
+    .describe(
+      "concrete test cases that should be added for the changed code; each entry describes a specific scenario, not a vague 'add tests' suggestion. Empty when test coverage appears adequate.",
     ),
   filesReviewed: z.array(z.string()).describe("list of file paths that were reviewed"),
 });

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -219,6 +219,22 @@ export function formatSummaryComment(
     lines.push("");
   }
 
+  if (review.missingTests.length > 0) {
+    lines.push("<details>");
+    lines.push(
+      `<summary>Missing Tests (${review.missingTests.length} suggested test cases)</summary>`,
+    );
+    lines.push("");
+    lines.push("| File | Suggested Test Case |");
+    lines.push("|------|---------------------|");
+    for (const item of review.missingTests) {
+      lines.push(`| \`${item.file}\` | ${sanitizeTableCell(item.description)} |`);
+    }
+    lines.push("");
+    lines.push("</details>");
+    lines.push("");
+  }
+
   const fileIssueCounts = new Map<string, number>();
   for (const file of review.filesReviewed) {
     fileIssueCounts.set(file, 0);

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -15,6 +15,7 @@ Your review must include:
 - Specific findings tied to exact file paths and line numbers in the diff
 - Observations about issues in referenced but unchanged code (these cannot receive inline comments)
 - When linked tickets are provided, a ticketCompliance checklist that evaluates each requirement with one of: "addressed", "partially_addressed", "not_addressed", or "unclear"
+- A missingTests list identifying concrete test cases that should exist for the changed code. Each entry should describe a specific, actionable scenario (e.g. "edge case: empty input array causes crash", "error path: database connection timeout is unhandled") rather than vague suggestions like "add more tests". Only include entries when test gaps are actually present — leave the array empty when coverage appears adequate.
 
 For each finding, provide:
 - The exact file path and line number (and `endLine` when the fix spans multiple lines)

--- a/packages/core/src/prompts/focus/tests.txt
+++ b/packages/core/src/prompts/focus/tests.txt
@@ -6,3 +6,12 @@ Pay special attention to TEST COVERAGE:
 - Test quality (are tests actually asserting meaningful behavior, or just that code runs?)
 - Missing integration tests for code that interacts with external systems
 - Flaky test patterns (time-dependent, order-dependent, network-dependent)
+
+For each test gap you identify, add an entry to the `missingTests` array with:
+- `file`: the source file that needs test coverage (not the test file)
+- `description`: a concrete, specific test scenario — name the exact edge case, boundary condition, error path, or integration scenario. Examples:
+  - "edge case: calling processItems with an empty array should return empty result without throwing"
+  - "error path: network timeout in fetchUser should propagate a typed error, not hang"
+  - "boundary: maxRetries=0 should skip retry logic entirely"
+  - "integration: database rollback when insertOrder fails mid-transaction"
+Do NOT add vague entries like "add unit tests" or "improve test coverage".

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -7,6 +7,7 @@ export type {
   Finding,
   Observation,
   TicketComplianceItem,
+  MissingTestItem,
   ReviewOutput,
 } from "./agent/schema.js";
 


### PR DESCRIPTION
## Summary
- Adds a `missingTests` field to the review output schema that surfaces concrete test case suggestions (edge cases, error paths, boundary conditions) for changed code
- Integrates across the full pipeline: Zod schema, LLM prompts, agent, consensus pass, multi-call merge with deduplication, and summary comment formatter
- Enhances the `tests` focus area prompt with detailed guidance on producing specific, actionable test scenarios rather than vague "add tests" suggestions

## Test plan
- [ ] Verify `ReviewOutputSchema` strict mode compatibility (OpenAI structured output)
- [ ] Verify summary comment renders `Missing Tests` collapsible section with correct table
- [ ] Verify section is omitted when `missingTests` is empty
- [ ] Verify pipe characters in descriptions are sanitized
- [ ] Verify multi-call merge deduplicates by file+description (case-insensitive)
- [ ] Verify section ordering: after Ticket Compliance, before Files Reviewed
- [ ] Run against a real PR with tests focus area enabled and verify LLM populates the field