### PR TITLE
Fix ADO suggestion anchors for single-line comments

### DIFF
--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -206,7 +206,7 @@ describe("AzureDevOpsProvider", () => {
       const firstBody = JSON.parse(fetchSpy.mock.calls[0][1].body);
       expect(firstBody.threadContext.filePath).toBe("/src/index.ts");
       expect(firstBody.threadContext.rightFileStart).toEqual({ line: 10, offset: 1 });
-      expect(firstBody.threadContext.rightFileEnd).toEqual({ line: 10, offset: 1 });
+      expect(firstBody.threadContext.rightFileEnd).toEqual({ line: 11, offset: 1 });
       expect(firstBody.comments[0].content).toContain("<!-- rusty-bot-review -->");
       expect(firstBody.comments[0].content).toContain("SQL injection risk");
       expect(firstBody.comments[0].content).toContain("```suggestion");
@@ -236,7 +236,7 @@ describe("AzureDevOpsProvider", () => {
 
       const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
       expect(body.threadContext.rightFileStart).toEqual({ line: 5, offset: 1 });
-      expect(body.threadContext.rightFileEnd).toEqual({ line: 12, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 13, offset: 1 });
     });
 
     it("falls back to line when endLine is null", async () => {
@@ -258,7 +258,30 @@ describe("AzureDevOpsProvider", () => {
 
       const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
       expect(body.threadContext.rightFileStart).toEqual({ line: 42, offset: 1 });
-      expect(body.threadContext.rightFileEnd).toEqual({ line: 42, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 43, offset: 1 });
+    });
+
+    it("anchors single-line suggestion so the full line is replaced, not inserted", async () => {
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      await provider.postInlineComments([
+        {
+          file: "pyproject.toml",
+          line: 58,
+          endLine: null,
+          severity: "warning",
+          category: "security",
+          message: "wildcard version pinning",
+          suggestedFix: 'cryptography = "^43.0.3"',
+        },
+      ]);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      const { rightFileStart, rightFileEnd } = body.threadContext;
+      // a zero-width range (start == end) makes ado insert the suggestion at col 1
+      // instead of replacing the line, concatenating the fix with the original content
+      expect(rightFileStart).not.toEqual(rightFileEnd);
+      expect(rightFileEnd.line).toBeGreaterThan(rightFileStart.line);
     });
 
     it("skips API call when findings array is empty", async () => {

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -300,6 +300,7 @@ export class AzureDevOpsProvider implements GitProvider {
 
     for (const finding of findings) {
       const content = `${BOT_MARKER}\n${formatInlineComment(finding)}`;
+      const endLine = finding.endLine ?? finding.line;
 
       await this.fetchApi(
         `${this.baseUrl}/pullRequests/${this.pullRequestId}/threads?${API_VERSION}`,
@@ -315,8 +316,11 @@ export class AzureDevOpsProvider implements GitProvider {
             ],
             threadContext: {
               filePath: `/${finding.file}`,
+              // anchor spans from col 1 of the first line to col 1 of the line after the
+              // last target line. zero-width ranges make ado treat ```suggestion blocks as
+              // insertions instead of replacements, concatenating the fix with the original
               rightFileStart: { line: finding.line, offset: 1 },
-              rightFileEnd: { line: finding.endLine ?? finding.line, offset: 1 },
+              rightFileEnd: { line: endLine + 1, offset: 1 },
             },
             status: 1,
           }),


### PR DESCRIPTION
## Summary
- Adjust Azure DevOps inline comment anchors so suggestion blocks cover the full target line range instead of using a zero-width range.
- This prevents ADO from inserting `suggestion` content at column 1 and concatenating it with the original line.
- Update tests to verify the thread context ends on the line after the target range.

## Testing
- Updated unit tests in `packages/azure-devops/src/__tests__/provider.test.ts` to assert non-zero-width anchors.
- Added a regression test for a single-line suggestion on `pyproject.toml`.
- Not run