### PR TITLE
add opt-in PR description generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **Inline code comments** — findings posted directly on PR diff lines
 - **Ticket compliance** — discovers linked tickets from PR description, branch name, and platform APIs (GitHub linked issues, ADO work items), then checks if requirements are addressed
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
+- **PR description generation** — optionally generate a structured PR description from the diff when the description is empty or a placeholder (off by default)
 - **GitHub + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps
 - **Web dashboard** — configure repos, review styles, focus areas, and view history
 
@@ -154,6 +155,7 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_JUDGE_MODEL` | model for the judge (can be cheaper than reviewer) | same as `RUSTY_LLM_MODEL` |
 | `RUSTY_LLM_TRIAGE_MODEL` | LLM model for triage classification (enables cascading) | — |
 | `RUSTY_CASCADE_ENABLED` | explicitly enable/disable cascading (`true`/`false`) | auto (enabled when triage model is set) |
+| `RUSTY_GENERATE_DESCRIPTION` | generate PR description when empty/placeholder | `false` |
 
 ### LLM Provider Configuration
 
@@ -343,6 +345,28 @@ RUSTY_CASCADE_ENABLED=false  # force off even if triage model is set
 
 **Cost:** The triage call itself is cheap (truncated diffs, small output schema). The savings come from skipping context expansion and tool calls for skim-tier files. For a typical PR where ~40% of files are config/docs/tests, expect roughly 30–50% token reduction on the review calls.
 
+### PR Description Generation
+
+When a PR has an empty or placeholder description, Rusty Bot can generate a structured one from the diff before starting the review. This helps reviewers understand the PR at a glance and also gives the review agent better context (the generated description is visible to the reviewer in the same run).
+
+Off by default. Enable via:
+
+```bash
+RUSTY_GENERATE_DESCRIPTION=true
+```
+
+Or per-repo in the dashboard (PR Description checkbox).
+
+**How it works:**
+
+1. Before the review starts, the bot checks the current PR description
+2. If the description is empty, whitespace-only, a short placeholder (e.g. "TODO", "WIP"), or a previously bot-generated description, it proceeds
+3. A dedicated agent produces a structured description: summary, per-file change table, breaking changes, and migration notes (sections are omitted when not applicable)
+4. The description is updated on the PR via the platform API
+5. The review then runs with the generated description visible in the PR metadata
+
+**Safety:** The bot never overwrites a human-written description. The detection is conservative — any description with meaningful prose, issue references, or structured content is left untouched. Bot-generated descriptions (identified by an HTML marker) can be regenerated on subsequent runs.
+
 ### Tree-sitter Context Expansion
 
 By default, when the LLM reviews a diff hunk, the surrounding context is expanded to the enclosing function, method, or class boundary using [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST parsing. This means the model sees complete semantic units — full functions instead of fragments cut mid-logic — which improves review accuracy and eliminates wasted tokens on unrelated adjacent code.
@@ -386,7 +410,7 @@ pnpm install
 # build all packages
 pnpm -r build
 
-# run tests (325 tests)
+# run tests (375 tests)
 pnpm test
 
 # start dev server

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -109,7 +109,7 @@ async function main(): Promise<void> {
   if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
     try {
       if (shouldGenerateDescription(metadata.description)) {
-        const descResult = await generatePRDescription(reviewable, metadata);
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
         await provider.updatePRDescription(descResult.markdown);
         metadata.description = descResult.markdown;
         log.info(

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -18,6 +18,8 @@ import {
   isCascadeEnabled,
   runTriage,
   splitByClassification,
+  generatePRDescription,
+  shouldGenerateDescription,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -103,6 +105,22 @@ async function main(): Promise<void> {
     { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
     "files changed",
   );
+
+  if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
+    try {
+      if (shouldGenerateDescription(metadata.description)) {
+        const descResult = await generatePRDescription(reviewable, metadata);
+        await provider.updatePRDescription(descResult.markdown);
+        metadata.description = descResult.markdown;
+        log.info(
+          { model: descResult.modelUsed, tokens: descResult.tokenCount },
+          "generated PR description",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to generate PR description, continuing with review");
+    }
+  }
 
   const ticketRefs = extractTicketRefs(metadata.description, metadata.sourceBranch);
 

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -353,4 +353,11 @@ export class AzureDevOpsProvider implements GitProvider {
     );
     return data.value.map((item) => item.id);
   }
+
+  async updatePRDescription(description: string): Promise<void> {
+    await this.fetchApi(`${this.baseUrl}/pullRequests/${this.pullRequestId}?${API_VERSION}`, {
+      method: "PATCH",
+      body: JSON.stringify({ description }),
+    });
+  }
 }

--- a/packages/core/src/__tests__/description.test.ts
+++ b/packages/core/src/__tests__/description.test.ts
@@ -249,6 +249,61 @@ describe("formatDescription", () => {
     });
     expect(result).toContain("added A \\| B union type");
   });
+
+  it("appends original description in a collapsed section", () => {
+    const result = formatDescription(
+      {
+        summary: "New description.",
+        fileChanges: [],
+        breakingChanges: [],
+        migrationNotes: null,
+      },
+      "WIP - need to also handle the timeout case",
+    );
+    expect(result).toContain("<summary>Original description</summary>");
+    expect(result).toContain("WIP - need to also handle the timeout case");
+  });
+
+  it("strips bot marker from original description before appending", () => {
+    const botGenerated = "<!-- rusty-bot-description -->\n\n## Summary\nPrevious bot text.";
+    const result = formatDescription(
+      {
+        summary: "Updated.",
+        fileChanges: [],
+        breakingChanges: [],
+        migrationNotes: null,
+      },
+      botGenerated,
+    );
+    expect(result).toContain("Original description");
+    expect(result).toContain("Previous bot text.");
+    // the marker inside the accordion body should be stripped
+    const accordionContent = result.split("Original description")[1];
+    expect(accordionContent).not.toContain("<!-- rusty-bot-description -->");
+  });
+
+  it("omits original description section when original is empty", () => {
+    const result = formatDescription(
+      {
+        summary: "Fresh.",
+        fileChanges: [],
+        breakingChanges: [],
+        migrationNotes: null,
+      },
+      "",
+    );
+    expect(result).not.toContain("Original description");
+  });
+
+  it("omits original description section when original is undefined", () => {
+    const result = formatDescription({
+      summary: "Fresh.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).not.toContain("Original description");
+  });
 });
 
 describe("buildDescriptionUserMessage", () => {

--- a/packages/core/src/__tests__/description.test.ts
+++ b/packages/core/src/__tests__/description.test.ts
@@ -109,6 +109,14 @@ describe("shouldGenerateDescription", () => {
     expect(shouldGenerateDescription("no description")).toBe(true);
   });
 
+  it("returns true for 'update' standalone placeholder", () => {
+    expect(shouldGenerateDescription("update")).toBe(true);
+  });
+
+  it("returns false for 'update' as part of a longer description", () => {
+    expect(shouldGenerateDescription("update login flow to use OAuth2")).toBe(false);
+  });
+
   it("returns false for a meaningful multi-sentence description", () => {
     const description =
       "This PR adds JWT authentication to all API endpoints. " +
@@ -220,6 +228,16 @@ describe("formatDescription", () => {
       migrationNotes: null,
     });
     expect(result).not.toContain("## Migration Notes");
+  });
+
+  it("sanitizes pipe characters in file paths", () => {
+    const result = formatDescription({
+      summary: "Test.",
+      fileChanges: [{ path: "src/a|b.ts", description: "renamed" }],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).toContain("a\\|b.ts");
   });
 
   it("sanitizes pipe characters in file descriptions", () => {

--- a/packages/core/src/__tests__/description.test.ts
+++ b/packages/core/src/__tests__/description.test.ts
@@ -269,4 +269,22 @@ describe("buildDescriptionUserMessage", () => {
     const msg = buildDescriptionUserMessage("diff", prMetadata);
     expect(msg).toContain("dev123");
   });
+
+  it("includes existing description when provided", () => {
+    const existing = "<!-- rusty-bot-description -->\n\n## Summary\nPrevious bot-generated text.";
+    const msg = buildDescriptionUserMessage("diff", prMetadata, existing);
+    expect(msg).toContain("Existing Description");
+    expect(msg).toContain("Previous bot-generated text.");
+    expect(msg).toContain("Preserve any useful human-added context");
+  });
+
+  it("omits existing description section when empty", () => {
+    const msg = buildDescriptionUserMessage("diff", prMetadata, "");
+    expect(msg).not.toContain("Existing Description");
+  });
+
+  it("omits existing description section when undefined", () => {
+    const msg = buildDescriptionUserMessage("diff", prMetadata);
+    expect(msg).not.toContain("Existing Description");
+  });
 });

--- a/packages/core/src/__tests__/description.test.ts
+++ b/packages/core/src/__tests__/description.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { PRDescriptionOutputSchema } from "../description/schema.js";
+import { shouldGenerateDescription, formatDescription } from "../description/generate.js";
+import { buildDescriptionUserMessage } from "../description/prompt.js";
+import type { PRMetadata } from "../types.js";
+
+const prMetadata: PRMetadata = {
+  id: "42",
+  title: "Add user authentication",
+  description: "",
+  author: "dev123",
+  sourceBranch: "feature/auth",
+  targetBranch: "main",
+  url: "https://github.com/org/repo/pull/42",
+};
+
+describe("PRDescriptionOutputSchema", () => {
+  it("validates well-formed output", () => {
+    const valid = {
+      summary: "Adds JWT-based authentication to the API.",
+      fileChanges: [{ path: "src/auth.ts", description: "new auth middleware" }],
+      breakingChanges: [],
+      migrationNotes: null,
+    };
+    expect(PRDescriptionOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("validates output with breaking changes and migration notes", () => {
+    const valid = {
+      summary: "Replaces session-based auth with JWT tokens.",
+      fileChanges: [],
+      breakingChanges: ["POST /login response shape changed"],
+      migrationNotes: "Update client SDK to v2 for the new token format.",
+    };
+    expect(PRDescriptionOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(PRDescriptionOutputSchema.safeParse({ summary: "ok" }).success).toBe(false);
+  });
+
+  it("passes openai strict mode — all properties in required", () => {
+    interface JsonSchemaObject {
+      properties?: Record<string, JsonSchemaObject>;
+      required?: string[];
+      items?: JsonSchemaObject;
+      additionalProperties?: boolean;
+      anyOf?: JsonSchemaObject[];
+    }
+
+    function collectViolations(schema: JsonSchemaObject, path = ""): string[] {
+      const violations: string[] = [];
+      if (schema.properties) {
+        const propKeys = Object.keys(schema.properties);
+        const required = new Set(schema.required ?? []);
+        for (const key of propKeys) {
+          if (!required.has(key)) {
+            violations.push(`${path}.${key} missing from required`);
+          }
+        }
+        if (schema.additionalProperties !== false) {
+          violations.push(`${path} must set additionalProperties to false`);
+        }
+        for (const [key, value] of Object.entries(schema.properties)) {
+          violations.push(...collectViolations(value, `${path}.${key}`));
+        }
+      }
+      if (schema.items) violations.push(...collectViolations(schema.items, `${path}[]`));
+      for (const branch of schema.anyOf ?? []) {
+        violations.push(...collectViolations(branch, path));
+      }
+      return violations;
+    }
+
+    const jsonSchema = z.toJSONSchema(PRDescriptionOutputSchema) as JsonSchemaObject;
+    const violations = collectViolations(jsonSchema);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("shouldGenerateDescription", () => {
+  it("returns true for empty string", () => {
+    expect(shouldGenerateDescription("")).toBe(true);
+  });
+
+  it("returns true for whitespace-only", () => {
+    expect(shouldGenerateDescription("   \n\t  ")).toBe(true);
+  });
+
+  it("returns true for previously bot-generated description", () => {
+    const botGenerated = "<!-- rusty-bot-description -->\n\n## Summary\nSome generated text.";
+    expect(shouldGenerateDescription(botGenerated)).toBe(true);
+  });
+
+  it("returns true for 'TODO' placeholder", () => {
+    expect(shouldGenerateDescription("TODO")).toBe(true);
+  });
+
+  it("returns true for 'WIP' placeholder", () => {
+    expect(shouldGenerateDescription("WIP")).toBe(true);
+  });
+
+  it("returns true for 'fix' placeholder", () => {
+    expect(shouldGenerateDescription("fix")).toBe(true);
+  });
+
+  it("returns true for 'no description' placeholder", () => {
+    expect(shouldGenerateDescription("no description")).toBe(true);
+  });
+
+  it("returns false for a meaningful multi-sentence description", () => {
+    const description =
+      "This PR adds JWT authentication to all API endpoints. " +
+      "It includes middleware for token validation and a new login flow.";
+    expect(shouldGenerateDescription(description)).toBe(false);
+  });
+
+  it("returns false for description with issue references", () => {
+    expect(shouldGenerateDescription("Fixes #42 — add rate limiting to login endpoint")).toBe(
+      false,
+    );
+  });
+
+  it("returns false for description with markdown sections", () => {
+    const description = "## Changes\n\n- Added auth middleware\n- Updated config schema";
+    expect(shouldGenerateDescription(description)).toBe(false);
+  });
+
+  it("returns false for a short but meaningful description", () => {
+    expect(shouldGenerateDescription("refactor auth to use bcrypt")).toBe(false);
+  });
+});
+
+describe("formatDescription", () => {
+  it("includes the bot marker", () => {
+    const result = formatDescription({
+      summary: "Test summary.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).toContain("<!-- rusty-bot-description -->");
+  });
+
+  it("renders summary section", () => {
+    const result = formatDescription({
+      summary: "Adds JWT auth.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).toContain("## Summary");
+    expect(result).toContain("Adds JWT auth.");
+  });
+
+  it("renders file changes table", () => {
+    const result = formatDescription({
+      summary: "Changes.",
+      fileChanges: [
+        { path: "src/auth.ts", description: "new auth middleware" },
+        { path: "src/config.ts", description: "added auth config" },
+      ],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).toContain("## Changes");
+    expect(result).toContain("| `src/auth.ts` | new auth middleware |");
+    expect(result).toContain("| `src/config.ts` | added auth config |");
+  });
+
+  it("omits changes section when no file changes", () => {
+    const result = formatDescription({
+      summary: "Test.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).not.toContain("## Changes");
+  });
+
+  it("renders breaking changes section", () => {
+    const result = formatDescription({
+      summary: "API change.",
+      fileChanges: [],
+      breakingChanges: ["POST /login response changed", "removed /session endpoint"],
+      migrationNotes: null,
+    });
+    expect(result).toContain("## Breaking Changes");
+    expect(result).toContain("- POST /login response changed");
+    expect(result).toContain("- removed /session endpoint");
+  });
+
+  it("omits breaking changes section when empty", () => {
+    const result = formatDescription({
+      summary: "No breaking.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).not.toContain("## Breaking Changes");
+  });
+
+  it("renders migration notes section", () => {
+    const result = formatDescription({
+      summary: "Schema change.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: "Run `alembic upgrade head` after deploying.",
+    });
+    expect(result).toContain("## Migration Notes");
+    expect(result).toContain("Run `alembic upgrade head` after deploying.");
+  });
+
+  it("omits migration notes when null", () => {
+    const result = formatDescription({
+      summary: "No migration.",
+      fileChanges: [],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).not.toContain("## Migration Notes");
+  });
+
+  it("sanitizes pipe characters in file descriptions", () => {
+    const result = formatDescription({
+      summary: "Test.",
+      fileChanges: [{ path: "src/types.ts", description: "added A | B union type" }],
+      breakingChanges: [],
+      migrationNotes: null,
+    });
+    expect(result).toContain("added A \\| B union type");
+  });
+});
+
+describe("buildDescriptionUserMessage", () => {
+  it("includes PR title and branch names", () => {
+    const msg = buildDescriptionUserMessage("diff content", prMetadata);
+    expect(msg).toContain("Add user authentication");
+    expect(msg).toContain("feature/auth");
+    expect(msg).toContain("main");
+  });
+
+  it("includes the diff", () => {
+    const msg = buildDescriptionUserMessage("+ new line\n- old line", prMetadata);
+    expect(msg).toContain("+ new line");
+    expect(msg).toContain("- old line");
+  });
+
+  it("includes author", () => {
+    const msg = buildDescriptionUserMessage("diff", prMetadata);
+    expect(msg).toContain("dev123");
+  });
+});

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -1,0 +1,101 @@
+import { Agent } from "@mastra/core/agent";
+import { compressDiff } from "../diff/compress.js";
+import { resolveModelConfig, resolveModel, getModelDisplayName } from "../agent/model.js";
+import { PRDescriptionOutputSchema, type PRDescriptionOutput } from "./schema.js";
+import { buildDescriptionSystemPrompt, buildDescriptionUserMessage } from "./prompt.js";
+import type { FilePatch, PRMetadata } from "../types.js";
+
+const DESCRIPTION_MARKER = "<!-- rusty-bot-description -->";
+const MAX_DESCRIPTION_TOKENS = 30_000;
+
+export interface GenerateDescriptionResult {
+  markdown: string;
+  modelUsed: string;
+  tokenCount: number;
+}
+
+const PLACEHOLDER_PATTERNS = [
+  /^\s*$/,
+  /^(todo|wip|fixme|tbd|placeholder|fill\s*(this\s*)?in)\s*\.?$/i,
+  /^(no\s+description|update|fix|changes?)\s*\.?$/i,
+];
+
+export function shouldGenerateDescription(currentDescription: string): boolean {
+  const trimmed = currentDescription.trim();
+  if (trimmed.length === 0) return true;
+  if (trimmed.includes(DESCRIPTION_MARKER)) return true;
+  if (trimmed.length < 20 && PLACEHOLDER_PATTERNS.some((p) => p.test(trimmed))) return true;
+  return false;
+}
+
+export function formatDescription(output: PRDescriptionOutput): string {
+  const lines: string[] = [DESCRIPTION_MARKER, ""];
+
+  lines.push("## Summary");
+  lines.push("");
+  lines.push(output.summary);
+  lines.push("");
+
+  if (output.fileChanges.length > 0) {
+    lines.push("## Changes");
+    lines.push("");
+    lines.push("| File | Description |");
+    lines.push("|------|-------------|");
+    for (const change of output.fileChanges) {
+      const desc = change.description.replace(/\|/g, "\\|").replace(/\n+/g, " ");
+      lines.push(`| \`${change.path}\` | ${desc} |`);
+    }
+    lines.push("");
+  }
+
+  if (output.breakingChanges.length > 0) {
+    lines.push("## Breaking Changes");
+    lines.push("");
+    for (const change of output.breakingChanges) {
+      lines.push(`- ${change}`);
+    }
+    lines.push("");
+  }
+
+  if (output.migrationNotes) {
+    lines.push("## Migration Notes");
+    lines.push("");
+    lines.push(output.migrationNotes);
+    lines.push("");
+  }
+
+  return lines.join("\n");
+}
+
+export async function generatePRDescription(
+  patches: FilePatch[],
+  prMetadata: PRMetadata,
+): Promise<GenerateDescriptionResult> {
+  const { compressed } = compressDiff(patches, MAX_DESCRIPTION_TOKENS);
+
+  const modelConfig = resolveModelConfig();
+  const model = resolveModel(modelConfig);
+  const modelName = getModelDisplayName(modelConfig);
+
+  const agent = new Agent({
+    id: "description-agent",
+    name: "Rusty Bot Description Generator",
+    instructions: buildDescriptionSystemPrompt(),
+    model,
+  });
+
+  const userMessage = buildDescriptionUserMessage(compressed, prMetadata);
+
+  const response = await agent.generate(userMessage, {
+    structuredOutput: { schema: PRDescriptionOutputSchema },
+  });
+
+  const parsed = response.object;
+  const tokenCount = response.usage.totalTokens ?? 0;
+
+  return {
+    markdown: formatDescription(parsed),
+    modelUsed: modelName,
+    tokenCount,
+  };
+}

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -42,8 +42,9 @@ export function formatDescription(output: PRDescriptionOutput): string {
     lines.push("| File | Description |");
     lines.push("|------|-------------|");
     for (const change of output.fileChanges) {
+      const path = change.path.replace(/\|/g, "\\|");
       const desc = change.description.replace(/\|/g, "\\|").replace(/\n+/g, " ");
-      lines.push(`| \`${change.path}\` | ${desc} |`);
+      lines.push(`| \`${path}\` | ${desc} |`);
     }
     lines.push("");
   }

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -28,7 +28,14 @@ export function shouldGenerateDescription(currentDescription: string): boolean {
   return false;
 }
 
-export function formatDescription(output: PRDescriptionOutput): string {
+function stripBotMarker(description: string): string {
+  return description.replace(DESCRIPTION_MARKER, "").trim();
+}
+
+export function formatDescription(
+  output: PRDescriptionOutput,
+  originalDescription?: string,
+): string {
   const lines: string[] = [DESCRIPTION_MARKER, ""];
 
   lines.push("## Summary");
@@ -65,6 +72,17 @@ export function formatDescription(output: PRDescriptionOutput): string {
     lines.push("");
   }
 
+  const stripped = originalDescription ? stripBotMarker(originalDescription) : "";
+  if (stripped.length > 0) {
+    lines.push("<details>");
+    lines.push("<summary>Original description</summary>");
+    lines.push("");
+    lines.push(stripped);
+    lines.push("");
+    lines.push("</details>");
+    lines.push("");
+  }
+
   return lines.join("\n");
 }
 
@@ -96,7 +114,7 @@ export async function generatePRDescription(
   const tokenCount = response.usage.totalTokens ?? 0;
 
   return {
-    markdown: formatDescription(parsed),
+    markdown: formatDescription(parsed, existingDescription),
     modelUsed: modelName,
     tokenCount,
   };

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -71,6 +71,7 @@ export function formatDescription(output: PRDescriptionOutput): string {
 export async function generatePRDescription(
   patches: FilePatch[],
   prMetadata: PRMetadata,
+  existingDescription?: string,
 ): Promise<GenerateDescriptionResult> {
   const { compressed } = compressDiff(patches, MAX_DESCRIPTION_TOKENS);
 
@@ -85,7 +86,7 @@ export async function generatePRDescription(
     model,
   });
 
-  const userMessage = buildDescriptionUserMessage(compressed, prMetadata);
+  const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription);
 
   const response = await agent.generate(userMessage, {
     structuredOutput: { schema: PRDescriptionOutputSchema },

--- a/packages/core/src/description/index.ts
+++ b/packages/core/src/description/index.ts
@@ -1,0 +1,4 @@
+export { PRDescriptionOutputSchema } from "./schema.js";
+export type { PRDescriptionOutput } from "./schema.js";
+export { generatePRDescription, shouldGenerateDescription, formatDescription } from "./generate.js";
+export type { GenerateDescriptionResult } from "./generate.js";

--- a/packages/core/src/description/prompt.ts
+++ b/packages/core/src/description/prompt.ts
@@ -10,19 +10,33 @@ Rules:
 - Only list breaking changes when the diff clearly introduces API/contract/schema incompatibilities
 - Only include migration notes when there are schema migrations, API changes, config changes, or dependency changes that consumers need to act on
 - If the PR title or branch name hints at the purpose, use that context
-- Do not invent context that isn't evident from the diff`;
+- Do not invent context that isn't evident from the diff
+- When an existing description is provided, preserve any useful human-added context (rationale, rollout notes, linked issues) and incorporate it into the new description`;
 
 export function buildDescriptionSystemPrompt(): string {
   return SYSTEM_PROMPT;
 }
 
-export function buildDescriptionUserMessage(diff: string, prMetadata: PRMetadata): string {
+export function buildDescriptionUserMessage(
+  diff: string,
+  prMetadata: PRMetadata,
+  existingDescription?: string,
+): string {
   const parts: string[] = [];
 
   parts.push("## Pull Request");
   parts.push(`**Title:** ${prMetadata.title}`);
   parts.push(`**Author:** ${prMetadata.author}`);
   parts.push(`**Branch:** ${prMetadata.sourceBranch} → ${prMetadata.targetBranch}`);
+
+  if (existingDescription?.trim()) {
+    parts.push("\n## Existing Description");
+    parts.push(
+      "The PR currently has the following description. Preserve any useful human-added " +
+        "context (rationale, rollout notes, linked issues) when generating the new description.\n",
+    );
+    parts.push(existingDescription.trim());
+  }
 
   parts.push("\n## Diff\n");
   parts.push(diff);

--- a/packages/core/src/description/prompt.ts
+++ b/packages/core/src/description/prompt.ts
@@ -1,0 +1,31 @@
+import type { PRMetadata } from "../types.js";
+
+const SYSTEM_PROMPT = `You are a PR description writer. Your job is to produce a clear, structured description of a pull request based on the diff and PR metadata.
+
+Write from the perspective of someone explaining the PR to a reviewer. Be concise and factual — describe what changed and why, not whether the changes are good.
+
+Rules:
+- Focus on the intent and effect of the changes, not low-level line-by-line details
+- Group related file changes by logical concern when the same feature touches multiple files
+- Only list breaking changes when the diff clearly introduces API/contract/schema incompatibilities
+- Only include migration notes when there are schema migrations, API changes, config changes, or dependency changes that consumers need to act on
+- If the PR title or branch name hints at the purpose, use that context
+- Do not invent context that isn't evident from the diff`;
+
+export function buildDescriptionSystemPrompt(): string {
+  return SYSTEM_PROMPT;
+}
+
+export function buildDescriptionUserMessage(diff: string, prMetadata: PRMetadata): string {
+  const parts: string[] = [];
+
+  parts.push("## Pull Request");
+  parts.push(`**Title:** ${prMetadata.title}`);
+  parts.push(`**Author:** ${prMetadata.author}`);
+  parts.push(`**Branch:** ${prMetadata.sourceBranch} → ${prMetadata.targetBranch}`);
+
+  parts.push("\n## Diff\n");
+  parts.push(diff);
+
+  return parts.join("\n");
+}

--- a/packages/core/src/description/schema.ts
+++ b/packages/core/src/description/schema.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const FileChangeSchema = z.object({
+  path: z.string().describe("file path that was modified"),
+  description: z.string().describe("concise summary of what changed in this file and why"),
+});
+
+export const PRDescriptionOutputSchema = z.object({
+  summary: z
+    .string()
+    .describe("2-4 sentence overview of what this PR does and why, written for a reviewer"),
+  fileChanges: z
+    .array(FileChangeSchema)
+    .describe("list of changed files with a description of what changed in each"),
+  breakingChanges: z
+    .array(z.string())
+    .describe("list of breaking changes introduced by this PR; empty array if none"),
+  migrationNotes: z
+    .string()
+    .nullable()
+    .describe(
+      "migration instructions for consumers (schema changes, API changes, config changes); null if not applicable",
+    ),
+});
+
+export type PRDescriptionOutput = z.infer<typeof PRDescriptionOutputSchema>;

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,4 +37,5 @@ export * from "./diff/index.js";
 export * from "./agent/index.js";
 export * from "./mcp/index.js";
 export * from "./triage/index.js";
+export * from "./description/index.js";
 export { fetchConventionFile } from "./convention-file.js";

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -79,6 +79,7 @@ export interface ReviewConfig {
   conventionFile?: string;
   consensusPasses?: number;
   consensusThreshold?: number | null;
+  generateDescription?: boolean;
 }
 
 export interface PRMetadata {
@@ -153,6 +154,7 @@ export interface GitProvider {
   postSummaryComment(markdown: string): Promise<void>;
   postInlineComments(findings: Finding[]): Promise<void>;
   deleteExistingBotComments(): Promise<void>;
+  updatePRDescription(description: string): Promise<void>;
 }
 
 export interface TicketProvider {

--- a/packages/dashboard/src/api.ts
+++ b/packages/dashboard/src/api.ts
@@ -6,6 +6,7 @@ export interface RepoConfig {
   style: "strict" | "balanced" | "lenient" | "roast" | "thorough";
   focusAreas: string[];
   ignorePatterns: string[];
+  generateDescription?: boolean;
 }
 
 export interface Settings {
@@ -57,7 +58,7 @@ export const api = {
   updateRepo: (
     owner: string,
     repo: string,
-    body: Pick<RepoConfig, "style" | "focusAreas" | "ignorePatterns">,
+    body: Pick<RepoConfig, "style" | "focusAreas" | "ignorePatterns" | "generateDescription">,
   ) =>
     request<RepoConfig>(`/api/config/repos/${owner}/${repo}`, {
       method: "PUT",

--- a/packages/dashboard/src/pages/RepoConfig.tsx
+++ b/packages/dashboard/src/pages/RepoConfig.tsx
@@ -54,12 +54,14 @@ export function RepoConfig() {
   const [style, setStyle] = useState<RepoConfig["style"]>("balanced");
   const [focusAreas, setFocusAreas] = useState<string[]>([]);
   const [ignorePatterns, setIgnorePatterns] = useState("");
+  const [generateDescription, setGenerateDescription] = useState(false);
 
   useEffect(() => {
     if (data) {
       setStyle(data.style);
       setFocusAreas(data.focusAreas);
       setIgnorePatterns(data.ignorePatterns.join("\n"));
+      setGenerateDescription(data.generateDescription ?? false);
     }
   }, [data]);
 
@@ -72,6 +74,7 @@ export function RepoConfig() {
           .split("\n")
           .map((s) => s.trim())
           .filter(Boolean),
+        generateDescription,
       }),
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: ["repo", owner, repo] });
@@ -172,6 +175,33 @@ export function RepoConfig() {
           className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-slate-100 placeholder-slate-600 focus:outline-none focus:border-amber-400 font-mono resize-y"
         />
         <p className="text-xs text-slate-500 mt-1">one pattern per line</p>
+      </section>
+
+      <section className="mb-8">
+        <h2 className="text-sm font-semibold text-slate-300 uppercase tracking-wide mb-3">
+          PR Description
+        </h2>
+        <label
+          className={`flex items-start gap-3 p-3 border rounded-lg cursor-pointer transition-colors ${
+            generateDescription
+              ? "border-amber-400 bg-amber-400/5"
+              : "border-slate-700 bg-slate-800 hover:border-slate-500"
+          }`}
+        >
+          <input
+            type="checkbox"
+            checked={generateDescription}
+            onChange={(e) => setGenerateDescription(e.target.checked)}
+            className="mt-0.5 accent-amber-400"
+          />
+          <div>
+            <p className="text-sm font-medium text-slate-100">Generate PR Description</p>
+            <p className="text-xs text-slate-500">
+              Automatically generate a structured PR description from the diff when the description
+              is empty or contains a placeholder.
+            </p>
+          </div>
+        </label>
       </section>
 
       {mutation.isSuccess && <p className="text-green-400 text-sm mb-3">Saved successfully.</p>}

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -20,6 +20,8 @@ import {
   isCascadeEnabled,
   runTriage,
   splitByClassification,
+  generatePRDescription,
+  shouldGenerateDescription,
 } from "@rusty-bot/core";
 import { GitHubProvider } from "./provider.js";
 import { getRepoConfig, saveReview, getSetting, type ReviewRecord } from "./storage.js";
@@ -93,6 +95,25 @@ export async function orchestrateReview(params: {
     const patches = parseDiff(rawDiff);
     const filtered = filterFiles(patches, config.ignorePatterns);
     const reviewable = stripDeletionOnlyHunks(filtered);
+
+    const shouldGenerate =
+      repoConfig?.generateDescription ?? process.env.RUSTY_GENERATE_DESCRIPTION === "true";
+
+    if (shouldGenerate) {
+      try {
+        if (shouldGenerateDescription(metadata.description)) {
+          const descResult = await generatePRDescription(reviewable, metadata);
+          await provider.updatePRDescription(descResult.markdown);
+          metadata.description = descResult.markdown;
+          log.info(
+            { model: descResult.modelUsed, tokens: descResult.tokenCount },
+            "generated PR description",
+          );
+        }
+      } catch (err) {
+        log.warn({ err }, "failed to generate PR description, continuing with review");
+      }
+    }
 
     const ticketRefs = extractTicketRefs(metadata.description, metadata.sourceBranch);
 

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -102,7 +102,11 @@ export async function orchestrateReview(params: {
     if (shouldGenerate) {
       try {
         if (shouldGenerateDescription(metadata.description)) {
-          const descResult = await generatePRDescription(reviewable, metadata);
+          const descResult = await generatePRDescription(
+            reviewable,
+            metadata,
+            metadata.description,
+          );
           await provider.updatePRDescription(descResult.markdown);
           metadata.description = descResult.markdown;
           log.info(

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -265,4 +265,13 @@ export class GitHubProvider implements GitProvider {
       ),
     );
   }
+
+  async updatePRDescription(description: string): Promise<void> {
+    await this.octokit.request("PATCH /repos/{owner}/{repo}/pulls/{pull_number}", {
+      owner: this.owner,
+      repo: this.repo,
+      pull_number: this.pullNumber,
+      body: description,
+    });
+  }
 }

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -134,7 +134,7 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     style: parsedStyle.success ? parsedStyle.data : "balanced",
     focusAreas: body.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
     ignorePatterns: body.ignorePatterns ?? [],
-    ...(body.generateDescription !== undefined && {
+    ...(typeof body.generateDescription === "boolean" && {
       generateDescription: body.generateDescription,
     }),
   };

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -120,6 +120,7 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     style?: string;
     focusAreas?: FocusArea[];
     ignorePatterns?: string[];
+    generateDescription?: boolean;
   } = await c.req.json();
 
   const parsedStyle = ReviewStyleSchema.safeParse(body.style);
@@ -133,6 +134,9 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     style: parsedStyle.success ? parsedStyle.data : "balanced",
     focusAreas: body.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
     ignorePatterns: body.ignorePatterns ?? [],
+    ...(body.generateDescription !== undefined && {
+      generateDescription: body.generateDescription,
+    }),
   };
 
   await setRepoConfig(owner, repo, config);

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -10,6 +10,7 @@ export interface RepoConfig {
   ignorePatterns: string[];
   consensusPasses?: number;
   consensusThreshold?: number | null;
+  generateDescription?: boolean;
 }
 
 export interface RepoConfigWithId extends RepoConfig {


### PR DESCRIPTION
## Summary
- Adds a new `description/` module in `@rusty-bot/core` that generates structured PR descriptions (summary, per-file changes table, breaking changes, migration notes) from the diff
- Off by default — enable via `RUSTY_GENERATE_DESCRIPTION=true` env var or per-repo toggle in the dashboard
- Runs before the review so the reviewer sees the generated description; never overwrites human-written descriptions
- Conservative placeholder detection: only generates when description is empty, whitespace, short placeholders (TODO/WIP), or previously bot-generated
- Adds `updatePRDescription()` to `GitProvider` interface with implementations for both GitHub and Azure DevOps
- Dashboard gets a new "PR Description" section with a checkbox toggle on the repo config page

## Changes across packages
- **core**: new `description/` module (schema, prompt, generate, tests), `generateDescription` added to `ReviewConfig`, `updatePRDescription` added to `GitProvider`
- **github**: provider implementation, orchestrator wiring, storage + server route updated
- **azure-devops**: provider implementation, CLI wiring
- **dashboard**: API type updated, RepoConfig page gets checkbox

## Test plan
- [ ] `PRDescriptionOutputSchema` validates well-formed output and passes OpenAI strict mode
- [ ] `shouldGenerateDescription` returns true for empty/whitespace/placeholder/bot-generated descriptions
- [ ] `shouldGenerateDescription` returns false for meaningful human descriptions
- [ ] `formatDescription` renders all sections correctly, omits empty sections, sanitizes pipes
- [ ] `buildDescriptionUserMessage` includes PR metadata and diff
- [ ] Verify GitHub provider `updatePRDescription` calls correct API endpoint
- [ ] Verify Azure DevOps provider `updatePRDescription` calls correct API endpoint
- [ ] End-to-end: enable on a repo, open PR with empty description, verify description is generated