### PR TITLE
Show elevated concerns when consensus drops all findings

### DIFF
--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -551,6 +551,167 @@ describe("formatSummaryComment with dropped findings", () => {
   });
 });
 
+describe("formatSummaryComment with elevated recommendation but no surviving findings", () => {
+  function makeElevatedReview(overrides: Partial<ReviewResult> = {}): ReviewResult {
+    return makeReview({
+      recommendation: "address_before_merge",
+      findings: [],
+      droppedFindings: [
+        {
+          file: "src/dao.ts",
+          line: 120,
+          severity: "warning",
+          message: "race path can return empty conflicts payload",
+          voteCount: 1,
+        },
+        {
+          file: "src/router.ts",
+          line: 55,
+          severity: "warning",
+          message: "partial RBAC grants on mid-loop failure",
+          voteCount: 1,
+        },
+        {
+          file: "src/dao.ts",
+          line: 200,
+          severity: "suggestion",
+          message: "bulk create ignores folder_id",
+          voteCount: 1,
+        },
+      ],
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0,
+        recommendationElevated: true,
+        passRecommendations: [
+          "address_before_merge",
+          "address_before_merge",
+          "address_before_merge",
+        ],
+        failedPasses: 0,
+      },
+      ...overrides,
+    });
+  }
+
+  it("renders a prominent Elevated Concerns section (expanded, not collapsed)", () => {
+    const result = formatSummaryComment(makeElevatedReview());
+
+    expect(result).toContain("## Elevated Concerns (3)");
+    expect(result).toContain("threshold of 2/3 passes");
+    expect(result).toContain("| `src/dao.ts` | 120 | warning |");
+    expect(result).toContain("| `src/router.ts` | 55 | warning |");
+    expect(result).toContain("| 1/3 |");
+    // not wrapped in a <details> block (no unclosed <details> before the section)
+    const elevatedIdx = result.indexOf("## Elevated Concerns");
+    const preceding = result.slice(0, elevatedIdx);
+    const lastDetailsOpen = preceding.lastIndexOf("<details>");
+    const lastDetailsClose = preceding.lastIndexOf("</details>");
+    expect(lastDetailsClose).toBeGreaterThanOrEqual(lastDetailsOpen);
+  });
+
+  it("suppresses the collapsed Filtered findings section to avoid duplication", () => {
+    const result = formatSummaryComment(makeElevatedReview());
+    expect(result).not.toContain("Filtered findings");
+  });
+
+  it("annotates the status line to point readers to the elevated concerns", () => {
+    const result = formatSummaryComment(makeElevatedReview());
+    expect(result).toContain(
+      "**Status:** 0 Issues Found — 3 elevated concerns below | **Recommendation:** Address before merge",
+    );
+  });
+
+  it("uses singular wording when exactly one concern is elevated", () => {
+    const review = makeElevatedReview({
+      droppedFindings: [
+        {
+          file: "src/a.ts",
+          line: 1,
+          severity: "warning",
+          message: "lone concern",
+          voteCount: 1,
+        },
+      ],
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("1 elevated concern below");
+    expect(result).not.toContain("1 elevated concerns below");
+    expect(result).toContain("## Elevated Concerns (1)");
+  });
+
+  it("places the prominent section before Overview so the zero-count table reads as context", () => {
+    const result = formatSummaryComment(makeElevatedReview());
+    const elevatedIdx = result.indexOf("## Elevated Concerns");
+    const overviewIdx = result.indexOf("## Overview");
+    expect(elevatedIdx).toBeGreaterThan(-1);
+    expect(elevatedIdx).toBeLessThan(overviewIdx);
+  });
+
+  it("sanitizes pipe characters in elevated concern messages", () => {
+    const review = makeElevatedReview({
+      droppedFindings: [
+        {
+          file: "src/a.ts",
+          line: 1,
+          severity: "warning",
+          message: "prefer a | b over a || b",
+          voteCount: 1,
+        },
+      ],
+    });
+
+    const result = formatSummaryComment(review);
+    expect(result).toContain("prefer a \\| b over a \\|\\| b");
+  });
+
+  it("falls back to the collapsed Filtered findings section when findings survived", () => {
+    // surviving findings + dropped findings + elevated flag false
+    // (this is the pre-existing behavior; the new section only kicks in when findings.length === 0)
+    const review = makeElevatedReview({
+      findings: [makeFinding({ severity: "warning" })],
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0.5,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "address_before_merge", "address_before_merge"],
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).not.toContain("## Elevated Concerns");
+    expect(result).toContain("Filtered findings");
+    expect(result).not.toContain("elevated concern below");
+    expect(result).not.toContain("elevated concerns below");
+  });
+
+  it("falls back to the collapsed Filtered findings section when elevation did not fire", () => {
+    // dropped findings exist, zero surviving findings, but recommendationElevated is false
+    const review = makeElevatedReview({
+      recommendation: "looks_good",
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "looks_good"],
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).not.toContain("## Elevated Concerns");
+    expect(result).toContain("Filtered findings");
+  });
+});
+
 describe("formatSummaryComment with consensus metadata in footer", () => {
   it("includes consensus pass count and agreement rate in footer", () => {
     const review = makeReview({

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -107,6 +107,32 @@ function buildDroppedFindingsSection(dropped: DroppedFinding[], passes: number):
   return lines.join("\n");
 }
 
+function buildElevatedConcernsSection(
+  dropped: DroppedFinding[],
+  passes: number,
+  threshold: number,
+): string {
+  const lines: string[] = [];
+  lines.push(`## Elevated Concerns (${dropped.length})`);
+  lines.push("");
+  lines.push(
+    `> No finding reached the consensus threshold of ${threshold}/${passes} passes, but each pass raised a concern. ` +
+      `The overall recommendation was elevated because multiple passes agreed something needs attention, ` +
+      `even though they did not agree on what. Review these manually — they may be real issues, noise, ` +
+      `or different angles on the same underlying problem.`,
+  );
+  lines.push("");
+  lines.push("| File | Line | Severity | Message | Votes |");
+  lines.push("|------|------|----------|---------|-------|");
+  for (const f of dropped) {
+    lines.push(
+      `| \`${f.file}\` | ${f.line} | ${f.severity} | ${sanitizeTableCell(f.message)} | ${f.voteCount}/${passes} |`,
+    );
+  }
+  lines.push("");
+  return lines.join("\n");
+}
+
 function buildTicketFetchMessage(status: TicketResolutionStatus): string {
   if (status.totalRefsFound === 0) {
     return "No linked ticket references detected.";
@@ -148,14 +174,23 @@ export function formatSummaryComment(
   const counts = countBySeverity(review.findings);
   const totalIssues = review.findings.length;
 
+  const droppedCount = review.droppedFindings?.length ?? 0;
+  const isElevatedWithoutSurvivors =
+    review.consensusMetadata?.recommendationElevated === true &&
+    totalIssues === 0 &&
+    droppedCount > 0;
+
   const lines: string[] = [];
 
   lines.push("# Code Review Summary");
   lines.push("");
   lines.push("---");
   lines.push("");
+  const statusSuffix = isElevatedWithoutSurvivors
+    ? ` — ${droppedCount} elevated concern${droppedCount === 1 ? "" : "s"} below`
+    : "";
   lines.push(
-    `**Status:** ${totalIssues} Issues Found | **Recommendation:** ${RECOMMENDATION_TEXT[review.recommendation]}`,
+    `**Status:** ${totalIssues} Issues Found${statusSuffix} | **Recommendation:** ${RECOMMENDATION_TEXT[review.recommendation]}`,
   );
   lines.push("");
 
@@ -165,6 +200,16 @@ export function formatSummaryComment(
 
   if (review.openGrepStats) {
     lines.push(buildOpenGrepStatsSection(review.openGrepStats));
+  }
+
+  if (isElevatedWithoutSurvivors && review.droppedFindings && review.consensusMetadata) {
+    lines.push(
+      buildElevatedConcernsSection(
+        review.droppedFindings,
+        review.consensusMetadata.passes,
+        review.consensusMetadata.threshold,
+      ),
+    );
   }
 
   lines.push("## Overview");
@@ -198,7 +243,12 @@ export function formatSummaryComment(
   lines.push("</details>");
   lines.push("");
 
-  if (review.droppedFindings && review.droppedFindings.length > 0 && review.consensusMetadata) {
+  if (
+    !isElevatedWithoutSurvivors &&
+    review.droppedFindings &&
+    review.droppedFindings.length > 0 &&
+    review.consensusMetadata
+  ) {
     lines.push(
       buildDroppedFindingsSection(review.droppedFindings, review.consensusMetadata.passes),
     );


### PR DESCRIPTION
## Summary

- When the consensus layer elevates the recommendation to `address_before_merge` but zero findings survive the agreement threshold, the summary comment previously showed "0 Issues Found" with the concerns buried in a collapsed `<details>` block — making the elevation look like a bug.
- Hoist those dropped findings into a prominent, expanded `## Elevated Concerns (N)` section placed before `## Overview`, with a callout explaining why the recommendation was elevated despite no consensus on any specific issue.
- The status line now reads `**Status:** 0 Issues Found — N elevated concerns below`, and the old collapsed `Filtered findings` block is suppressed in this case to avoid duplication. Non-elevated reviews keep the existing collapsed presentation.

## Test plan

- [x] `pnpm -r test` — 575 tests across `core`, `github`, `azure-devops` pass
- [x] `pnpm lint` clean
- [x] `pnpm format:check` clean
- [x] `pnpm -r build` (typecheck) clean
- [x] 8 new unit tests in `formatter.test.ts` cover: prominent rendering, status-line annotation, singular/plural wording, placement before Overview, pipe sanitization, no-duplication with collapsed section, and two fallback paths (surviving findings + non-elevated review)