### PR TITLE
Promote opengrep-flagged files to deep-review and scope findings per tier

### DIFF
--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -175,7 +175,7 @@ async function main(): Promise<void> {
 
     let triageResult;
     try {
-      triageResult = await runTriage(reviewable);
+      triageResult = await runTriage(reviewable, openGrepFindings);
     } catch (err) {
       log.warn({ err }, "triage failed, falling back to full review");
     }

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { countTokens } from "../diff/compress.js";
 import type { FilePatch, ReviewConfig, ReviewResult, TicketInfo, Observation } from "../types.js";
+import type { OpenGrepFinding } from "../opengrep/types.js";
 
 function makeMockReview(diff: string): ReviewResult {
   return {
@@ -581,5 +582,84 @@ describe("runCascadeReview", () => {
 
     const deepOpts = deepCalls[0][4];
     expect(deepOpts?.otherPrFiles).toBeUndefined();
+  });
+
+  function makeFinding(file: string): OpenGrepFinding {
+    return {
+      ruleId: "python.sqlalchemy.security.text-sql-injection",
+      file,
+      startLine: 10,
+      endLine: 10,
+      message: "Potential SQL injection",
+      severity: "error",
+    };
+  }
+
+  it("does not leak skim-file opengrep findings into the deep-review tier (single-group)", async () => {
+    const skimPatches = [makePatch("tests/test_auth.py", 20)];
+    const deepPatches = [makePatch("src/datasource_service.py", 20)];
+    const findings = [makeFinding("tests/test_auth.py")];
+
+    await runCascadeReview(skimPatches, deepPatches, config, prMetadata, undefined, {
+      openGrepFindings: findings,
+    });
+
+    const skimCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier === "skim");
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+    expect(skimCalls.length).toBeGreaterThanOrEqual(1);
+    expect(deepCalls.length).toBeGreaterThanOrEqual(1);
+
+    expect(skimCalls[0][4]?.openGrepFindings).toHaveLength(1);
+    expect(skimCalls[0][4]?.openGrepFindings?.[0].file).toBe("tests/test_auth.py");
+    expect(deepCalls[0][4]?.openGrepFindings).toBeUndefined();
+  });
+
+  it("does not leak deep-file opengrep findings into the skim tier (single-group)", async () => {
+    const skimPatches = [makePatch("tests/test_auth.py", 20)];
+    const deepPatches = [makePatch("src/datasource_service.py", 20)];
+    const findings = [makeFinding("src/datasource_service.py")];
+
+    await runCascadeReview(skimPatches, deepPatches, config, prMetadata, undefined, {
+      openGrepFindings: findings,
+    });
+
+    const skimCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier === "skim");
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+
+    expect(skimCalls[0][4]?.openGrepFindings).toBeUndefined();
+    expect(deepCalls[0][4]?.openGrepFindings).toHaveLength(1);
+    expect(deepCalls[0][4]?.openGrepFindings?.[0].file).toBe("src/datasource_service.py");
+  });
+
+  it("routes opengrep findings to both tiers when each has a matching file", async () => {
+    const skimPatches = [makePatch("tests/test_auth.py", 20)];
+    const deepPatches = [makePatch("src/datasource_service.py", 20)];
+    const findings = [makeFinding("tests/test_auth.py"), makeFinding("src/datasource_service.py")];
+
+    await runCascadeReview(skimPatches, deepPatches, config, prMetadata, undefined, {
+      openGrepFindings: findings,
+    });
+
+    const skimCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier === "skim");
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+
+    expect(skimCalls[0][4]?.openGrepFindings).toHaveLength(1);
+    expect(skimCalls[0][4]?.openGrepFindings?.[0].file).toBe("tests/test_auth.py");
+    expect(deepCalls[0][4]?.openGrepFindings).toHaveLength(1);
+    expect(deepCalls[0][4]?.openGrepFindings?.[0].file).toBe("src/datasource_service.py");
+  });
+
+  it("drops findings whose file is in neither tier", async () => {
+    const skimPatches = [makePatch("tests/test_auth.py", 20)];
+    const deepPatches = [makePatch("src/auth.py", 20)];
+    const findings = [makeFinding("src/not-in-pr.py")];
+
+    await runCascadeReview(skimPatches, deepPatches, config, prMetadata, undefined, {
+      openGrepFindings: findings,
+    });
+
+    for (const call of runReviewMock.mock.calls) {
+      expect(call[4]?.openGrepFindings).toBeUndefined();
+    }
   });
 });

--- a/packages/core/src/__tests__/triage.test.ts
+++ b/packages/core/src/__tests__/triage.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import type { FilePatch, TriageFileResult } from "../types.js";
+import type { OpenGrepFinding } from "../opengrep/types.js";
 import { TriageOutputSchema } from "../triage/schema.js";
 import { buildTriageSystemPrompt, buildTriageUserMessage } from "../triage/prompt.js";
-import { splitByClassification, isCascadeEnabled } from "../triage/triage.js";
+import {
+  splitByClassification,
+  isCascadeEnabled,
+  promoteOpenGrepFindings,
+} from "../triage/triage.js";
 
 function makePatch(path: string, additions = 10): FilePatch {
   const lines = Array.from({ length: additions }, (_, i) => `+line ${i}`).join("\n");
@@ -166,6 +171,133 @@ describe("splitByClassification", () => {
     expect(skip).toHaveLength(5);
     expect(skim).toHaveLength(0);
     expect(deepReview).toHaveLength(0);
+  });
+});
+
+describe("promoteOpenGrepFindings", () => {
+  function makeFinding(file: string): OpenGrepFinding {
+    return {
+      ruleId: "python.sqlalchemy.security.text-sql-injection",
+      file,
+      startLine: 10,
+      endLine: 10,
+      message: "Potential SQL injection via sa.text()",
+      severity: "error",
+    };
+  }
+
+  const baseFiles: TriageFileResult[] = [
+    { path: "src/datasource_service.py", classification: "skim", reason: "mostly tests" },
+    { path: "src/unrelated.py", classification: "skim", reason: "docs" },
+    { path: "tests/fixtures.py", classification: "skip", reason: "fixtures" },
+    { path: "src/auth.py", classification: "deep-review", reason: "security-sensitive" },
+  ];
+
+  it("promotes a skim-classified file when opengrep flags it", () => {
+    const findings = [makeFinding("src/datasource_service.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    const promoted = result.find((f) => f.path === "src/datasource_service.py");
+    expect(promoted?.classification).toBe("deep-review");
+    expect(promoted?.reason).toBe("opengrep finding");
+  });
+
+  it("promotes a skip-classified file when opengrep flags it", () => {
+    const findings = [makeFinding("tests/fixtures.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    const promoted = result.find((f) => f.path === "tests/fixtures.py");
+    expect(promoted?.classification).toBe("deep-review");
+    expect(promoted?.reason).toBe("opengrep finding");
+  });
+
+  it("leaves unflagged files unchanged", () => {
+    const findings = [makeFinding("src/datasource_service.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    const untouched = result.find((f) => f.path === "src/unrelated.py");
+    expect(untouched?.classification).toBe("skim");
+    expect(untouched?.reason).toBe("docs");
+  });
+
+  it("preserves existing deep-review classification and reason", () => {
+    const findings = [makeFinding("src/auth.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    const preserved = result.find((f) => f.path === "src/auth.py");
+    expect(preserved?.classification).toBe("deep-review");
+    expect(preserved?.reason).toBe("security-sensitive");
+  });
+
+  it("returns files unchanged when no findings are provided", () => {
+    expect(promoteOpenGrepFindings(baseFiles, undefined)).toEqual(baseFiles);
+    expect(promoteOpenGrepFindings(baseFiles, [])).toEqual(baseFiles);
+  });
+
+  it("matches paths with ./ prefix", () => {
+    const findings = [makeFinding("./src/datasource_service.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    const promoted = result.find((f) => f.path === "src/datasource_service.py");
+    expect(promoted?.classification).toBe("deep-review");
+  });
+
+  it("matches paths with backslash separators", () => {
+    const files: TriageFileResult[] = [
+      { path: "src/utils/db.py", classification: "skim", reason: "simple" },
+    ];
+    const findings = [makeFinding("src\\utils\\db.py")];
+    const result = promoteOpenGrepFindings(files, findings);
+
+    expect(result[0].classification).toBe("deep-review");
+  });
+
+  it("matches paths with trailing line:col suffix", () => {
+    const files: TriageFileResult[] = [
+      { path: "src/db.py", classification: "skim", reason: "simple" },
+    ];
+    const findings = [makeFinding("src/db.py:42:10")];
+    const result = promoteOpenGrepFindings(files, findings);
+
+    expect(result[0].classification).toBe("deep-review");
+  });
+
+  it("ignores findings referring to files not in the triage set", () => {
+    const findings = [makeFinding("src/not-in-pr.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    expect(result).toEqual(baseFiles);
+  });
+
+  it("promotes multiple files when multiple findings match", () => {
+    const findings = [makeFinding("src/datasource_service.py"), makeFinding("tests/fixtures.py")];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    expect(result.find((f) => f.path === "src/datasource_service.py")?.classification).toBe(
+      "deep-review",
+    );
+    expect(result.find((f) => f.path === "tests/fixtures.py")?.classification).toBe("deep-review");
+    expect(result.find((f) => f.path === "src/unrelated.py")?.classification).toBe("skim");
+  });
+
+  it("collapses multiple findings on the same file into one promotion", () => {
+    const findings = [
+      makeFinding("src/datasource_service.py"),
+      makeFinding("src/datasource_service.py"),
+    ];
+    const result = promoteOpenGrepFindings(baseFiles, findings);
+
+    expect(result.filter((f) => f.path === "src/datasource_service.py")).toHaveLength(1);
+    expect(result.find((f) => f.path === "src/datasource_service.py")?.classification).toBe(
+      "deep-review",
+    );
+  });
+
+  it("does not mutate the input files array", () => {
+    const findings = [makeFinding("src/datasource_service.py")];
+    const snapshot = JSON.parse(JSON.stringify(baseFiles));
+    promoteOpenGrepFindings(baseFiles, findings);
+    expect(baseFiles).toEqual(snapshot);
   });
 });
 

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -76,7 +76,7 @@ function estimateTicketContextTokens(ticketContext?: TicketInfo[]): number {
   return countTokens(serialized);
 }
 
-function normalizePath(file: string): string {
+export function normalizePath(file: string): string {
   return file
     .replace(/\\/g, "/")
     .replace(/^\.\//, "")
@@ -240,7 +240,13 @@ async function runTieredReview(
 ): Promise<ReviewResult[]> {
   if (patches.length === 0) return [];
 
-  const tierOptions: RunReviewOptions = { ...resolvedOptions, tier };
+  const tierPaths = new Set(patches.map((p) => p.path));
+  const tierFindings = filterOpenGrepForFiles(resolvedOptions.openGrepFindings, tierPaths);
+  const tierOptions: RunReviewOptions = {
+    ...resolvedOptions,
+    tier,
+    openGrepFindings: tierFindings,
+  };
 
   if (tier === "skim") {
     const { compressed, skippedFiles } = compressDiff(patches, maxTokens);

--- a/packages/core/src/triage/index.ts
+++ b/packages/core/src/triage/index.ts
@@ -1,3 +1,8 @@
 export { TriageOutputSchema } from "./schema.js";
 export { buildTriageSystemPrompt, buildTriageUserMessage } from "./prompt.js";
-export { runTriage, isCascadeEnabled, splitByClassification } from "./triage.js";
+export {
+  runTriage,
+  isCascadeEnabled,
+  splitByClassification,
+  promoteOpenGrepFindings,
+} from "./triage.js";

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -1,5 +1,6 @@
 import { Agent } from "@mastra/core/agent";
 import type { FilePatch, TriageResult, TriageFileResult, TriageClassification } from "../types.js";
+import type { OpenGrepFinding } from "../opengrep/types.js";
 import { TriageOutputSchema } from "./schema.js";
 import { buildTriageSystemPrompt, buildTriageUserMessage } from "./prompt.js";
 import {
@@ -8,6 +9,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
 } from "../agent/model.js";
+import { normalizePath } from "../agent/multi-call.js";
 import { countTokens } from "../diff/compress.js";
 import { logger } from "../logger.js";
 
@@ -26,6 +28,25 @@ function applyOverflowDefaults(
       classification: "deep-review" as const,
       reason: "exceeded triage token budget",
     }));
+}
+
+export function promoteOpenGrepFindings(
+  files: TriageFileResult[],
+  openGrepFindings: OpenGrepFinding[] | undefined,
+): TriageFileResult[] {
+  if (!openGrepFindings || openGrepFindings.length === 0) return files;
+
+  const flaggedPaths = new Set(openGrepFindings.map((f) => normalizePath(f.file)));
+
+  return files.map((f) => {
+    if (f.classification === "deep-review") return f;
+    if (!flaggedPaths.has(normalizePath(f.path))) return f;
+    return {
+      ...f,
+      classification: "deep-review" as TriageClassification,
+      reason: "opengrep finding",
+    };
+  });
 }
 
 function applySafetyNet(files: TriageFileResult[], patches: FilePatch[]): TriageFileResult[] {
@@ -50,7 +71,10 @@ function applySafetyNet(files: TriageFileResult[], patches: FilePatch[]): Triage
   );
 }
 
-export async function runTriage(patches: FilePatch[]): Promise<TriageResult> {
+export async function runTriage(
+  patches: FilePatch[],
+  openGrepFindings?: OpenGrepFinding[],
+): Promise<TriageResult> {
   const modelConfig = resolveTriageModelConfig();
   if (!modelConfig) {
     throw new Error("triage model not configured");
@@ -119,13 +143,19 @@ export async function runTriage(patches: FilePatch[]): Promise<TriageResult> {
     }
   }
 
-  const safeFiles = applySafetyNet(allFiles, patches);
+  const promotedFiles = promoteOpenGrepFindings(allFiles, openGrepFindings);
+  const safeFiles = applySafetyNet(promotedFiles, patches);
+
+  const promotedCount = promotedFiles.filter(
+    (f, i) => f.classification === "deep-review" && allFiles[i].classification !== "deep-review",
+  ).length;
 
   log.info(
     {
       skipped: safeFiles.filter((f) => f.classification === "skip").length,
       skimmed: safeFiles.filter((f) => f.classification === "skim").length,
       deepReview: safeFiles.filter((f) => f.classification === "deep-review").length,
+      openGrepPromoted: promotedCount,
       model: modelName,
       tokens: tokenCount,
     },

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -193,7 +193,7 @@ export async function orchestrateReview(params: {
 
       let triageResult;
       try {
-        triageResult = await runTriage(reviewable);
+        triageResult = await runTriage(reviewable, openGrepFindings);
       } catch (err) {
         log.warn({ err }, "triage failed, falling back to full review");
       }


### PR DESCRIPTION
## Summary

Two related bugs caused an opengrep finding on a file to be silently dropped: the triage LLM classified the file as `skim`, and the deep-review consensus never saw the finding (consensus models kept saying "OpenGrep finding ... is not evidenced in this diff chunk"). Both now fixed.

- **Triage was blind to opengrep findings.** `runTriage` now post-processes its LLM output via a new `promoteOpenGrepFindings()` pure function that force-promotes any `skip`/`skim` file with an opengrep hit to `deep-review` with reason `"opengrep finding"`. Already-`deep-review` classifications keep their original reason. Wired through both the GitHub orchestrator and the Azure DevOps CLI.
- **Deep-review tier saw skim-tier findings.** In `runTieredReview`, the single-group branches of both the skim and deep-review tiers forwarded `resolvedOptions.openGrepFindings` unfiltered via `...resolvedOptions`, so each tier saw findings on files from the other tier. The multi-group branches already called `filterOpenGrepForFiles`; now the single-group path does too, via a tier-level filter computed once and baked into `tierOptions`.

## Test plan

- [x] `pnpm test` — 567/567 pass (up from 551), across 23 files
- [x] `pnpm -r build` — all 4 buildable packages compile cleanly
- [x] `promoteOpenGrepFindings` unit tests cover: skim promotion, skip promotion, non-flagged files untouched, existing `deep-review` reason preserved, no-op on empty/undefined, path normalization (`./` prefix, backslash separators, `:line:col` suffix), findings referring to unknown files, multiple findings, duplicate findings collapsing to one promotion, input immutability
- [x] `runCascadeReview` tier-filtering tests cover: skim-only finding doesn't leak to deep tier, deep-only finding doesn't leak to skim tier, both-tier findings route correctly, findings for files outside both tiers get dropped

## Files touched

- `packages/core/src/triage/triage.ts` — add `promoteOpenGrepFindings`, apply it in `runTriage`, accept optional `openGrepFindings` arg
- `packages/core/src/triage/index.ts` — export `promoteOpenGrepFindings`
- `packages/core/src/agent/multi-call.ts` — tier-level filtering in `runTieredReview`; export `normalizePath` for reuse in triage
- `packages/github/src/orchestrator.ts`, `packages/azure-devops/src/cli.ts` — pass `openGrepFindings` into `runTriage`
- Tests: `triage.test.ts` (+12 cases), `multi-call.test.ts` (+4 cases)