### PR TITLE
Use GitHub App installation token for GitHubTicketProvider

### DIFF
--- a/packages/core/src/__tests__/tickets.test.ts
+++ b/packages/core/src/__tests__/tickets.test.ts
@@ -492,6 +492,21 @@ describe("provider normalization", () => {
       const result = await provider.fetchTicket("1");
       expect(result!.description.length).toBe(10_000);
     });
+
+    it.each(["#", "abc", "repo#not-a-number", "", "owner/repo#"])(
+      "returns null without calling fetcher for malformed ref: %s",
+      async (ref) => {
+        const issueFetcher = vi.fn();
+        const provider = new GitHubTicketProvider({
+          owner: "o",
+          repo: "r",
+          issueFetcher,
+        });
+
+        expect(await provider.fetchTicket(ref)).toBeNull();
+        expect(issueFetcher).not.toHaveBeenCalled();
+      },
+    );
   });
 
   describe("JiraTicketProvider", () => {

--- a/packages/core/src/__tests__/tickets.test.ts
+++ b/packages/core/src/__tests__/tickets.test.ts
@@ -385,6 +385,115 @@ describe("provider normalization", () => {
     });
   });
 
+  describe("GitHubTicketProvider with issueFetcher", () => {
+    it("uses the injected fetcher instead of global fetch", async () => {
+      const issueFetcher = vi.fn().mockResolvedValue({
+        number: 7,
+        title: "From octokit",
+        body: "fetched via installation token",
+        labels: [{ name: "enhancement" }],
+      });
+
+      const provider = new GitHubTicketProvider({
+        owner: "acme",
+        repo: "widgets",
+        issueFetcher,
+      });
+
+      const result = await provider.fetchTicket("7");
+      expect(issueFetcher).toHaveBeenCalledWith("acme", "widgets", 7);
+      expect(result).toEqual({
+        id: "7",
+        title: "From octokit",
+        description: "fetched via installation token",
+        labels: ["enhancement"],
+        source: "github",
+      });
+    });
+
+    it("returns null when fetcher returns null", async () => {
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher: vi.fn().mockResolvedValue(null),
+      });
+
+      expect(await provider.fetchTicket("1")).toBeNull();
+    });
+
+    it("returns null when fetcher throws", async () => {
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher: vi.fn().mockRejectedValue(new Error("network error")),
+      });
+
+      expect(await provider.fetchTicket("1")).toBeNull();
+    });
+
+    it("returns null when fetcher returns invalid schema", async () => {
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher: vi.fn().mockResolvedValue({ unexpected: "shape" }),
+      });
+
+      expect(await provider.fetchTicket("1")).toBeNull();
+    });
+
+    it("strips # prefix from ref before passing to fetcher", async () => {
+      const issueFetcher = vi.fn().mockResolvedValue({
+        number: 55,
+        title: "t",
+        body: null,
+        labels: [],
+      });
+
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher,
+      });
+
+      await provider.fetchTicket("#55");
+      expect(issueFetcher).toHaveBeenCalledWith("o", "r", 55);
+    });
+
+    it("parses cross-repo ref and passes parsed number to fetcher", async () => {
+      const issueFetcher = vi.fn().mockResolvedValue({
+        number: 99,
+        title: "t",
+        body: null,
+        labels: [],
+      });
+
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher,
+      });
+
+      await provider.fetchTicket("acme/widgets#99");
+      expect(issueFetcher).toHaveBeenCalledWith("o", "r", 99);
+    });
+
+    it("truncates long description from fetcher", async () => {
+      const provider = new GitHubTicketProvider({
+        owner: "o",
+        repo: "r",
+        issueFetcher: vi.fn().mockResolvedValue({
+          number: 1,
+          title: "t",
+          body: "x".repeat(20_000),
+          labels: [],
+        }),
+      });
+
+      const result = await provider.fetchTicket("1");
+      expect(result!.description.length).toBe(10_000);
+    });
+  });
+
   describe("JiraTicketProvider", () => {
     it("normalizes jira response with string description", async () => {
       const provider = new JiraTicketProvider({

--- a/packages/core/src/tickets/index.ts
+++ b/packages/core/src/tickets/index.ts
@@ -2,6 +2,7 @@ export { extractTicketRefs } from "./extract.js";
 export { resolveTickets } from "./resolve.js";
 export { resolveTicketsWithStatus } from "./resolve.js";
 export { GitHubTicketProvider } from "./providers/github.js";
+export type { GitHubTicketProviderConfig, IssueFetcher } from "./providers/github.js";
 export { JiraTicketProvider } from "./providers/jira.js";
 export { LinearTicketProvider } from "./providers/linear.js";
 export { AzureDevOpsTicketProvider } from "./providers/azure-devops.js";

--- a/packages/core/src/tickets/providers/github.ts
+++ b/packages/core/src/tickets/providers/github.ts
@@ -38,11 +38,13 @@ export class GitHubTicketProvider implements TicketProvider {
   }
 
   async fetchTicket(ref: string): Promise<TicketInfo | null> {
-    const number = ref.includes("#") ? ref.split("#").pop() : ref;
+    const raw_number = ref.includes("#") ? ref.split("#").pop() : ref;
+    const issueNumber = Number(raw_number);
+    if (!Number.isInteger(issueNumber) || issueNumber <= 0) return null;
 
     let raw: unknown;
     try {
-      raw = await this.fetcher(this.owner, this.repo, Number(number));
+      raw = await this.fetcher(this.owner, this.repo, issueNumber);
     } catch {
       return null;
     }

--- a/packages/core/src/tickets/providers/github.ts
+++ b/packages/core/src/tickets/providers/github.ts
@@ -3,33 +3,52 @@ import { GitHubIssueSchema } from "../schemas.js";
 
 const MAX_DESC_LENGTH = 10_000;
 
-interface GitHubTicketProviderConfig {
-  token: string;
+export type IssueFetcher = (owner: string, repo: string, issueNumber: number) => Promise<unknown>;
+
+export type GitHubTicketProviderConfig = {
   owner: string;
   repo: string;
-}
+} & ({ token: string } | { issueFetcher: IssueFetcher });
 
 export class GitHubTicketProvider implements TicketProvider {
-  private config: GitHubTicketProviderConfig;
+  private readonly owner: string;
+  private readonly repo: string;
+  private readonly fetcher: IssueFetcher;
 
   constructor(config: GitHubTicketProviderConfig) {
-    this.config = config;
+    this.owner = config.owner;
+    this.repo = config.repo;
+
+    if ("issueFetcher" in config) {
+      this.fetcher = config.issueFetcher;
+    } else {
+      const token = config.token;
+      this.fetcher = async (owner, repo, issueNumber) => {
+        const url = `https://api.github.com/repos/${owner}/${repo}/issues/${issueNumber}`;
+        const res = await fetch(url, {
+          headers: {
+            Authorization: `Bearer ${token}`,
+            Accept: "application/vnd.github+json",
+          },
+        });
+        if (!res.ok) return null;
+        return res.json();
+      };
+    }
   }
 
   async fetchTicket(ref: string): Promise<TicketInfo | null> {
     const number = ref.includes("#") ? ref.split("#").pop() : ref;
-    const url = `https://api.github.com/repos/${this.config.owner}/${this.config.repo}/issues/${number}`;
 
-    const res = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${this.config.token}`,
-        Accept: "application/vnd.github+json",
-      },
-    });
+    let raw: unknown;
+    try {
+      raw = await this.fetcher(this.owner, this.repo, Number(number));
+    } catch {
+      return null;
+    }
+    if (raw == null) return null;
 
-    if (!res.ok) return null;
-
-    const parsed = GitHubIssueSchema.safeParse(await res.json());
+    const parsed = GitHubIssueSchema.safeParse(raw);
     if (!parsed.success) return null;
 
     const data = parsed.data;

--- a/packages/github/src/__tests__/octokit-issue-fetcher.test.ts
+++ b/packages/github/src/__tests__/octokit-issue-fetcher.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createOctokitIssueFetcher } from "../orchestrator.js";
+import type { Octokit } from "octokit";
+import { logger } from "@rusty-bot/core";
+
+function createMockOctokit() {
+  return {
+    request: vi.fn(),
+    graphql: vi.fn(),
+  } as unknown as Octokit & {
+    request: ReturnType<typeof vi.fn>;
+  };
+}
+
+describe("createOctokitIssueFetcher", () => {
+  let octokit: ReturnType<typeof createMockOctokit>;
+  let fetcher: ReturnType<typeof createOctokitIssueFetcher>;
+
+  beforeEach(() => {
+    octokit = createMockOctokit();
+    fetcher = createOctokitIssueFetcher(octokit);
+  });
+
+  it("returns issue data on success", async () => {
+    const issueData = { number: 42, title: "test", body: "desc", labels: [] };
+    octokit.request.mockResolvedValueOnce({ data: issueData });
+
+    const result = await fetcher("acme", "widgets", 42);
+    expect(result).toEqual(issueData);
+    expect(octokit.request).toHaveBeenCalledWith(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}",
+      { owner: "acme", repo: "widgets", issue_number: 42 },
+    );
+  });
+
+  it("returns null silently on 404", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(vi.fn());
+    octokit.request.mockRejectedValueOnce(Object.assign(new Error("Not Found"), { status: 404 }));
+
+    const result = await fetcher("o", "r", 999);
+    expect(result).toBeNull();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns null and logs warning on 403", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(vi.fn());
+    octokit.request.mockRejectedValueOnce(Object.assign(new Error("Forbidden"), { status: 403 }));
+
+    const result = await fetcher("o", "r", 1);
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "o", repo: "r", issueNumber: 1 }),
+      "installation token issue fetch failed",
+    );
+    warn.mockRestore();
+  });
+
+  it("returns null and logs warning on 401", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(vi.fn());
+    octokit.request.mockRejectedValueOnce(
+      Object.assign(new Error("Unauthorized"), { status: 401 }),
+    );
+
+    const result = await fetcher("o", "r", 5);
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalledWith(
+      expect.objectContaining({ owner: "o", repo: "r", issueNumber: 5 }),
+      "installation token issue fetch failed",
+    );
+    warn.mockRestore();
+  });
+
+  it("returns null and logs warning on rate limit (429)", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(vi.fn());
+    octokit.request.mockRejectedValueOnce(
+      Object.assign(new Error("rate limit exceeded"), { status: 429 }),
+    );
+
+    const result = await fetcher("o", "r", 10);
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it("returns null and logs warning on errors without status", async () => {
+    const warn = vi.spyOn(logger, "warn").mockImplementation(vi.fn());
+    octokit.request.mockRejectedValueOnce(new Error("network failure"));
+
+    const result = await fetcher("o", "r", 1);
+    expect(result).toBeNull();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+});

--- a/packages/github/src/index.ts
+++ b/packages/github/src/index.ts
@@ -1,7 +1,7 @@
 export { GitHubProvider } from "./provider.js";
 export { createAppOctokit } from "./auth.js";
 export { app } from "./server.js";
-export { orchestrateReview } from "./orchestrator.js";
+export { orchestrateReview, createOctokitIssueFetcher } from "./orchestrator.js";
 export {
   getRepoConfig,
   setRepoConfig,

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -1,5 +1,5 @@
 import type { Octokit } from "octokit";
-import type { FocusArea, TicketProvider, TicketRef } from "@rusty-bot/core";
+import type { FocusArea, IssueFetcher, TicketProvider, TicketRef } from "@rusty-bot/core";
 import {
   parseDiff,
   filterFiles,
@@ -29,6 +29,24 @@ import { GitHubProvider } from "./provider.js";
 import { getRepoConfig, saveReview, getSetting, type ReviewRecord } from "./storage.js";
 
 const log = logger.child({ package: "github" });
+
+export function createOctokitIssueFetcher(octokit: Octokit): IssueFetcher {
+  return async (owner, repo, issueNumber) => {
+    try {
+      const { data } = await octokit.request("GET /repos/{owner}/{repo}/issues/{issue_number}", {
+        owner,
+        repo,
+        issue_number: issueNumber,
+      });
+      return data;
+    } catch (err: unknown) {
+      const status = (err as { status?: number }).status;
+      if (status === 404) return null;
+      log.warn({ err, owner, repo, issueNumber }, "installation token issue fetch failed");
+      return null;
+    }
+  };
+}
 const MAX_DIFF_TOKENS = 60_000;
 const ALL_FOCUS_AREAS: FocusArea[] = ["security", "performance", "bugs", "style", "tests", "docs"];
 
@@ -48,17 +66,7 @@ async function buildTicketProviders(
       new GitHubTicketProvider({
         owner,
         repo,
-        issueFetcher: async (o, r, num) => {
-          try {
-            const { data } = await octokit.request(
-              "GET /repos/{owner}/{repo}/issues/{issue_number}",
-              { owner: o, repo: r, issue_number: num },
-            );
-            return data;
-          } catch {
-            return null;
-          }
-        },
+        issueFetcher: createOctokitIssueFetcher(octokit),
       }),
     );
   }

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -33,6 +33,7 @@ const MAX_DIFF_TOKENS = 60_000;
 const ALL_FOCUS_AREAS: FocusArea[] = ["security", "performance", "bugs", "style", "tests", "docs"];
 
 async function buildTicketProviders(
+  octokit: Octokit,
   owner: string,
   repo: string,
 ): Promise<Map<string, TicketProvider>> {
@@ -41,6 +42,25 @@ async function buildTicketProviders(
   const ghToken = await getSetting("github_token");
   if (ghToken) {
     providers.set("github", new GitHubTicketProvider({ token: ghToken, owner, repo }));
+  } else {
+    providers.set(
+      "github",
+      new GitHubTicketProvider({
+        owner,
+        repo,
+        issueFetcher: async (o, r, num) => {
+          try {
+            const { data } = await octokit.request(
+              "GET /repos/{owner}/{repo}/issues/{issue_number}",
+              { owner: o, repo: r, issue_number: num },
+            );
+            return data;
+          } catch {
+            return null;
+          }
+        },
+      }),
+    );
   }
 
   const jiraUrl = await getSetting("jira_base_url");
@@ -140,7 +160,7 @@ export async function orchestrateReview(params: {
     }
     const allRefs = [...ticketRefs, ...linkedRefs];
 
-    const ticketProviders = await buildTicketProviders(owner, repo);
+    const ticketProviders = await buildTicketProviders(octokit, owner, repo);
     const { tickets, status: ticketResolution } = await resolveTicketsWithStatus(
       allRefs,
       ticketProviders,


### PR DESCRIPTION
## Summary
- Refactor `GitHubTicketProvider` to accept an `issueFetcher` function as an alternative to a raw PAT, keeping the core package free of octokit dependency
- The GitHub orchestrator now always registers a `github` ticket provider — using the installation Octokit when no `github_token` setting is configured, giving zero-config ticket resolution
- `github_token` setting is preserved as an optional override for broader/cross-repo access

Closes #46

## Test plan
- [x] Existing token-based tests still pass (unchanged behavior)
- [x] New tests cover the `issueFetcher` path: normal resolution, null return, thrown errors, invalid schema, `#`-prefix stripping, cross-repo ref parsing, description truncation
- [x] Full suite passes (502 tests)
- [ ] Deploy to staging and verify linked GitHub issues resolve without `github_token` configured