### PR TITLE
Handle multiline Azure DevOps inline suggestion spans

### DIFF
--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -217,6 +217,50 @@ describe("AzureDevOpsProvider", () => {
       expect(secondBody.comments[0].content).not.toContain("```suggestion");
     });
 
+    it("uses endLine for rightFileEnd when finding spans multiple lines", async () => {
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      const findings: Finding[] = [
+        {
+          file: "src/config.ts",
+          line: 5,
+          endLine: 12,
+          severity: "warning",
+          category: "bugs",
+          message: "duplicate entries",
+          suggestedFix: "const plugins = [\n  'react',\n  'vitest',\n];",
+        },
+      ];
+
+      await provider.postInlineComments(findings);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.threadContext.rightFileStart).toEqual({ line: 5, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 12, offset: 1 });
+    });
+
+    it("falls back to line when endLine is null", async () => {
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      const findings: Finding[] = [
+        {
+          file: "src/index.ts",
+          line: 42,
+          endLine: null,
+          severity: "warning",
+          category: "bugs",
+          message: "issue",
+          suggestedFix: null,
+        },
+      ];
+
+      await provider.postInlineComments(findings);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.threadContext.rightFileStart).toEqual({ line: 42, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 42, offset: 1 });
+    });
+
     it("skips API call when findings array is empty", async () => {
       await provider.postInlineComments([]);
       expect(fetchSpy).not.toHaveBeenCalled();

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -316,7 +316,7 @@ export class AzureDevOpsProvider implements GitProvider {
             threadContext: {
               filePath: `/${finding.file}`,
               rightFileStart: { line: finding.line, offset: 1 },
-              rightFileEnd: { line: finding.line, offset: 1 },
+              rightFileEnd: { line: finding.endLine ?? finding.line, offset: 1 },
             },
             status: 1,
           }),


### PR DESCRIPTION
## Summary
- Use `endLine` when building Azure DevOps inline suggestion thread context so multiline findings span the full suggested range.
- Fall back to `line` when `endLine` is `null`.
- Add tests covering multiline spans and the single-line fallback.

## Testing
- `Not run`