### PR TITLE
Route model overrides through provider resolution

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -11,8 +11,13 @@ vi.mock("@mastra/core/agent", () => ({
 
 vi.mock("../agent/model.js", () => ({
   resolveModelConfig: vi.fn(() => ({ type: "router", model: "test-model" })),
-  resolveModel: vi.fn(() => "test-model"),
-  getModelDisplayName: vi.fn(() => "test-model"),
+  resolveModelConfigWithOverride: vi.fn((model: string) => ({ type: "router", model })),
+  resolveModel: vi.fn((config: { type: string; model?: string }) =>
+    config.type === "router" ? (config.model ?? "test-model") : "test-model",
+  ),
+  getModelDisplayName: vi.fn((config: { type: string; model?: string }) =>
+    config.type === "router" ? (config.model ?? "test-model") : "test-model",
+  ),
   resolveModelSettings: vi.fn(() => ({})),
 }));
 
@@ -266,6 +271,32 @@ describe("judgeFindings", () => {
     expect(Agent).toHaveBeenCalledWith(
       expect.objectContaining({ model: "anthropic/claude-haiku" }),
     );
+  });
+
+  it("routes override model through provider resolution (azure-openai prefix)", async () => {
+    const modelModule = await import("../agent/model.js");
+    const resolveWithOverrideSpy = vi.mocked(modelModule.resolveModelConfigWithOverride);
+    resolveWithOverrideSpy.mockClear();
+
+    const findings = [makeFinding()];
+
+    generateMock.mockResolvedValueOnce({
+      object: {
+        evaluations: [{ index: 0, confidence: 9, reasoning: "valid" }],
+      },
+      usage: { totalTokens: 200 },
+    });
+
+    await judgeFindings(findings, DIFF, {
+      enabled: true,
+      threshold: 6,
+      model: "azure-openai/gpt-5.4-mini",
+    });
+
+    // override must flow through the provider resolution helper, otherwise
+    // azure-openai/ strings get handed to the mastra router and fail with
+    // "Could not find config for provider azure-openai"
+    expect(resolveWithOverrideSpy).toHaveBeenCalledWith("azure-openai/gpt-5.4-mini");
   });
 });
 

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -179,14 +179,37 @@ describe("resolveModelConfigWithOverride", () => {
     expect(process.env.RUSTY_LLM_MODEL).toBeUndefined();
   });
 
-  it("restores RUSTY_LLM_MODEL even when resolution throws", () => {
+  it("restores RUSTY_LLM_MODEL when resolveModelConfig throws", () => {
     process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
 
-    // force a throw by stubbing resolveModelConfig via an invalid azure-openai setup —
-    // actually resolveModelConfig doesn't throw on its own, so we simulate by making
-    // the call succeed but verify the restore path is exercised on the happy path too.
-    // (the throw path is indirectly covered by the try/finally structure.)
-    resolveModelConfigWithOverride("azure-openai/does-not-matter");
+    // process.env rejects accessor descriptors, so wrap it in a Proxy that
+    // throws on AZURE_API_KEY reads — resolveModelConfig hits that read
+    // once the model string starts with "azure-openai/"
+    const realEnv = process.env;
+    const throwingEnv = new Proxy(realEnv, {
+      get(target, prop) {
+        if (prop === "AZURE_API_KEY") throw new Error("simulated env failure");
+        return Reflect.get(target, prop);
+      },
+      // delegate set/delete directly to target so process.env's string-coercion
+      // path runs on the real env, not on the Proxy wrapper
+      set(target, prop, value) {
+        (target as Record<string, string>)[prop as string] = value;
+        return true;
+      },
+      deleteProperty(target, prop) {
+        return Reflect.deleteProperty(target, prop);
+      },
+    });
+    Object.defineProperty(process, "env", { value: throwingEnv, configurable: true });
+
+    try {
+      expect(() => resolveModelConfigWithOverride("azure-openai/gpt-5.4-mini")).toThrow(
+        "simulated env failure",
+      );
+    } finally {
+      Object.defineProperty(process, "env", { value: realEnv, configurable: true });
+    }
 
     expect(process.env.RUSTY_LLM_MODEL).toBe("anthropic/claude-sonnet");
   });

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  resolveModelConfig,
+  resolveTriageModelConfig,
+  resolveModelConfigWithOverride,
+  getModelDisplayName,
+} from "../agent/model.js";
+
+function clearEnv() {
+  delete process.env.RUSTY_LLM_MODEL;
+  delete process.env.RUSTY_LLM_TRIAGE_MODEL;
+  delete process.env.AZURE_API_KEY;
+  delete process.env.AZURE_OPENAI_API_KEY;
+  delete process.env.AZURE_OPENAI_RESOURCE_NAME;
+  delete process.env.RUSTY_AZURE_RESOURCE_NAME;
+  delete process.env.RUSTY_AZURE_DEPLOYMENT;
+  delete process.env.RUSTY_LLM_BASE_URL;
+  delete process.env.RUSTY_LLM_API_KEY;
+}
+
+describe("resolveModelConfig", () => {
+  beforeEach(clearEnv);
+
+  it("falls back to router with the default model when nothing is set", () => {
+    const config = resolveModelConfig();
+    expect(config.type).toBe("router");
+    if (config.type === "router") {
+      expect(config.model).toMatch(/anthropic\//);
+    }
+  });
+
+  it("returns router config for arbitrary provider strings", () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-haiku";
+    const config = resolveModelConfig();
+    expect(config).toEqual({ type: "router", model: "anthropic/claude-haiku" });
+  });
+
+  it("builds azure-api-key config when azure-openai prefix + api key + resource name are present", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-openai/gpt-5.4-mini";
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "my-resource";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-api-key");
+    if (config.type === "azure-api-key") {
+      expect(config.deploymentName).toBe("gpt-5.4-mini");
+      expect(config.resourceName).toBe("my-resource");
+      expect(config.apiKey).toBe("secret");
+    }
+  });
+
+  it("accepts AZURE_OPENAI_API_KEY as an alternative to AZURE_API_KEY", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-openai/gpt-5.4-mini";
+    process.env.AZURE_OPENAI_API_KEY = "other-secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "my-resource";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-api-key");
+    if (config.type === "azure-api-key") {
+      expect(config.apiKey).toBe("other-secret");
+    }
+  });
+
+  it("falls through to router when azure-openai prefix is set but resource name is missing", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-openai/gpt-5.4-mini";
+    process.env.AZURE_API_KEY = "secret";
+    // no AZURE_OPENAI_RESOURCE_NAME
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("router");
+  });
+});
+
+describe("getModelDisplayName", () => {
+  it("returns azure/<deployment> for azure-api-key configs", () => {
+    const name = getModelDisplayName({
+      type: "azure-api-key",
+      resourceName: "my-resource",
+      deploymentName: "gpt-5.4-mini",
+      apiKey: "secret",
+    });
+    expect(name).toBe("azure/gpt-5.4-mini");
+  });
+
+  it("returns the raw model string for router configs", () => {
+    const name = getModelDisplayName({ type: "router", model: "azure-openai/gpt-5.4-mini" });
+    expect(name).toBe("azure-openai/gpt-5.4-mini");
+  });
+});
+
+describe("resolveTriageModelConfig", () => {
+  beforeEach(clearEnv);
+
+  it("returns null when no triage model is configured", () => {
+    expect(resolveTriageModelConfig()).toBeNull();
+  });
+
+  it("resolves the triage override through the azure-api-key branch when env is set", () => {
+    process.env.RUSTY_LLM_TRIAGE_MODEL = "azure-openai/gpt-5.4-mini";
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "my-resource";
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    const config = resolveTriageModelConfig();
+    expect(config?.type).toBe("azure-api-key");
+    if (config?.type === "azure-api-key") {
+      expect(config.deploymentName).toBe("gpt-5.4-mini");
+    }
+  });
+
+  it("restores the original RUSTY_LLM_MODEL after resolving", () => {
+    process.env.RUSTY_LLM_TRIAGE_MODEL = "azure-openai/gpt-5.4-mini";
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "my-resource";
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    resolveTriageModelConfig();
+
+    expect(process.env.RUSTY_LLM_MODEL).toBe("anthropic/claude-sonnet");
+  });
+
+  it("leaves RUSTY_LLM_MODEL unset when it was unset before", () => {
+    process.env.RUSTY_LLM_TRIAGE_MODEL = "anthropic/claude-haiku";
+    expect(process.env.RUSTY_LLM_MODEL).toBeUndefined();
+
+    resolveTriageModelConfig();
+
+    expect(process.env.RUSTY_LLM_MODEL).toBeUndefined();
+  });
+});
+
+describe("resolveModelConfigWithOverride", () => {
+  beforeEach(clearEnv);
+
+  it("resolves an azure-openai override through the azure-api-key branch", () => {
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "my-resource";
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    const config = resolveModelConfigWithOverride("azure-openai/gpt-5.4-mini");
+    expect(config.type).toBe("azure-api-key");
+    if (config.type === "azure-api-key") {
+      expect(config.deploymentName).toBe("gpt-5.4-mini");
+      expect(config.resourceName).toBe("my-resource");
+    }
+  });
+
+  it("returns a router config for a plain router-style override", () => {
+    const config = resolveModelConfigWithOverride("anthropic/claude-haiku");
+    expect(config).toEqual({ type: "router", model: "anthropic/claude-haiku" });
+  });
+
+  it("routes through openai-compatible when RUSTY_LLM_BASE_URL is set", () => {
+    process.env.RUSTY_LLM_BASE_URL = "https://litellm.example/v1";
+    process.env.RUSTY_LLM_API_KEY = "k";
+
+    const config = resolveModelConfigWithOverride("custom/model");
+    expect(config).toEqual({
+      type: "openai-compatible",
+      baseUrl: "https://litellm.example/v1",
+      model: "custom/model",
+      apiKey: "k",
+    });
+  });
+
+  it("restores the original RUSTY_LLM_MODEL after resolving", () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    resolveModelConfigWithOverride("anthropic/claude-haiku");
+
+    expect(process.env.RUSTY_LLM_MODEL).toBe("anthropic/claude-sonnet");
+  });
+
+  it("leaves RUSTY_LLM_MODEL unset when it was unset before", () => {
+    expect(process.env.RUSTY_LLM_MODEL).toBeUndefined();
+
+    resolveModelConfigWithOverride("anthropic/claude-haiku");
+
+    expect(process.env.RUSTY_LLM_MODEL).toBeUndefined();
+  });
+
+  it("restores RUSTY_LLM_MODEL even when resolution throws", () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    // force a throw by stubbing resolveModelConfig via an invalid azure-openai setup —
+    // actually resolveModelConfig doesn't throw on its own, so we simulate by making
+    // the call succeed but verify the restore path is exercised on the happy path too.
+    // (the throw path is indirectly covered by the try/finally structure.)
+    resolveModelConfigWithOverride("azure-openai/does-not-matter");
+
+    expect(process.env.RUSTY_LLM_MODEL).toBe("anthropic/claude-sonnet");
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -27,6 +27,7 @@ export { runConsensusReview } from "./consensus.js";
 export {
   resolveModelConfig,
   resolveTriageModelConfig,
+  resolveModelConfigWithOverride,
   resolveModel,
   getModelDisplayName,
 } from "./model.js";

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -2,6 +2,7 @@ import { Agent } from "@mastra/core/agent";
 import { z } from "zod";
 import {
   resolveModelConfig,
+  resolveModelConfigWithOverride,
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
@@ -89,11 +90,13 @@ function formatFindingsForJudge(findings: readonly Finding[], diff: string): str
 }
 
 function resolveJudgeModel(judgeModelOverride?: string) {
-  if (judgeModelOverride) {
-    return { model: judgeModelOverride, displayName: judgeModelOverride };
-  }
-
-  const config = resolveModelConfig();
+  // override must go through the full resolution chain so azure-openai/ prefix
+  // + API key + resource name get wrapped in createAzure() — otherwise the
+  // raw string is handed to mastra's model router which doesn't know the
+  // azure-openai provider
+  const config = judgeModelOverride
+    ? resolveModelConfigWithOverride(judgeModelOverride)
+    : resolveModelConfig();
   return { model: resolveModel(config), displayName: getModelDisplayName(config) };
 }
 

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -44,12 +44,14 @@ export function resolveModelConfig(): ModelConfig {
   return { type: "router", model };
 }
 
-export function resolveTriageModelConfig(): ModelConfig | null {
-  const triageModel = process.env.RUSTY_LLM_TRIAGE_MODEL;
-  if (!triageModel) return null;
-  // triage model uses the same provider resolution logic but with its own model string
+/**
+ * resolve a ModelConfig for a specific model string, as if RUSTY_LLM_MODEL
+ * were set to it — so azure-openai/ prefix handling, openai-compatible
+ * endpoints, etc. all apply consistently across per-agent overrides.
+ */
+export function resolveModelConfigWithOverride(overrideModel: string): ModelConfig {
   const saved = process.env.RUSTY_LLM_MODEL;
-  process.env.RUSTY_LLM_MODEL = triageModel;
+  process.env.RUSTY_LLM_MODEL = overrideModel;
   try {
     return resolveModelConfig();
   } finally {
@@ -59,6 +61,12 @@ export function resolveTriageModelConfig(): ModelConfig | null {
       delete process.env.RUSTY_LLM_MODEL;
     }
   }
+}
+
+export function resolveTriageModelConfig(): ModelConfig | null {
+  const triageModel = process.env.RUSTY_LLM_TRIAGE_MODEL;
+  if (!triageModel) return null;
+  return resolveModelConfigWithOverride(triageModel);
 }
 
 export function resolveModel(


### PR DESCRIPTION
## Summary

- Extracted `resolveModelConfigWithOverride` so per-agent model overrides flow through the same provider-resolution chain as `RUSTY_LLM_MODEL` (handles `azure-openai/` prefix, `openai-compatible` endpoints, env restore in try/finally).
- Wired the judge agent's `judgeModelOverride` through the new helper — previously an `azure-openai/...` override was passed as a raw string to mastra's model router, which doesn't know that provider and failed with *"Could not find config for provider azure-openai"*.
- Refactored `resolveTriageModelConfig` to reuse the helper instead of open-coding the save/restore dance.

## Test plan

- [x] `resolveModelConfigWithOverride` unit tests: azure-api-key branch, plain router override, `RUSTY_LLM_BASE_URL` → openai-compatible, `RUSTY_LLM_MODEL` restored on success and when unset beforehand
- [x] `resolveTriageModelConfig` tests updated to assert azure branch + env restore
- [x] `judgeFindings` test asserts the `azure-openai/...` override flows through `resolveModelConfigWithOverride`
- [ ] Manual smoke: run a review with `RUSTY_LLM_JUDGE_MODEL=azure-openai/gpt-5.4-mini` against a repo with `AZURE_API_KEY` + `AZURE_OPENAI_RESOURCE_NAME` set