### PR TITLE
Add GitHub Action mode with Docker-based runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/
 COPY packages/github/package.json ./packages/github/
+COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/
 COPY packages/dashboard/package.json ./packages/dashboard/
 
@@ -41,6 +42,7 @@ RUN corepack enable
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/
 COPY packages/github/package.json ./packages/github/
+COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/
 COPY packages/dashboard/package.json ./packages/dashboard/
 
@@ -48,6 +50,7 @@ RUN pnpm install --frozen-lockfile --prod --ignore-scripts
 
 COPY --from=build /app/packages/core/dist ./packages/core/dist
 COPY --from=build /app/packages/github/dist ./packages/github/dist
+COPY --from=build /app/packages/github-action/dist ./packages/github-action/dist
 COPY --from=build /app/packages/azure-devops/dist ./packages/azure-devops/dist
 COPY --from=build /app/packages/dashboard/dist ./packages/dashboard/dist
 
@@ -69,11 +72,17 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 COPY <<'EOF' /app/entrypoint.sh
 #!/bin/sh
 set -e
-if [ "$RUSTY_MODE" = "pipeline" ]; then
-  exec node /app/packages/azure-devops/dist/index.js
-else
-  exec node /app/packages/github/dist/server.js
-fi
+case "$RUSTY_MODE" in
+  pipeline)
+    exec node /app/packages/azure-devops/dist/index.js
+    ;;
+  github-action)
+    exec node /app/packages/github-action/dist/cli.js
+    ;;
+  *)
+    exec node /app/packages/github/dist/server.js
+    ;;
+esac
 EOF
 
 RUN chmod +x /app/entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **OpenGrep pre-scan** — runs [OpenGrep](https://opengrep.dev/) SAST on changed files before LLM review, feeds findings for triage (gracefully skipped when not installed)
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
 - **PR description generation** — optionally generate a structured PR description from the diff when the description is empty or a placeholder (off by default)
-- **GitHub + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps
+- **GitHub + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps, or a drop-in GitHub Action
 - **Web dashboard** — configure repos, review styles, focus areas, and view history
 
 ## Quick Start
@@ -62,6 +62,7 @@ packages/
 │   │   └── types.ts    # shared type definitions
 │   └── src/prompts/    # externalized prompt templates (styles + focus areas)
 ├── github/         # GitHub App webhook server + config API
+├── github-action/  # One-shot CLI driven by GitHub Actions env + event payload
 ├── azure-devops/   # Azure DevOps pipeline task (Docker entrypoint)
 └── dashboard/      # React SPA for configuration and review history
 ```
@@ -85,6 +86,58 @@ GITHUB_WEBHOOK_SECRET=your-secret
 
 6. Point the webhook URL to `https://your-domain/api/webhooks/github`
 7. Install the app on your repositories
+
+## GitHub Action Setup
+
+The repo publishes a Docker-based GitHub Action alongside the webhook server. Drop it into any repo to get AI review on pull requests without hosting anything — reviews run on the GitHub-hosted runner, authenticated with the built-in `GITHUB_TOKEN`.
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: read
+    steps:
+      - uses: jegork/ai-review@v1
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          review-style: balanced
+          focus-areas: security,bugs,performance
+          fail-on-critical: "true"
+```
+
+**Required permissions** (set on the job, not the whole workflow):
+
+- `pull-requests: write` — post summary and inline review comments
+- `issues: read` — read linked issues for ticket compliance
+- `contents: read` — read the diff and convention file from the target branch
+
+**Action inputs:**
+
+| Input | Default | Notes |
+|---|---|---|
+| `github-token` | `${{ github.token }}` | Built-in token has the right scopes when the `permissions:` block above is set |
+| `review-style` | `balanced` | One of `strict`, `balanced`, `lenient`, `roast`, `thorough` |
+| `focus-areas` | _all_ | Comma-separated: `security,performance,bugs,style,tests,docs` |
+| `ignore-patterns` | — | Comma-separated glob patterns (e.g. `*.lock,dist/**`) |
+| `llm-model` | `anthropic/claude-sonnet-4-20250514` | `provider/model` format |
+| `fail-on-critical` | `true` | Exit code 1 on critical findings — gates the PR |
+| `generate-description` | `false` | Generate a PR description when empty/placeholder |
+| `review-drafts` | `false` | Review draft PRs (skipped by default) |
+| `opengrep-rules` | `auto` | OpenGrep ruleset or config path |
+| `anthropic-api-key` / `openai-api-key` / `google-api-key` | — | Pass exactly one, matching your `llm-model` provider |
+| `jira-base-url` / `jira-email` / `jira-api-token` | — | Enable Jira ticket compliance |
+| `linear-api-key` | — | Enable Linear ticket compliance |
+
+The Action runs inside the published Docker image (`ghcr.io/jegork/ai-review:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
+
+**Skipped events:** the Action exits early with no error for `closed`/`labeled`/`unlabeled`/`assigned`/`unassigned` and for draft PRs (unless `review-drafts: "true"`).
 
 ## Azure DevOps Pipeline Setup
 
@@ -140,7 +193,8 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_REVIEW_STYLE` | default review style | `balanced` |
 | `RUSTY_FOCUS_AREAS` | comma-separated focus areas | all enabled |
 | `RUSTY_IGNORE_PATTERNS` | comma-separated glob patterns to skip | — |
-| `RUSTY_FAIL_ON_CRITICAL` | exit 1 on critical findings (pipeline mode) | `true` |
+| `RUSTY_FAIL_ON_CRITICAL` | exit 1 on critical findings (pipeline/action mode) | `true` |
+| `RUSTY_REVIEW_DRAFTS` | review draft PRs in GitHub Action mode | `false` |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,87 @@
+name: Rusty Bot
+description: AI-powered PR review with configurable styles, focus areas, OpenGrep SAST, and ticket compliance checks
+author: jegork
+branding:
+  icon: git-pull-request
+  color: orange
+
+inputs:
+  github-token:
+    description: Token used to read the PR diff and post review comments. Requires pull-requests:write, issues:read, contents:read
+    required: true
+    default: ${{ github.token }}
+  review-style:
+    description: "Review style: strict | balanced | lenient | roast | thorough"
+    required: false
+    default: balanced
+  focus-areas:
+    description: "Comma-separated focus areas (security,performance,bugs,style,tests,docs). Empty = all"
+    required: false
+    default: ""
+  ignore-patterns:
+    description: Comma-separated glob patterns to skip (e.g. "*.lock,dist/**")
+    required: false
+    default: ""
+  llm-model:
+    description: LLM model in provider/model format (e.g. anthropic/claude-sonnet-4-20250514)
+    required: false
+    default: anthropic/claude-sonnet-4-20250514
+  fail-on-critical:
+    description: Exit with code 1 when critical findings are produced (gates the PR)
+    required: false
+    default: "true"
+  generate-description:
+    description: Generate a PR description when it's empty or a placeholder
+    required: false
+    default: "false"
+  review-drafts:
+    description: Review draft PRs (skipped by default)
+    required: false
+    default: "false"
+  anthropic-api-key:
+    description: Anthropic API key
+    required: false
+  openai-api-key:
+    description: OpenAI API key
+    required: false
+  google-api-key:
+    description: Google Generative AI API key
+    required: false
+  opengrep-rules:
+    description: OpenGrep config string (ruleset or path)
+    required: false
+    default: auto
+  jira-base-url:
+    description: Jira instance URL for ticket compliance
+    required: false
+  jira-email:
+    description: Jira auth email
+    required: false
+  jira-api-token:
+    description: Jira API token
+    required: false
+  linear-api-key:
+    description: Linear API key
+    required: false
+
+runs:
+  using: docker
+  image: docker://ghcr.io/jegork/ai-review:latest
+  env:
+    RUSTY_MODE: github-action
+    GITHUB_TOKEN: ${{ inputs.github-token }}
+    RUSTY_REVIEW_STYLE: ${{ inputs.review-style }}
+    RUSTY_FOCUS_AREAS: ${{ inputs.focus-areas }}
+    RUSTY_IGNORE_PATTERNS: ${{ inputs.ignore-patterns }}
+    RUSTY_LLM_MODEL: ${{ inputs.llm-model }}
+    RUSTY_FAIL_ON_CRITICAL: ${{ inputs.fail-on-critical }}
+    RUSTY_GENERATE_DESCRIPTION: ${{ inputs.generate-description }}
+    RUSTY_REVIEW_DRAFTS: ${{ inputs.review-drafts }}
+    RUSTY_OPENGREP_RULES: ${{ inputs.opengrep-rules }}
+    ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
+    OPENAI_API_KEY: ${{ inputs.openai-api-key }}
+    GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.google-api-key }}
+    RUSTY_JIRA_BASE_URL: ${{ inputs.jira-base-url }}
+    RUSTY_JIRA_EMAIL: ${{ inputs.jira-email }}
+    RUSTY_JIRA_API_TOKEN: ${{ inputs.jira-api-token }}
+    RUSTY_LINEAR_API_KEY: ${{ inputs.linear-api-key }}

--- a/packages/github-action/package.json
+++ b/packages/github-action/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rusty-bot/github-action",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@rusty-bot/core": "workspace:*",
+    "@rusty-bot/github": "workspace:*",
+    "octokit": "^5.0.5",
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -135,6 +135,22 @@ describe("parseConfig", () => {
     expect(onlyCommas).toHaveLength(6);
   });
 
+  it("filters unknown focus area values out and keeps the valid ones", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FOCUS_AREAS: "security,bogus,bugs,YOLO" }),
+    });
+    expect(config.review.focusAreas).toEqual(["security", "bugs"]);
+  });
+
+  it("falls back to all focus areas when every provided value is invalid", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FOCUS_AREAS: "bogus,YOLO" }),
+    });
+    expect(config.review.focusAreas).toHaveLength(6);
+  });
+
   it("parses ignore patterns", () => {
     const config = parseConfig({
       event: BASE_EVENT,

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { parseConfig } from "../cli.js";
+import type { PullRequestEvent } from "../event.js";
+
+const BASE_EVENT: PullRequestEvent = {
+  action: "opened",
+  pull_request: { number: 42, draft: false },
+};
+
+function makeEnv(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
+  const defaults: Record<string, string> = {
+    GITHUB_TOKEN: "ghs_abc123",
+    GITHUB_REPOSITORY: "jegork/ai-review",
+  };
+  const merged: NodeJS.ProcessEnv = {};
+  for (const [k, v] of Object.entries(defaults)) {
+    if (!(k in overrides)) merged[k] = v;
+  }
+  for (const [k, v] of Object.entries(overrides)) {
+    if (v !== undefined) merged[k] = v;
+  }
+  return merged;
+}
+
+describe("parseConfig", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("parses a minimal valid config", () => {
+    const config = parseConfig({ event: BASE_EVENT, env: makeEnv() });
+    expect(config.owner).toBe("jegork");
+    expect(config.repo).toBe("ai-review");
+    expect(config.pullNumber).toBe(42);
+    expect(config.token).toBe("ghs_abc123");
+    expect(config.review.style).toBe("balanced");
+    expect(config.review.focusAreas).toEqual([
+      "security",
+      "performance",
+      "bugs",
+      "style",
+      "tests",
+      "docs",
+    ]);
+    expect(config.failOnCritical).toBe(true);
+    expect(config.generateDescription).toBe(false);
+  });
+
+  it("throws when GITHUB_TOKEN is missing", () => {
+    expect(() =>
+      parseConfig({ event: BASE_EVENT, env: makeEnv({ GITHUB_TOKEN: undefined }) }),
+    ).toThrow("GITHUB_TOKEN");
+  });
+
+  it("throws when GITHUB_REPOSITORY is missing", () => {
+    expect(() =>
+      parseConfig({ event: BASE_EVENT, env: makeEnv({ GITHUB_REPOSITORY: undefined }) }),
+    ).toThrow("GITHUB_REPOSITORY");
+  });
+
+  it("lists all missing vars when both are absent", () => {
+    expect(() =>
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ GITHUB_TOKEN: undefined, GITHUB_REPOSITORY: undefined }),
+      }),
+    ).toThrow(/GITHUB_TOKEN, GITHUB_REPOSITORY/);
+  });
+
+  it("falls back to INPUT_GITHUB_TOKEN when GITHUB_TOKEN is not set", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ GITHUB_TOKEN: undefined, INPUT_GITHUB_TOKEN: "ghp_fallback" }),
+    });
+    expect(config.token).toBe("ghp_fallback");
+  });
+
+  it("throws when GITHUB_REPOSITORY is malformed", () => {
+    expect(() =>
+      parseConfig({ event: BASE_EVENT, env: makeEnv({ GITHUB_REPOSITORY: "no-slash" }) }),
+    ).toThrow('must be in the form "owner/repo"');
+  });
+
+  it("throws when the pull request number cannot be determined", () => {
+    expect(() => parseConfig({ event: { action: "synchronize" }, env: makeEnv() })).toThrow(
+      "could not determine pull request number",
+    );
+  });
+
+  it("uses top-level event.number when pull_request is absent", () => {
+    const config = parseConfig({ event: { action: "opened", number: 7 }, env: makeEnv() });
+    expect(config.pullNumber).toBe(7);
+  });
+
+  it("parses review style and rejects invalid values", () => {
+    expect(
+      parseConfig({ event: BASE_EVENT, env: makeEnv({ RUSTY_REVIEW_STYLE: "strict" }) }).review
+        .style,
+    ).toBe("strict");
+
+    expect(() =>
+      parseConfig({ event: BASE_EVENT, env: makeEnv({ RUSTY_REVIEW_STYLE: "bogus" }) }),
+    ).toThrow("invalid review style: bogus");
+  });
+
+  it("parses focus areas and filters empties / whitespace", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FOCUS_AREAS: "security, , performance ," }),
+    });
+    expect(config.review.focusAreas).toEqual(["security", "performance"]);
+  });
+
+  it("defaults focus areas to all six when RUSTY_FOCUS_AREAS is absent or empty", () => {
+    const defaulted = parseConfig({ event: BASE_EVENT, env: makeEnv() }).review.focusAreas;
+    expect(defaulted).toHaveLength(6);
+
+    const emptyString = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FOCUS_AREAS: "" }),
+    }).review.focusAreas;
+    expect(emptyString).toHaveLength(6);
+
+    const onlyCommas = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FOCUS_AREAS: ",,," }),
+    }).review.focusAreas;
+    expect(onlyCommas).toHaveLength(6);
+  });
+
+  it("parses ignore patterns", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_IGNORE_PATTERNS: "*.lock,dist/**" }),
+    });
+    expect(config.review.ignorePatterns).toEqual(["*.lock", "dist/**"]);
+  });
+
+  it("respects RUSTY_FAIL_ON_CRITICAL=false", () => {
+    const config = parseConfig({
+      event: BASE_EVENT,
+      env: makeEnv({ RUSTY_FAIL_ON_CRITICAL: "false" }),
+    });
+    expect(config.failOnCritical).toBe(false);
+  });
+
+  it("treats any non-false RUSTY_FAIL_ON_CRITICAL as true", () => {
+    for (const value of ["true", "1", "yes", "anything"]) {
+      const config = parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_FAIL_ON_CRITICAL: value }),
+      });
+      expect(config.failOnCritical).toBe(true);
+    }
+  });
+
+  it("enables description generation only on exact 'true'", () => {
+    expect(
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_GENERATE_DESCRIPTION: "true" }),
+      }).generateDescription,
+    ).toBe(true);
+
+    expect(
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_GENERATE_DESCRIPTION: "1" }),
+      }).generateDescription,
+    ).toBe(false);
+
+    expect(parseConfig({ event: BASE_EVENT, env: makeEnv() }).generateDescription).toBe(false);
+  });
+});

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -11,6 +11,7 @@ function makeEnv(overrides: Record<string, string | undefined> = {}): NodeJS.Pro
   const defaults: Record<string, string> = {
     GITHUB_TOKEN: "ghs_abc123",
     GITHUB_REPOSITORY: "jegork/ai-review",
+    ANTHROPIC_API_KEY: "sk-ant-test",
   };
   const merged: NodeJS.ProcessEnv = {};
   for (const [k, v] of Object.entries(defaults)) {
@@ -158,6 +159,73 @@ describe("parseConfig", () => {
       });
       expect(config.failOnCritical).toBe(true);
     }
+  });
+
+  describe("LLM credential validation", () => {
+    it("throws when the model provider's API key env var is missing", () => {
+      expect(() =>
+        parseConfig({ event: BASE_EVENT, env: makeEnv({ ANTHROPIC_API_KEY: undefined }) }),
+      ).toThrow(/ANTHROPIC_API_KEY is missing/);
+    });
+
+    it("validates against the provider prefix of RUSTY_LLM_MODEL, not the default", () => {
+      expect(() =>
+        parseConfig({
+          event: BASE_EVENT,
+          env: makeEnv({
+            ANTHROPIC_API_KEY: undefined,
+            RUSTY_LLM_MODEL: "openai/gpt-4o",
+          }),
+        }),
+      ).toThrow(/OPENAI_API_KEY is missing/);
+
+      expect(() =>
+        parseConfig({
+          event: BASE_EVENT,
+          env: makeEnv({
+            ANTHROPIC_API_KEY: undefined,
+            RUSTY_LLM_MODEL: "openai/gpt-4o",
+            OPENAI_API_KEY: "sk-openai",
+          }),
+        }),
+      ).not.toThrow();
+    });
+
+    it("skips key validation when RUSTY_LLM_BASE_URL is set (custom endpoint)", () => {
+      expect(() =>
+        parseConfig({
+          event: BASE_EVENT,
+          env: makeEnv({
+            ANTHROPIC_API_KEY: undefined,
+            RUSTY_LLM_BASE_URL: "http://localhost:4000/v1",
+          }),
+        }),
+      ).not.toThrow();
+    });
+
+    it("skips key validation for Azure managed identity", () => {
+      expect(() =>
+        parseConfig({
+          event: BASE_EVENT,
+          env: makeEnv({
+            ANTHROPIC_API_KEY: undefined,
+            RUSTY_AZURE_RESOURCE_NAME: "my-resource",
+          }),
+        }),
+      ).not.toThrow();
+    });
+
+    it("skips key validation for unknown provider prefixes (router-handled)", () => {
+      expect(() =>
+        parseConfig({
+          event: BASE_EVENT,
+          env: makeEnv({
+            ANTHROPIC_API_KEY: undefined,
+            RUSTY_LLM_MODEL: "requesty/google/gemini-3.1-flash-lite-preview",
+          }),
+        }),
+      ).not.toThrow();
+    });
   });
 
   it("enables description generation only on exact 'true'", () => {

--- a/packages/github-action/src/__tests__/event.test.ts
+++ b/packages/github-action/src/__tests__/event.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtemp, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readEventPayload, parseOwnerRepo, extractPullNumber, shouldSkipEvent } from "../event.js";
+
+describe("parseOwnerRepo", () => {
+  it("splits a valid owner/repo string", () => {
+    expect(parseOwnerRepo("jegork/ai-review")).toEqual({ owner: "jegork", repo: "ai-review" });
+  });
+
+  it("throws on missing slash", () => {
+    expect(() => parseOwnerRepo("oops")).toThrow(
+      'GITHUB_REPOSITORY must be in the form "owner/repo"',
+    );
+  });
+
+  it("throws on empty halves", () => {
+    expect(() => parseOwnerRepo("/repo")).toThrow();
+    expect(() => parseOwnerRepo("owner/")).toThrow();
+  });
+
+  it("throws on more than one slash", () => {
+    expect(() => parseOwnerRepo("a/b/c")).toThrow();
+  });
+});
+
+describe("extractPullNumber", () => {
+  it("prefers pull_request.number over top-level number", () => {
+    expect(
+      extractPullNumber({
+        action: "opened",
+        number: 99,
+        pull_request: { number: 42 },
+      }),
+    ).toBe(42);
+  });
+
+  it("falls back to top-level number", () => {
+    expect(extractPullNumber({ action: "opened", number: 7 })).toBe(7);
+  });
+
+  it("returns null when neither is present", () => {
+    expect(extractPullNumber({ action: "synchronize" })).toBeNull();
+  });
+});
+
+describe("shouldSkipEvent", () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it("skips closed PRs", () => {
+    const result = shouldSkipEvent({ action: "closed", pull_request: { number: 1 } });
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain("closed");
+  });
+
+  it("skips label-only changes", () => {
+    expect(shouldSkipEvent({ action: "labeled", pull_request: { number: 1 } }).skip).toBe(true);
+    expect(shouldSkipEvent({ action: "unlabeled", pull_request: { number: 1 } }).skip).toBe(true);
+  });
+
+  it("skips draft PRs by default", () => {
+    delete process.env.RUSTY_REVIEW_DRAFTS;
+    const result = shouldSkipEvent({
+      action: "opened",
+      pull_request: { number: 1, draft: true },
+    });
+    expect(result.skip).toBe(true);
+    expect(result.reason).toContain("draft");
+  });
+
+  it("reviews draft PRs when RUSTY_REVIEW_DRAFTS=true", () => {
+    process.env.RUSTY_REVIEW_DRAFTS = "true";
+    const result = shouldSkipEvent({
+      action: "opened",
+      pull_request: { number: 1, draft: true },
+    });
+    expect(result.skip).toBe(false);
+  });
+
+  it("does not skip on opened/synchronize/reopened for non-draft PRs", () => {
+    for (const action of ["opened", "synchronize", "reopened"]) {
+      expect(shouldSkipEvent({ action, pull_request: { number: 1, draft: false } }).skip).toBe(
+        false,
+      );
+    }
+  });
+
+  it("does not skip when draft flag is missing", () => {
+    expect(shouldSkipEvent({ action: "opened", pull_request: { number: 1 } }).skip).toBe(false);
+  });
+});
+
+describe("readEventPayload", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), "github-action-test-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("reads and parses a pull_request event payload", async () => {
+    const path = join(dir, "event.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        action: "opened",
+        number: 42,
+        pull_request: {
+          number: 42,
+          draft: false,
+          head: { ref: "feat", sha: "abc" },
+          base: { ref: "main", sha: "def" },
+        },
+        repository: { name: "ai-review", owner: { login: "jegork" } },
+      }),
+    );
+
+    const event = await readEventPayload(path);
+    expect(event.pull_request?.number).toBe(42);
+    expect(event.repository?.owner.login).toBe("jegork");
+  });
+
+  it("tolerates unknown extra fields (forward-compat)", async () => {
+    const path = join(dir, "event.json");
+    await writeFile(
+      path,
+      JSON.stringify({
+        action: "opened",
+        pull_request: { number: 1, _new_field_we_dont_know: "hi" },
+        some_new_top_level: true,
+      }),
+    );
+
+    const event = await readEventPayload(path);
+    expect(event.pull_request?.number).toBe(1);
+  });
+
+  it("throws when JSON is malformed", async () => {
+    const path = join(dir, "event.json");
+    await writeFile(path, "{not json");
+    await expect(readEventPayload(path)).rejects.toThrow();
+  });
+
+  it("throws when required shape is violated (pull_request.number as string)", async () => {
+    const path = join(dir, "event.json");
+    await writeFile(path, JSON.stringify({ pull_request: { number: "42" } }));
+    await expect(readEventPayload(path)).rejects.toThrow();
+  });
+
+  it("throws when file does not exist", async () => {
+    await expect(readEventPayload(join(dir, "missing.json"))).rejects.toThrow();
+  });
+});

--- a/packages/github-action/src/__tests__/event.test.ts
+++ b/packages/github-action/src/__tests__/event.test.ts
@@ -146,7 +146,7 @@ describe("readEventPayload", () => {
   it("throws when JSON is malformed", async () => {
     const path = join(dir, "event.json");
     await writeFile(path, "{not json");
-    await expect(readEventPayload(path)).rejects.toThrow();
+    await expect(readEventPayload(path)).rejects.toThrow(SyntaxError);
   });
 
   it("throws when required shape is violated (pull_request.number as string)", async () => {

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -109,9 +109,20 @@ export function parseConfig({ event, env = process.env }: ParseConfigOptions): A
     throw new Error(`invalid review style: ${reviewStyle}`);
   }
 
-  const focusAreas = (env.RUSTY_FOCUS_AREAS?.split(",")
-    .map((s) => s.trim())
-    .filter(Boolean) ?? []) as FocusArea[];
+  const rawFocusAreas =
+    env.RUSTY_FOCUS_AREAS?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  const focusAreas = rawFocusAreas.filter((area): area is FocusArea =>
+    (ALL_FOCUS_AREAS as string[]).includes(area),
+  );
+  const invalidFocusAreas = rawFocusAreas.filter((area) => !focusAreas.includes(area as FocusArea));
+  if (invalidFocusAreas.length > 0) {
+    log.warn(
+      { invalid: invalidFocusAreas, allowed: ALL_FOCUS_AREAS },
+      "ignoring unknown RUSTY_FOCUS_AREAS values",
+    );
+  }
   const ignorePatterns =
     env.RUSTY_IGNORE_PATTERNS?.split(",")
       .map((s) => s.trim())

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -57,17 +57,42 @@ interface ParseConfigOptions {
   env?: NodeJS.ProcessEnv;
 }
 
+const PROVIDER_API_KEY_ENV: Record<string, string> = {
+  anthropic: "ANTHROPIC_API_KEY",
+  openai: "OPENAI_API_KEY",
+  google: "GOOGLE_GENERATIVE_AI_API_KEY",
+  "azure-openai": "AZURE_OPENAI_API_KEY",
+};
+
+function assertLlmCredentials(env: NodeJS.ProcessEnv): void {
+  if (env.RUSTY_LLM_BASE_URL || env.RUSTY_AZURE_RESOURCE_NAME) {
+    return;
+  }
+
+  const model = env.RUSTY_LLM_MODEL ?? "anthropic/claude-sonnet-4-20250514";
+  const provider = model.split("/")[0]?.toLowerCase();
+  if (!provider) return;
+
+  const requiredKey = PROVIDER_API_KEY_ENV[provider];
+  if (!requiredKey || env[requiredKey]) return;
+
+  throw new Error(
+    `RUSTY_LLM_MODEL is set to "${model}" but ${requiredKey} is missing. Provide the matching API key, or set RUSTY_LLM_BASE_URL / RUSTY_AZURE_RESOURCE_NAME for alternative providers.`,
+  );
+}
+
 export function parseConfig({ event, env = process.env }: ParseConfigOptions): ActionConfig {
   const token = env.GITHUB_TOKEN ?? env.INPUT_GITHUB_TOKEN;
   const repository = env.GITHUB_REPOSITORY;
 
-  const missing: string[] = [];
-  if (!token) missing.push("GITHUB_TOKEN");
-  if (!repository) missing.push("GITHUB_REPOSITORY");
-  if (missing.length > 0) {
+  if (!token || !repository) {
+    const missing: string[] = [];
+    if (!token) missing.push("GITHUB_TOKEN");
+    if (!repository) missing.push("GITHUB_REPOSITORY");
     throw new Error(`missing required env vars: ${missing.join(", ")}`);
   }
-  if (!token || !repository) throw new Error("unreachable");
+
+  assertLlmCredentials(env);
 
   const { owner, repo } = parseOwnerRepo(repository);
 

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -1,0 +1,369 @@
+import { Octokit } from "octokit";
+import type { FocusArea, ReviewConfig, TicketProvider, TicketRef } from "@rusty-bot/core";
+import {
+  ReviewStyleSchema,
+  filterFiles,
+  stripDeletionOnlyHunks,
+  expandContext,
+  summarizeLanguages,
+  extractTicketRefs,
+  resolveTicketsWithStatus,
+  fetchConventionFile,
+  GitHubTicketProvider,
+  JiraTicketProvider,
+  LinearTicketProvider,
+  runMultiCallReview,
+  runCascadeReview,
+  formatSummaryComment,
+  loadMcpServerConfigsFromEnv,
+  logger,
+  flushLogger,
+  isCascadeEnabled,
+  runTriage,
+  splitByClassification,
+  runOpenGrep,
+  extractChangedFilePaths,
+  generatePRDescription,
+  shouldGenerateDescription,
+  parseDiff,
+} from "@rusty-bot/core";
+import { GitHubProvider, createOctokitIssueFetcher } from "@rusty-bot/github";
+import {
+  readEventPayload,
+  parseOwnerRepo,
+  extractPullNumber,
+  shouldSkipEvent,
+  type PullRequestEvent,
+} from "./event.js";
+
+const log = logger.child({ package: "github-action" });
+
+const MAX_TOKENS = 60_000;
+const ALL_FOCUS_AREAS: FocusArea[] = ["security", "performance", "bugs", "style", "tests", "docs"];
+
+export interface ActionConfig {
+  octokit: Octokit;
+  owner: string;
+  repo: string;
+  pullNumber: number;
+  token: string;
+  review: ReviewConfig;
+  failOnCritical: boolean;
+  generateDescription: boolean;
+}
+
+interface ParseConfigOptions {
+  event: PullRequestEvent;
+  env?: NodeJS.ProcessEnv;
+}
+
+export function parseConfig({ event, env = process.env }: ParseConfigOptions): ActionConfig {
+  const token = env.GITHUB_TOKEN ?? env.INPUT_GITHUB_TOKEN;
+  const repository = env.GITHUB_REPOSITORY;
+
+  const missing: string[] = [];
+  if (!token) missing.push("GITHUB_TOKEN");
+  if (!repository) missing.push("GITHUB_REPOSITORY");
+  if (missing.length > 0) {
+    throw new Error(`missing required env vars: ${missing.join(", ")}`);
+  }
+  if (!token || !repository) throw new Error("unreachable");
+
+  const { owner, repo } = parseOwnerRepo(repository);
+
+  const pullNumber = extractPullNumber(event);
+  if (pullNumber == null) {
+    throw new Error(
+      "could not determine pull request number from event payload — is this a pull_request event?",
+    );
+  }
+
+  const reviewStyle = env.RUSTY_REVIEW_STYLE ?? "balanced";
+  const parsedStyle = ReviewStyleSchema.safeParse(reviewStyle);
+  if (!parsedStyle.success) {
+    throw new Error(`invalid review style: ${reviewStyle}`);
+  }
+
+  const focusAreas = (env.RUSTY_FOCUS_AREAS?.split(",")
+    .map((s) => s.trim())
+    .filter(Boolean) ?? []) as FocusArea[];
+  const ignorePatterns =
+    env.RUSTY_IGNORE_PATTERNS?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  const failOnCritical = env.RUSTY_FAIL_ON_CRITICAL !== "false";
+  const generateDescription = env.RUSTY_GENERATE_DESCRIPTION === "true";
+
+  const octokit = new Octokit({ auth: token });
+
+  return {
+    octokit,
+    owner,
+    repo,
+    pullNumber,
+    token,
+    review: {
+      style: parsedStyle.data,
+      focusAreas: focusAreas.length > 0 ? focusAreas : ALL_FOCUS_AREAS,
+      ignorePatterns,
+    },
+    failOnCritical,
+    generateDescription,
+  };
+}
+
+function buildTicketProviders(
+  octokit: Octokit,
+  owner: string,
+  repo: string,
+  env: NodeJS.ProcessEnv,
+): Map<string, TicketProvider> {
+  const providers = new Map<string, TicketProvider>();
+
+  providers.set(
+    "github",
+    new GitHubTicketProvider({
+      owner,
+      repo,
+      issueFetcher: createOctokitIssueFetcher(octokit),
+    }),
+  );
+
+  const jiraUrl = env.RUSTY_JIRA_BASE_URL;
+  const jiraEmail = env.RUSTY_JIRA_EMAIL;
+  const jiraToken = env.RUSTY_JIRA_API_TOKEN;
+  if (jiraUrl && jiraEmail && jiraToken) {
+    providers.set(
+      "jira",
+      new JiraTicketProvider({ baseUrl: jiraUrl, email: jiraEmail, apiToken: jiraToken }),
+    );
+  }
+
+  const linearKey = env.RUSTY_LINEAR_API_KEY;
+  if (linearKey) {
+    providers.set("linear", new LinearTicketProvider({ apiKey: linearKey }));
+  }
+
+  return providers;
+}
+
+export async function runAction(config: ActionConfig): Promise<number> {
+  const { octokit, owner, repo, pullNumber, review: reviewConfig, failOnCritical } = config;
+
+  const provider = new GitHubProvider({ octokit, owner, repo, pullNumber });
+
+  const metadata = await provider.getPRMetadata();
+  log.info(
+    {
+      owner,
+      repo,
+      prId: metadata.id,
+      source: metadata.sourceBranch,
+      target: metadata.targetBranch,
+    },
+    "reviewing PR",
+  );
+
+  const conventionFile = await fetchConventionFile(
+    (path, ref) => provider.getFileContent(path, ref),
+    metadata.targetBranch,
+  );
+  if (conventionFile) {
+    reviewConfig.conventionFile = conventionFile;
+  }
+
+  await provider.deleteExistingBotComments();
+
+  const rawDiff = await provider.getRawDiff();
+  const rawPatches = parseDiff(rawDiff);
+  const filtered = filterFiles(rawPatches, reviewConfig.ignorePatterns);
+  const reviewable = stripDeletionOnlyHunks(filtered);
+  const skippedCount = rawPatches.length - reviewable.length;
+  log.info(
+    { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
+    "files changed",
+  );
+
+  if (config.generateDescription) {
+    try {
+      if (shouldGenerateDescription(metadata.description)) {
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
+        await provider.updatePRDescription(descResult.markdown);
+        metadata.description = descResult.markdown;
+        log.info(
+          { model: descResult.modelUsed, tokens: descResult.tokenCount },
+          "generated PR description",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to generate PR description, continuing with review");
+    }
+  }
+
+  const ticketRefs = extractTicketRefs(metadata.description, metadata.sourceBranch);
+
+  let linkedRefs: TicketRef[] = [];
+  try {
+    const linkedNumbers = await provider.getLinkedIssueNumbers();
+    const existingIds = new Set(ticketRefs.filter((r) => r.source === "github").map((r) => r.id));
+    linkedRefs = linkedNumbers
+      .filter((n) => !existingIds.has(String(n)))
+      .map((n) => ({ id: String(n), source: "github" }));
+  } catch (err) {
+    log.warn({ err }, "failed to fetch linked issues from github, continuing with extracted refs");
+  }
+  const allRefs = [...ticketRefs, ...linkedRefs];
+
+  const ticketProviders = buildTicketProviders(octokit, owner, repo, process.env);
+  const { tickets, status: ticketResolution } = await resolveTicketsWithStatus(
+    allRefs,
+    ticketProviders,
+  );
+
+  const languageSummary = summarizeLanguages(reviewable);
+  const mcpServers = await loadMcpServerConfigsFromEnv();
+
+  const openGrepResult = await runOpenGrep(extractChangedFilePaths(reviewable), {
+    config: process.env.RUSTY_OPENGREP_RULES ?? "auto",
+  });
+  const openGrepFindings = openGrepResult.findings.length > 0 ? openGrepResult.findings : undefined;
+  if (openGrepResult.available) {
+    log.info({ findingCount: openGrepResult.findings.length }, "opengrep pre-scan complete");
+  }
+
+  let review;
+
+  if (isCascadeEnabled()) {
+    log.info({ fileCount: reviewable.length }, "cascade enabled, running triage");
+
+    let triageResult;
+    try {
+      triageResult = await runTriage(reviewable);
+    } catch (err) {
+      log.warn({ err }, "triage failed, falling back to full review");
+    }
+
+    if (triageResult) {
+      const { skip, skim, deepReview } = splitByClassification(reviewable, triageResult.files);
+      log.info(
+        { skipped: skip.length, skimmed: skim.length, deepReview: deepReview.length },
+        "triage classification",
+      );
+
+      const expandedDeep = await expandContext(deepReview, (path) =>
+        provider.getFileContent(path, metadata.sourceBranch),
+      );
+
+      review = await runCascadeReview(
+        skim,
+        expandedDeep,
+        reviewConfig,
+        metadata,
+        tickets.length > 0 ? tickets : undefined,
+        {
+          provider,
+          sourceRef: metadata.sourceBranch,
+          languageSummary,
+          mcpServers,
+          maxTokens: MAX_TOKENS,
+          openGrepFindings,
+        },
+      );
+
+      review.triageStats = {
+        filesSkipped: skip.length,
+        filesSkimmed: skim.length,
+        filesDeepReviewed: deepReview.length,
+        triageModelUsed: triageResult.modelUsed,
+        triageTokenCount: triageResult.tokenCount,
+      };
+    }
+  }
+
+  if (!review) {
+    const expanded = await expandContext(reviewable, (path) =>
+      provider.getFileContent(path, metadata.sourceBranch),
+    );
+
+    review = await runMultiCallReview(
+      expanded,
+      reviewConfig,
+      metadata,
+      tickets.length > 0 ? tickets : undefined,
+      {
+        provider,
+        sourceRef: metadata.sourceBranch,
+        languageSummary,
+        mcpServers,
+        maxTokens: MAX_TOKENS,
+        openGrepFindings,
+      },
+    );
+  }
+
+  review.openGrepStats = {
+    available: openGrepResult.available,
+    findingCount: openGrepResult.rawCount,
+    ...(openGrepResult.error ? { error: openGrepResult.error } : {}),
+  };
+
+  const criticalCount = review.findings.filter((f) => f.severity === "critical").length;
+  const warningCount = review.findings.filter((f) => f.severity === "warning").length;
+  log.info(
+    {
+      findings: review.findings.length,
+      critical: criticalCount,
+      warnings: warningCount,
+      recommendation: review.recommendation,
+    },
+    "review complete",
+  );
+
+  const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
+  await provider.postSummaryComment(summaryMarkdown);
+
+  const inlineFindings = review.findings.filter((f) => f.line > 0);
+  if (inlineFindings.length > 0) {
+    await provider.postInlineComments(inlineFindings);
+  }
+
+  log.info({ inlineComments: inlineFindings.length }, "posted summary and inline comments");
+
+  if (failOnCritical && criticalCount > 0) {
+    log.warn({ criticalCount }, "failing action due to critical issues");
+    return 1;
+  }
+  return 0;
+}
+
+async function main(): Promise<void> {
+  const eventPath = process.env.GITHUB_EVENT_PATH;
+  if (!eventPath) {
+    throw new Error("GITHUB_EVENT_PATH is not set — this CLI must run inside a GitHub Action");
+  }
+
+  const event = await readEventPayload(eventPath);
+
+  const skip = shouldSkipEvent(event);
+  if (skip.skip) {
+    log.info({ reason: skip.reason }, "skipping review");
+    return;
+  }
+
+  const config = parseConfig({ event });
+  const exitCode = await runAction(config);
+  if (exitCode !== 0) {
+    flushLogger(() => process.exit(exitCode));
+    // keep the event loop alive until the logger drains
+    await new Promise(() => undefined);
+  }
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectRun) {
+  main().catch((err: unknown) => {
+    log.fatal({ err }, "fatal error");
+    flushLogger(() => process.exit(2));
+  });
+}

--- a/packages/github-action/src/event.ts
+++ b/packages/github-action/src/event.ts
@@ -1,0 +1,58 @@
+import { readFile } from "node:fs/promises";
+import { z } from "zod";
+
+export const PullRequestEventSchema = z.object({
+  action: z.string().optional(),
+  number: z.number().optional(),
+  pull_request: z
+    .object({
+      number: z.number(),
+      draft: z.boolean().optional(),
+      head: z.object({ ref: z.string(), sha: z.string() }).optional(),
+      base: z.object({ ref: z.string(), sha: z.string() }).optional(),
+    })
+    .optional(),
+  repository: z
+    .object({
+      name: z.string(),
+      owner: z.object({ login: z.string() }),
+    })
+    .optional(),
+});
+
+export type PullRequestEvent = z.infer<typeof PullRequestEventSchema>;
+
+export async function readEventPayload(eventPath: string): Promise<PullRequestEvent> {
+  const raw = await readFile(eventPath, "utf-8");
+  const parsed: unknown = JSON.parse(raw);
+  return PullRequestEventSchema.parse(parsed);
+}
+
+export function parseOwnerRepo(githubRepository: string): { owner: string; repo: string } {
+  const parts = githubRepository.split("/");
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error(
+      `GITHUB_REPOSITORY must be in the form "owner/repo", got "${githubRepository}"`,
+    );
+  }
+  return { owner: parts[0], repo: parts[1] };
+}
+
+export function extractPullNumber(event: PullRequestEvent): number | null {
+  return event.pull_request?.number ?? event.number ?? null;
+}
+
+const SKIPPED_PR_ACTIONS = new Set(["closed", "labeled", "unlabeled", "assigned", "unassigned"]);
+
+export function shouldSkipEvent(event: PullRequestEvent): {
+  skip: boolean;
+  reason?: string;
+} {
+  if (event.action && SKIPPED_PR_ACTIONS.has(event.action)) {
+    return { skip: true, reason: `action "${event.action}" is not reviewed` };
+  }
+  if (event.pull_request?.draft === true && process.env.RUSTY_REVIEW_DRAFTS !== "true") {
+    return { skip: true, reason: "PR is a draft (set RUSTY_REVIEW_DRAFTS=true to review drafts)" };
+  }
+  return { skip: false };
+}

--- a/packages/github-action/src/index.ts
+++ b/packages/github-action/src/index.ts
@@ -1,0 +1,9 @@
+export { parseConfig, runAction } from "./cli.js";
+export {
+  readEventPayload,
+  parseOwnerRepo,
+  extractPullNumber,
+  shouldSkipEvent,
+  PullRequestEventSchema,
+  type PullRequestEvent,
+} from "./event.js";

--- a/packages/github-action/tsconfig.json
+++ b/packages/github-action/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }, { "path": "../github" }]
+}

--- a/packages/github-action/vitest.config.ts
+++ b/packages/github-action/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,21 @@ importers:
         specifier: ^5.0.5
         version: 5.0.5
 
+  packages/github-action:
+    dependencies:
+      '@rusty-bot/core':
+        specifier: workspace:*
+        version: link:../core
+      '@rusty-bot/github':
+        specifier: workspace:*
+        version: link:../github
+      octokit:
+        specifier: ^5.0.5
+        version: 5.0.5
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
 packages:
 
   '@a2a-js/sdk@0.2.5':
@@ -1850,7 +1865,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,6 +18,7 @@
   "references": [
     { "path": "packages/core" },
     { "path": "packages/github" },
+    { "path": "packages/github-action" },
     { "path": "packages/azure-devops" }
   ]
 }


### PR DESCRIPTION
## Summary
- New `@rusty-bot/github-action` workspace: a one-shot CLI driven by the GitHub Actions event payload and authenticated with the built-in `GITHUB_TOKEN`.
- `action.yml` at the repo root publishes the action as a Docker-based step pointing at `ghcr.io/jegork/ai-review:latest`, exposing review style, focus areas, ignore patterns, model override, fail-on-critical, description generation, draft handling, OpenGrep rules, LLM keys, and Jira/Linear credentials as inputs.
- Dockerfile entrypoint now switches on `RUSTY_MODE` (`pipeline` / `github-action` / default webhook server) so the same image serves all three deployment modes.
- README gets a GitHub Action Setup section with the minimal workflow, required job permissions, and an inputs reference table.

## Test plan
- [x] `pnpm --filter @rusty-bot/github-action test` — 33 tests across `cli.test.ts` and `event.test.ts` (config parsing, env resolution, skip-event logic)
- [x] Repo-wide `pnpm build` succeeds with the new project reference in `tsconfig.json`
- [ ] Smoke test the published image (`ghcr.io/jegork/ai-review:latest`) against a real PR once the image is tagged with the action changes
- [ ] Consume the action from a sibling repo via `uses: jegork/ai-review@v1` and confirm summary + inline comments post with the default `GITHUB_TOKEN` permissions