### PR TITLE
Tolerate failed consensus passes and retry structured-output errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,14 @@ Configure via per-repo config:
 4. Clusters with votes below the threshold are dropped
 5. Surviving findings include a `voteCount` showing how many passes flagged them
 
+**Pass-level fault tolerance:**
+
+Consensus uses `Promise.allSettled` rather than `Promise.all`, so a single flaky pass no longer fails the whole review:
+
+- Each pass retries once on `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED` (common with models that have inconsistent structured-output support, e.g. Kimi K2 via aggregators). Other errors are not retried.
+- If at least `consensusThreshold` passes succeed, consensus is formed from the surviving passes and `consensusMetadata.failedPasses` records how many threw.
+- If fewer than `consensusThreshold` passes succeed, the review throws an `AggregateError` containing every pass failure.
+
 **Cost:** With the default 3 passes, LLM cost per review triples. Combine with the judge pass (using a cheaper model) to offset costs.
 
 Set `consensusPasses` to `1` to disable consensus voting and get the original single-pass behavior with zero overhead.

--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -254,3 +254,99 @@ describe("runConsensusReview", () => {
     expect(result.recommendation).toBe("address_before_merge");
   });
 });
+
+describe("runConsensusReview failure tolerance", () => {
+  beforeEach(() => {
+    callCount = 0;
+    mockBehavior = "default";
+    vi.clearAllMocks();
+  });
+
+  it("tolerates one failed pass when the remaining successes still meet the threshold", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockRejectedValueOnce(new Error("structured output failed"))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    // 2 successful passes, threshold=2 ⇒ finding with 2 votes still survives
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].voteCount).toBe(2);
+    expect(result.consensusMetadata?.failedPasses).toBe(1);
+    expect(result.consensusMetadata?.passRecommendations).toHaveLength(2);
+  });
+
+  it("throws when too few passes succeed to meet the threshold", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockRejectedValueOnce(new Error("structured output failed (pass 2)"))
+      .mockRejectedValueOnce(new Error("structured output failed (pass 3)"));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+
+    // 1 successful pass, threshold=2 ⇒ cannot form consensus
+    await expect(
+      runConsensusReview([], consensusConfig, prMetadata, "diff content"),
+    ).rejects.toThrow(/consensus/i);
+  });
+
+  it("throws when every pass fails", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("fail 1"))
+      .mockRejectedValueOnce(new Error("fail 2"))
+      .mockRejectedValueOnce(new Error("fail 3"));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    await expect(
+      runConsensusReview([], consensusConfig, prMetadata, "diff content"),
+    ).rejects.toThrow();
+  });
+
+  it("reports failedPasses=0 when all passes succeed", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.consensusMetadata?.failedPasses).toBe(0);
+  });
+
+  it("aggregates token counts only from successful passes", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockRejectedValueOnce(new Error("pass 2 failed"))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 250 }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.tokenCount).toBe(350);
+  });
+
+  it("throws with an AggregateError that includes every pass failure", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("first failure"))
+      .mockRejectedValueOnce(new Error("second failure"))
+      .mockRejectedValueOnce(new Error("third failure"));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    try {
+      await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+      expect.fail("expected runConsensusReview to throw");
+    } catch (err) {
+      expect(err).toBeInstanceOf(AggregateError);
+      expect((err as AggregateError).errors).toHaveLength(3);
+    }
+  });
+});

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -491,6 +491,7 @@ describe("formatSummaryComment with dropped findings", () => {
         agreementRate: 0.5,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
+        failedPasses: 0,
       },
     });
 
@@ -517,6 +518,7 @@ describe("formatSummaryComment with dropped findings", () => {
         agreementRate: 1,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
+        failedPasses: 0,
       },
     });
     const result = formatSummaryComment(review);
@@ -540,6 +542,7 @@ describe("formatSummaryComment with dropped findings", () => {
         agreementRate: 0.5,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
+        failedPasses: 0,
       },
     });
 
@@ -557,6 +560,7 @@ describe("formatSummaryComment with consensus metadata in footer", () => {
         agreementRate: 0.67,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "address_before_merge"],
+        failedPasses: 0,
       },
     });
 
@@ -579,6 +583,7 @@ describe("formatSummaryComment with consensus metadata in footer", () => {
           "address_before_merge",
           "address_before_merge",
         ],
+        failedPasses: 0,
       },
     });
 

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -388,6 +388,7 @@ describe("judgeReviewResult", () => {
           "address_before_merge",
           "address_before_merge",
         ],
+        failedPasses: 0,
       },
     };
 
@@ -410,6 +411,7 @@ describe("judgeReviewResult", () => {
           "address_before_merge",
           "address_before_merge",
         ],
+        failedPasses: 0,
       },
     };
 

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -512,6 +512,7 @@ describe("mergeResults", () => {
           "address_before_merge",
           "address_before_merge",
         ],
+        failedPasses: 0,
       },
     };
 

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReviewConfig, PRMetadata } from "../types.js";
+
+const generateMock = vi.fn();
+
+vi.mock("@mastra/core/agent", () => ({
+  Agent: vi.fn().mockImplementation(function () {
+    return { generate: generateMock };
+  }),
+}));
+
+vi.mock("../agent/model.js", () => ({
+  resolveModelConfig: vi.fn(() => ({ type: "router", model: "test-model" })),
+  resolveModel: vi.fn(() => "test-model"),
+  getModelDisplayName: vi.fn(() => "test-model"),
+  resolveModelSettings: vi.fn(() => ({})),
+}));
+
+const { runReview } = await import("../agent/review.js");
+
+class FakeMastraError extends Error {
+  id: string;
+  domain: string;
+  category: string;
+  constructor(id: string, message: string) {
+    super(message);
+    this.id = id;
+    this.domain = "AGENT";
+    this.category = "SYSTEM";
+    this.name = "MastraError";
+  }
+}
+
+const prMetadata: PRMetadata = {
+  id: "1",
+  title: "test",
+  description: "",
+  author: "dev",
+  sourceBranch: "feat",
+  targetBranch: "main",
+  url: "https://example.com/pr/1",
+};
+
+const config: ReviewConfig = {
+  style: "balanced",
+  focusAreas: [],
+  ignorePatterns: [],
+};
+
+function makeValidResponse() {
+  return {
+    object: {
+      summary: "looks fine",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["a.ts"],
+    },
+    usage: { totalTokens: 100 },
+  };
+}
+
+describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+  });
+
+  it("retries once when first attempt throws STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", async () => {
+    generateMock
+      .mockRejectedValueOnce(
+        new FakeMastraError(
+          "STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED",
+          "Structured output validation failed: root: Invalid input: expected object, received undefined",
+        ),
+      )
+      .mockResolvedValueOnce(makeValidResponse());
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(generateMock).toHaveBeenCalledTimes(2);
+    expect(result.recommendation).toBe("looks_good");
+  });
+
+  it("does not retry on errors that are not structured output validation failures", async () => {
+    generateMock.mockRejectedValueOnce(new Error("API rate limit"));
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("API rate limit");
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry on a MastraError with a different id", async () => {
+    generateMock.mockRejectedValueOnce(new FakeMastraError("AGENT_STREAM_ERROR", "stream died"));
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("stream died");
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws when both the initial attempt and the retry fail the same way", async () => {
+    generateMock.mockRejectedValue(
+      new FakeMastraError(
+        "STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED",
+        "Structured output validation failed again",
+      ),
+    );
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow(
+      "Structured output validation failed again",
+    );
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries at most once (caps at 2 attempts, not more)", async () => {
+    generateMock.mockRejectedValue(
+      new FakeMastraError("STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", "failure"),
+    );
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow();
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("succeeds on the first attempt without retrying when the model returns a valid object", async () => {
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    const result = await runReview(config, "diff", prMetadata);
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    expect(result.recommendation).toBe("looks_good");
+  });
+
+  it("propagates the original error unchanged when the retry also fails with a different error", async () => {
+    generateMock
+      .mockRejectedValueOnce(
+        new FakeMastraError(
+          "STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED",
+          "first-attempt-validation-failure",
+        ),
+      )
+      .mockRejectedValueOnce(new Error("provider timeout"));
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("provider timeout");
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -82,7 +82,31 @@ export async function runConsensusReview(
     return runReview(config, compressed, prMetadata, tickets, options);
   });
 
-  const results = await Promise.all(passPromises);
+  const settled = await Promise.allSettled(passPromises);
+  const results: ReviewResult[] = [];
+  const failures: unknown[] = [];
+
+  for (let i = 0; i < settled.length; i++) {
+    const outcome = settled[i];
+    if (outcome.status === "fulfilled") {
+      results.push(outcome.value);
+    } else {
+      failures.push(outcome.reason);
+      logger.warn(
+        { err: outcome.reason, passIndex: i, prId: prMetadata.id },
+        "consensus pass failed",
+      );
+    }
+  }
+
+  if (results.length < threshold) {
+    throw new AggregateError(
+      failures,
+      `consensus review failed: only ${results.length}/${passes} passes succeeded (threshold ${threshold})`,
+    );
+  }
+
+  const failedPasses = failures.length;
 
   const findingsByPass = results.map((r) => r.findings);
   const observationsByPass = results.map((r) => r.observations);
@@ -126,6 +150,7 @@ export async function runConsensusReview(
     {
       passes,
       threshold,
+      failedPasses,
       totalClusters: findingClusters.length,
       surviving: survivingFindings.length,
       dropped: droppedFindings.length,
@@ -158,6 +183,7 @@ export async function runConsensusReview(
       agreementRate,
       recommendationElevated,
       passRecommendations,
+      failedPasses,
     },
     droppedFindings: droppedFindings.length > 0 ? droppedFindings : undefined,
   };

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -11,6 +11,33 @@ import {
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 import { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
+import { logger } from "../logger.js";
+
+const log = logger.child({ module: "review" });
+
+const STRUCTURED_OUTPUT_VALIDATION_ERROR_ID = "STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED";
+
+function isStructuredOutputValidationError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "id" in err &&
+    (err as { id: unknown }).id === STRUCTURED_OUTPUT_VALIDATION_ERROR_ID
+  );
+}
+
+async function generateWithStructuredOutputRetry<T>(fn: () => Promise<T>): Promise<T> {
+  try {
+    return await fn();
+  } catch (err) {
+    if (!isStructuredOutputValidationError(err)) throw err;
+    log.warn(
+      { err },
+      "structured output validation failed, retrying once before giving up on this pass",
+    );
+    return await fn();
+  }
+}
 
 export type ReviewTier = "skim" | "deep-review";
 
@@ -74,10 +101,12 @@ export async function runReview(
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;
 
   const modelSettings = resolveModelSettings("review");
-  const response = await agent.generate(userMessage, {
-    structuredOutput: { schema },
-    ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-  });
+  const response = await generateWithStructuredOutputRetry(() =>
+    agent.generate(userMessage, {
+      structuredOutput: { schema },
+      ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+    }),
+  );
 
   const parsed = response.object;
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,8 @@ export interface ConsensusMetadata {
   agreementRate: number;
   recommendationElevated: boolean;
   passRecommendations: Recommendation[];
+  /** number of consensus passes that threw before producing a result */
+  failedPasses: number;
 }
 
 export type TriageClassification = "skip" | "skim" | "deep-review";


### PR DESCRIPTION
## Summary
- Run consensus passes with `Promise.allSettled` instead of `Promise.all`: a single flaky pass no longer fails the whole review, as long as at least `consensusThreshold` passes succeed. If fewer succeed, throw an `AggregateError` containing every pass failure.
- Retry `runReview` once on `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED` (common with models that have inconsistent structured-output support, e.g. Kimi K2 via aggregators). Other errors are not retried.
- Add `failedPasses` to `ConsensusMetadata` so downstream formatters/judges can see how many passes threw.

## Test plan
- [x] `consensus.test.ts` — new suite covering: one pass fails but threshold still met, too few successes to meet threshold, all passes fail, zero failures, token aggregation skips failed passes, `AggregateError` shape.
- [x] `review.test.ts` — new suite covering: retry on structured-output validation error, no retry on unrelated errors, no retry on other `MastraError` ids, both attempts failing, cap at 2 attempts, happy path, different error on retry propagates.
- [x] Updated `formatter.test.ts`, `judge.test.ts`, `multi-call.test.ts` fixtures to include the new `failedPasses: 0` field.
- [x] `pnpm build` + full vitest run pass in pre-commit hooks.