### PR TITLE
fix cascade ticket compliance for skim-tier files

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -199,6 +199,11 @@ describe("buildUserMessage", () => {
     expect(msg).toContain("Do NOT report observations");
   });
 
+  it("instructs the LLM to consider other PR files for ticket compliance", () => {
+    const msg = buildUserMessage("diff", prMetadata, undefined, undefined, ["tests/test_auth.py"]);
+    expect(msg).toContain("ticket compliance");
+  });
+
   it("omits other PR files section when not provided", () => {
     const msg = buildUserMessage("diff", prMetadata);
     expect(msg).not.toContain("Other Files Changed");

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -29,7 +29,7 @@ vi.mock("../agent/review.js", () => ({
   runReview: vi.fn(async (_config, diff, _prMeta, _tickets, _opts) => makeMockReview(diff)),
 }));
 
-const { runMultiCallReview, filterObservationsForPrFiles, mergeResults } =
+const { runMultiCallReview, runCascadeReview, filterObservationsForPrFiles, mergeResults } =
   await import("../agent/multi-call.js");
 const { runReview } = await import("../agent/review.js");
 const runReviewMock = vi.mocked(runReview);
@@ -486,5 +486,38 @@ describe("mergeResults", () => {
 
     const merged = mergeResults([result1, result2], "test-model");
     expect(merged.recommendation).toBe("looks_good");
+  });
+});
+
+describe("runCascadeReview", () => {
+  beforeEach(() => {
+    runReviewMock.mockReset();
+    runReviewMock.mockImplementation(async (_config, diff) => makeMockReview(diff));
+  });
+
+  it("passes skim file paths as otherPrFiles to the deep-review tier", async () => {
+    const skimPatches = [makePatch("tests/test_auth.py", 20)];
+    const deepPatches = [makePatch("src/auth.ts", 20)];
+
+    await runCascadeReview(skimPatches, deepPatches, config, prMetadata, undefined);
+
+    // find the deep-review call (tier !== "skim")
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+    expect(deepCalls.length).toBeGreaterThanOrEqual(1);
+
+    const deepOpts = deepCalls[0][4];
+    expect(deepOpts?.otherPrFiles).toContain("tests/test_auth.py");
+  });
+
+  it("does not inject skim paths when there are no skim files", async () => {
+    const deepPatches = [makePatch("src/auth.ts", 20)];
+
+    await runCascadeReview([], deepPatches, config, prMetadata, undefined);
+
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+    expect(deepCalls.length).toBeGreaterThanOrEqual(1);
+
+    const deepOpts = deepCalls[0][4];
+    expect(deepOpts?.otherPrFiles).toBeUndefined();
   });
 });

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -410,12 +410,24 @@ export async function runCascadeReview(
     );
     allResults.push(...skimResults);
 
+    // pass skim file paths to the deep tier so the LLM knows they exist
+    // (particularly important for ticket compliance — e.g. test files triaged
+    // as skim should still count as evidence when evaluating "add tests" requirements)
+    const skimFilePaths = skimPatches.map((p) => p.path);
+    const deepOptionsWithSkimContext: RunReviewOptions =
+      skimFilePaths.length > 0
+        ? {
+            ...resolvedOptions,
+            otherPrFiles: [...(resolvedOptions.otherPrFiles ?? []), ...skimFilePaths],
+          }
+        : resolvedOptions;
+
     const deepResults = await runTieredReview(
       deepPatches,
       config,
       prMetadata,
       deepTickets,
-      resolvedOptions,
+      deepOptionsWithSkimContext,
       maxTokens,
       "deep-review",
     );

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -87,7 +87,9 @@ export function buildUserMessage(
     parts.push(
       "The following files are also being modified in this PR but are not included in this review chunk. " +
         'Do NOT report observations about these files as issues in "unchanged code" — they are actively changed in this PR ' +
-        "and will be reviewed in a separate chunk. If searchCode returns results in these files, " +
+        "and will be reviewed in a separate chunk. However, DO consider their presence when evaluating ticket compliance — " +
+        "for example, if a ticket requires tests and test files appear in this list, that requirement is likely addressed " +
+        "even though the test diffs are not shown here. If searchCode returns results in these files, " +
         "note that the search results may be stale (pre-merge content).\n",
     );
     parts.push(otherPrFiles.map((f) => `- \`${f}\``).join("\n"));


### PR DESCRIPTION
## Summary
- When triage classifies files as skim (e.g. test files), the deep-review tier had zero visibility into them — the skim files weren't listed in `otherPrFiles` and the deep tier couldn't see their diffs
- This caused ticket compliance to report "unclear" for requirements like "add tests" even when test files were present in the PR, because the LLM honestly couldn't verify their existence
- Now skim file paths are passed to the deep tier via `otherPrFiles`, and the prompt explicitly instructs the LLM to consider those files when evaluating ticket compliance

## Test plan
- [ ] Verify deep-review calls receive skim file paths in `otherPrFiles`
- [ ] Verify no skim paths injected when there are no skim files
- [ ] Verify prompt mentions "ticket compliance" in the other-files section
- [ ] Test against a real PR with triage enabled where test files get skim-classified and a linked ticket mentions tests