### PR TITLE
fix: install charset-normalizer for opengrep rule downloads

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ WORKDIR /app
 
 ARG OPENGREP_VERSION=v1.19.0
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates \
+    && apt-get install -y --no-install-recommends curl ca-certificates python3 python3-pip \
+    && pip3 install --break-system-packages charset-normalizer chardet \
     && curl -fsSL -o /usr/local/bin/opengrep \
        "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86" \
     && chmod +x /usr/local/bin/opengrep \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ WORKDIR /app
 ARG OPENGREP_VERSION=v1.19.0
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates python3 python3-pip \
-    && pip3 install --break-system-packages charset-normalizer chardet \
+    && pip3 install --break-system-packages charset-normalizer==3.4.1 chardet==5.2.0 \
     && curl -fsSL -o /usr/local/bin/opengrep \
        "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86" \
     && chmod +x /usr/local/bin/opengrep \

--- a/packages/core/src/opengrep/runner.ts
+++ b/packages/core/src/opengrep/runner.ts
@@ -109,7 +109,7 @@ export async function runOpenGrep(
         findings: [],
         rawCount: 0,
         available: true,
-        error: `opengrep exited with code ${exitCode}: ${stderr.slice(0, 200)}`,
+        error: `opengrep exited with code ${exitCode}: ${stderr.slice(0, 500)}`,
       };
     }
 


### PR DESCRIPTION
## Summary

- OpenGrep's bundled `requests` library needs `charset_normalizer` or `chardet` for HTTP rule downloads (`--config auto`), causing exit code 2 in the container
- Installs `python3`, `python3-pip`, `charset-normalizer`, and `chardet` in the Docker runtime image
- Increases stderr capture from 200 to 500 chars so errors are less truncated in the summary comment

## Test plan

- [x] 495 tests pass
- [ ] Rebuild Docker image and verify `--config auto` rule download works

🤖 Generated with [Claude Code](https://claude.com/claude-code)