### PR TITLE
Install opengrep python deps with pip --target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,23 +23,15 @@ WORKDIR /app
 
 ARG OPENGREP_VERSION=v1.19.0
 
-COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
-
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates python3 \
+    && apt-get install -y --no-install-recommends curl ca-certificates python3 python3-pip \
     && curl -fsSL -o /usr/local/bin/opengrep \
        "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86" \
     && chmod +x /usr/local/bin/opengrep \
     && opengrep --version \
-    # force extraction of the bundled python env via an offline scan
-    && printf 'rules:\n  - id: prime-cache\n    pattern: TODO\n    message: prime\n    languages: [generic]\n    severity: INFO\n' > /tmp/prime.yml \
-    && printf 'prime\n' > /tmp/prime.txt \
-    && opengrep scan --config /tmp/prime.yml --quiet /tmp/prime.txt \
-    && rm /tmp/prime.yml /tmp/prime.txt \
-    && test -d "/root/.cache/opengrep/${OPENGREP_VERSION#v}" \
-    && uv pip install --target="/root/.cache/opengrep/${OPENGREP_VERSION#v}" \
+    && pip3 install --target="/root/.cache/opengrep/${OPENGREP_VERSION}" \
        charset-normalizer==3.4.1 chardet==5.2.0 \
-    && apt-get purge -y curl \
+    && apt-get purge -y curl python3-pip \
     && apt-get autoremove -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,13 +22,23 @@ FROM node:22-slim AS runtime
 WORKDIR /app
 
 ARG OPENGREP_VERSION=v1.19.0
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends curl ca-certificates python3 python3-pip \
-    && pip3 install --break-system-packages charset-normalizer==3.4.1 chardet==5.2.0 \
+    && apt-get install -y --no-install-recommends curl ca-certificates python3 \
     && curl -fsSL -o /usr/local/bin/opengrep \
        "https://github.com/opengrep/opengrep/releases/download/${OPENGREP_VERSION}/opengrep_manylinux_x86" \
     && chmod +x /usr/local/bin/opengrep \
     && opengrep --version \
+    # force extraction of the bundled python env via an offline scan
+    && printf 'rules:\n  - id: prime-cache\n    pattern: TODO\n    message: prime\n    languages: [generic]\n    severity: INFO\n' > /tmp/prime.yml \
+    && printf 'prime\n' > /tmp/prime.txt \
+    && opengrep scan --config /tmp/prime.yml --quiet /tmp/prime.txt \
+    && rm /tmp/prime.yml /tmp/prime.txt \
+    && test -d "/root/.cache/opengrep/${OPENGREP_VERSION#v}" \
+    && uv pip install --target="/root/.cache/opengrep/${OPENGREP_VERSION#v}" \
+       charset-normalizer==3.4.1 chardet==5.2.0 \
     && apt-get purge -y curl \
     && apt-get autoremove -y \
     && apt-get clean \


### PR DESCRIPTION
## Summary
- Drops the `pip3 install --break-system-packages` workaround for `charset-normalizer` and `chardet`.
- Installs them directly into opengrep's bundled cache directory (`/root/.cache/opengrep/${OPENGREP_VERSION}`) using `pip3 install --target=...`, which sidesteps PEP 668 without `--break-system-packages`.
- `python3-pip` is installed for the build then purged alongside `curl` so it isn't carried into the final image.

## Notes
- Uses `${OPENGREP_VERSION}` (which already includes the `v` prefix) to match opengrep's actual cache path at `/root/.cache/opengrep/v1.19.0/`.
- opengrep's bundled Python treats this cache dir as a site-packages root (e.g. `requests` ships at `/root/.cache/opengrep/v1.19.0/requests/`), so dropping charset/chardet in as siblings puts them on the PYTHONPATH.

## Test plan
- [ ] `podman build .` succeeds.
- [ ] Running `opengrep scan` in the built image does not emit the `RequestsDependencyWarning: Unable to find acceptable character detection dependency` warning.
- [ ] `/root/.cache/opengrep/v1.19.0/charset_normalizer` and `.../chardet` exist in the final image.