### PR TITLE
Anchor ADO suggestions within target line to preserve newline

### DIFF
--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -32,6 +32,17 @@ function mockFetchResponse(body: unknown, ok = true, status = 200): Response {
   } as Response;
 }
 
+function mockFileContentResponse(body: string, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 400,
+    statusText: ok ? "OK" : "Bad Request",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as Response;
+}
+
 describe("AzureDevOpsProvider", () => {
   let provider: AzureDevOpsProvider;
   let fetchSpy: ReturnType<typeof vi.fn>;
@@ -281,7 +292,176 @@ describe("AzureDevOpsProvider", () => {
       // a zero-width range (start == end) makes ado insert the suggestion at col 1
       // instead of replacing the line, concatenating the fix with the original content
       expect(rightFileStart).not.toEqual(rightFileEnd);
-      expect(rightFileEnd.line).toBeGreaterThan(rightFileStart.line);
+    });
+
+    it("anchors multi-line suggestion to the end of the last line when content is cached", async () => {
+      const fileContent = [
+        "const plugins = [",
+        "  'react',",
+        "  'vitest',",
+        "  'unused',",
+        "];",
+      ].join("\n");
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          pullRequestId: 42,
+          title: "",
+          description: "",
+          createdBy: { displayName: "U", uniqueName: "u@e.com" },
+          sourceRefName: "refs/heads/feature",
+          targetRefName: "refs/heads/main",
+          repository: { webUrl: "" },
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({ value: [{ id: 1 }] }));
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          changeEntries: [
+            { changeType: "edit", item: { path: "/src/config.ts", gitObjectType: "blob" } },
+          ],
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse(fileContent));
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("old"));
+
+      await provider.getDiff();
+
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      await provider.postInlineComments([
+        {
+          file: "src/config.ts",
+          line: 2,
+          endLine: 4,
+          severity: "warning",
+          category: "bugs",
+          message: "drop unused plugin entry",
+          suggestedFix: "  'react',\n  'vitest',",
+        },
+      ]);
+
+      const threadCall = fetchSpy.mock.calls.find((args: unknown[]) => {
+        const init = args[1] as RequestInit | undefined;
+        return init?.method === "POST" && (args[0] as string).includes("/threads?");
+      });
+      const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
+      expect(body.threadContext.rightFileStart).toEqual({ line: 2, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({
+        line: 4,
+        offset: "  'unused',".length,
+      });
+    });
+
+    it("falls back to next-line anchor for empty target lines to avoid a zero-width range", async () => {
+      const fileContent = ["first", "", "third"].join("\n");
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          pullRequestId: 42,
+          title: "",
+          description: "",
+          createdBy: { displayName: "U", uniqueName: "u@e.com" },
+          sourceRefName: "refs/heads/feature",
+          targetRefName: "refs/heads/main",
+          repository: { webUrl: "" },
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({ value: [{ id: 1 }] }));
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          changeEntries: [
+            { changeType: "edit", item: { path: "/src/file.ts", gitObjectType: "blob" } },
+          ],
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse(fileContent));
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("old"));
+
+      await provider.getDiff();
+
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      await provider.postInlineComments([
+        {
+          file: "src/file.ts",
+          line: 2,
+          endLine: null,
+          severity: "suggestion",
+          category: "style",
+          message: "add content here",
+          suggestedFix: "// new content",
+        },
+      ]);
+
+      const threadCall = fetchSpy.mock.calls.find((args: unknown[]) => {
+        const init = args[1] as RequestInit | undefined;
+        return init?.method === "POST" && (args[0] as string).includes("/threads?");
+      });
+      const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 3, offset: 1 });
+    });
+
+    it("anchors single-line suggestion within the target line so the trailing newline is preserved", async () => {
+      const fileContent = [
+        "{",
+        '  "rules": {',
+        '    "typescript/no-floating-promises": "off",',
+        '    "@typescript-eslint/ban-ts-comment": "error",',
+        "  }",
+        "}",
+      ].join("\n");
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          pullRequestId: 42,
+          title: "",
+          description: "",
+          createdBy: { displayName: "U", uniqueName: "u@e.com" },
+          sourceRefName: "refs/heads/feature",
+          targetRefName: "refs/heads/main",
+          repository: { webUrl: "" },
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({ value: [{ id: 1 }] }));
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          changeEntries: [
+            { changeType: "edit", item: { path: "/.oxlintrc.json", gitObjectType: "blob" } },
+          ],
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse(fileContent));
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("old"));
+
+      await provider.getDiff();
+
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      await provider.postInlineComments([
+        {
+          file: ".oxlintrc.json",
+          line: 3,
+          endLine: null,
+          severity: "warning",
+          category: "bugs",
+          message: "disabling this rule removes protection",
+          suggestedFix: '    "typescript/no-floating-promises": "error",',
+        },
+      ]);
+
+      const threadCall = fetchSpy.mock.calls.find((args: unknown[]) => {
+        const init = args[1] as RequestInit | undefined;
+        if (init?.method !== "POST") return false;
+        const url = args[0] as string;
+        return url.includes("/threads?");
+      });
+      expect(threadCall).toBeDefined();
+
+      const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
+      const targetLineLength = '    "typescript/no-floating-promises": "off",'.length;
+      expect(body.threadContext.rightFileStart).toEqual({ line: 3, offset: 1 });
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 3, offset: targetLineLength });
     });
 
     it("skips API call when findings array is empty", async () => {

--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -345,6 +345,8 @@ describe("AzureDevOpsProvider", () => {
         const init = args[1] as RequestInit | undefined;
         return init?.method === "POST" && (args[0] as string).includes("/threads?");
       });
+      expect(threadCall).toBeDefined();
+
       const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
       expect(body.threadContext.rightFileStart).toEqual({ line: 2, offset: 1 });
       expect(body.threadContext.rightFileEnd).toEqual({
@@ -398,6 +400,8 @@ describe("AzureDevOpsProvider", () => {
         const init = args[1] as RequestInit | undefined;
         return init?.method === "POST" && (args[0] as string).includes("/threads?");
       });
+      expect(threadCall).toBeDefined();
+
       const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
       expect(body.threadContext.rightFileEnd).toEqual({ line: 3, offset: 1 });
     });
@@ -462,6 +466,60 @@ describe("AzureDevOpsProvider", () => {
       const targetLineLength = '    "typescript/no-floating-promises": "off",'.length;
       expect(body.threadContext.rightFileStart).toEqual({ line: 3, offset: 1 });
       expect(body.threadContext.rightFileEnd).toEqual({ line: 3, offset: targetLineLength });
+    });
+
+    it("excludes trailing carriage returns from offsets when file uses crlf line endings", async () => {
+      const targetLine = '    "typescript/no-floating-promises": "off",';
+      const fileContent = ["{", '  "rules": {', targetLine, "  }", "}"].join("\r\n");
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          pullRequestId: 42,
+          title: "",
+          description: "",
+          createdBy: { displayName: "U", uniqueName: "u@e.com" },
+          sourceRefName: "refs/heads/feature",
+          targetRefName: "refs/heads/main",
+          repository: { webUrl: "" },
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({ value: [{ id: 1 }] }));
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          changeEntries: [
+            { changeType: "edit", item: { path: "/.oxlintrc.json", gitObjectType: "blob" } },
+          ],
+        }),
+      );
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse(fileContent));
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("old"));
+
+      await provider.getDiff();
+
+      fetchSpy.mockResolvedValue(mockFetchResponse({}));
+
+      await provider.postInlineComments([
+        {
+          file: ".oxlintrc.json",
+          line: 3,
+          endLine: null,
+          severity: "warning",
+          category: "bugs",
+          message: "disabling this rule removes protection",
+          suggestedFix: '    "typescript/no-floating-promises": "error",',
+        },
+      ]);
+
+      const threadCall = fetchSpy.mock.calls.find((args: unknown[]) => {
+        const init = args[1] as RequestInit | undefined;
+        return init?.method === "POST" && (args[0] as string).includes("/threads?");
+      });
+      expect(threadCall).toBeDefined();
+
+      const body = JSON.parse((threadCall![1] as RequestInit & { body: string }).body);
+      // offset must equal raw line length without the trailing \r; otherwise ado
+      // extends the anchor past the visible content and the suggestion leaves behind a cr
+      expect(body.threadContext.rightFileEnd).toEqual({ line: 3, offset: targetLine.length });
     });
 
     it("skips API call when findings array is empty", async () => {

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -72,6 +72,9 @@ export class AzureDevOpsProvider implements GitProvider {
   private readonly repoName: string;
   private readonly pullRequestId: number;
   private readonly accessToken: string;
+  // source-branch file contents indexed by path; populated by getDiff and used
+  // by postInlineComments to compute exact line-end offsets for suggestion anchors
+  private readonly fileLineCache = new Map<string, string[]>();
 
   constructor(config: AzureDevOpsProviderConfig) {
     this.orgUrl = config.orgUrl.replace(/\/$/, "");
@@ -187,6 +190,7 @@ export class AzureDevOpsProvider implements GitProvider {
         ]);
 
         if (newContent !== null) {
+          this.fileLineCache.set(filePath, newContent.split("\n"));
           const patch = buildPatchFromContent(filePath, oldContent, newContent);
           if (patch.hunks.length > 0) {
             patches.push(patch);
@@ -316,17 +320,28 @@ export class AzureDevOpsProvider implements GitProvider {
             ],
             threadContext: {
               filePath: `/${finding.file}`,
-              // anchor spans from col 1 of the first line to col 1 of the line after the
-              // last target line. zero-width ranges make ado treat ```suggestion blocks as
-              // insertions instead of replacements, concatenating the fix with the original
               rightFileStart: { line: finding.line, offset: 1 },
-              rightFileEnd: { line: endLine + 1, offset: 1 },
+              rightFileEnd: this.computeRightFileEnd(finding.file, endLine),
             },
             status: 1,
           }),
         },
       );
     }
+  }
+
+  // ado's ```suggestion renders as a diff based on the thread's character range. if the
+  // range covers line content + trailing newline, the newline gets stripped when the
+  // suggestion replaces it, merging the target line with the next one. we anchor strictly
+  // within the target line's content (col 1 to col len) so the newline survives. zero-width
+  // ranges must be avoided too — ado treats those as insertions, not replacements.
+  private computeRightFileEnd(path: string, endLine: number): { line: number; offset: number } {
+    const lines = this.fileLineCache.get(path);
+    const lineContent = lines?.[endLine - 1];
+    if (!lineContent) {
+      return { line: endLine + 1, offset: 1 };
+    }
+    return { line: endLine, offset: lineContent.length };
   }
 
   async deleteExistingBotComments(): Promise<void> {

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -143,6 +143,8 @@ export class AzureDevOpsProvider implements GitProvider {
   }
 
   async getDiff(): Promise<FilePatch[]> {
+    this.fileLineCache.clear();
+
     const pr = await this.request(
       `${this.baseUrl}/pullRequests/${this.pullRequestId}?${API_VERSION}`,
       AdoPullRequestSchema,
@@ -190,7 +192,9 @@ export class AzureDevOpsProvider implements GitProvider {
         ]);
 
         if (newContent !== null) {
-          this.fileLineCache.set(filePath, newContent.split("\n"));
+          // split on both lf and crlf so windows line endings don't leak a trailing \r
+          // into cached line contents — that would inflate the offset passed to ado
+          this.fileLineCache.set(filePath, newContent.split(/\r?\n/));
           const patch = buildPatchFromContent(filePath, oldContent, newContent);
           if (patch.hunks.length > 0) {
             patches.push(patch);


### PR DESCRIPTION
## Summary
- Cache each file's source-branch line contents during `getDiff` so `postInlineComments` can compute the exact end offset for a suggestion anchor.
- Replace the `line: endLine + 1, offset: 1` end-anchor with `line: endLine, offset: <line length>` when the cached line content is available. ADO's ```suggestion renders as a diff of the anchored character range, and spanning the trailing newline caused the suggestion to strip that newline and merge the target line with the next one.
- Fall back to the previous next-line anchor when the target line is empty (or not cached) so we still avoid a zero-width range.

## Test plan
- [ ] `pnpm --filter @rusty-bot/azure-devops test` — covers the three new scenarios: multi-line cached content, empty-target-line fallback, and single-line anchor that preserves the trailing newline.