### PR TITLE
Dogfood Rusty Bot via new GitHub Action workflow

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -1,0 +1,31 @@
+name: Rusty Bot Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches: [main]
+
+concurrency:
+  group: rusty-bot-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    # skip PRs from forks — they cannot access the LLM secret
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Rusty Bot
+        uses: ./
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+          review-style: balanced
+          fail-on-critical: "true"

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -17,7 +17,6 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # skip PRs from forks — they cannot access the LLM secret
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
@@ -26,6 +25,15 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          review-style: balanced
-          fail-on-critical: "true"
+          llm-api-key: ${{ secrets.REQUESTY_API_KEY }}
+        env:
+          RUSTY_LLM_MODEL: requesty/moonshotai/kimi-k2.5
+          RUSTY_LLM_BASE_URL: https://router.requesty.ai/v1
+          RUSTY_REVIEW_TEMPERATURE: "1"
+          RUSTY_JUDGE_ENABLED: "true"
+          RUSTY_JUDGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
+          RUSTY_JUDGE_TEMPERATURE: "0"
+          RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
+          RUSTY_TRIAGE_TEMPERATURE: "0"
+          RUSTY_REVIEW_STYLE: balanced
+          RUSTY_FAIL_ON_CRITICAL: "true"

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -23,13 +23,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # the action.yml points at a private GHCR image, so authenticate before
-      # the runner tries to docker pull it
+      # the action.yml points at a private GHCR image; the runner's implicit
+      # docker pull during `docker run` doesn't reuse docker/login-action's
+      # credentials, so authenticate and pull explicitly first
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pre-pull Rusty Bot image
+        run: docker pull ghcr.io/jegork/ai-review:latest
 
       - name: Run Rusty Bot
         uses: ./

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -39,10 +39,11 @@ jobs:
         uses: ./
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          llm-api-key: ${{ secrets.REQUESTY_API_KEY }}
         env:
+          # mastra's native requesty provider reads this directly; no base-url
+          # wiring needed when the model id already starts with "requesty/"
+          REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
           RUSTY_LLM_MODEL: requesty/moonshotai/kimi-k2.5
-          RUSTY_LLM_BASE_URL: https://router.requesty.ai/v1
           RUSTY_REVIEW_TEMPERATURE: "1"
           RUSTY_JUDGE_ENABLED: "true"
           RUSTY_JUDGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -13,13 +13,23 @@ permissions:
   contents: read
   pull-requests: write
   issues: read
+  packages: read
 
 jobs:
   review:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
+
+      # the action.yml points at a private GHCR image, so authenticate before
+      # the runner tries to docker pull it
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run Rusty Bot
         uses: ./

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -43,7 +43,7 @@ jobs:
           # mastra's native requesty provider reads this directly; no base-url
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
-          RUSTY_LLM_MODEL: requesty/moonshotai/kimi-k2.5
+          RUSTY_LLM_MODEL: requesty/moonshot/kimi-k2.5
           RUSTY_REVIEW_TEMPERATURE: "1"
           RUSTY_JUDGE_ENABLED: "true"
           RUSTY_JUDGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview

--- a/README.md
+++ b/README.md
@@ -107,9 +107,11 @@ jobs:
       - uses: jegork/ai-review@v1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
-          review-style: balanced
-          focus-areas: security,bugs,performance
-          fail-on-critical: "true"
+        env:
+          RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
+          RUSTY_REVIEW_STYLE: balanced
+          RUSTY_FOCUS_AREAS: security,bugs,performance
+          RUSTY_FAIL_ON_CRITICAL: "true"
 ```
 
 **Required permissions** (set on the job, not the whole workflow):
@@ -118,22 +120,20 @@ jobs:
 - `issues: read` — read linked issues for ticket compliance
 - `contents: read` — read the diff and convention file from the target branch
 
-**Action inputs:**
+**Action inputs** (secret-bearing only — everything else flows through `env:`):
 
-| Input | Default | Notes |
-|---|---|---|
-| `github-token` | `${{ github.token }}` | Built-in token has the right scopes when the `permissions:` block above is set |
-| `review-style` | `balanced` | One of `strict`, `balanced`, `lenient`, `roast`, `thorough` |
-| `focus-areas` | _all_ | Comma-separated: `security,performance,bugs,style,tests,docs` |
-| `ignore-patterns` | — | Comma-separated glob patterns (e.g. `*.lock,dist/**`) |
-| `llm-model` | `anthropic/claude-sonnet-4-20250514` | `provider/model` format |
-| `fail-on-critical` | `true` | Exit code 1 on critical findings — gates the PR |
-| `generate-description` | `false` | Generate a PR description when empty/placeholder |
-| `review-drafts` | `false` | Review draft PRs (skipped by default) |
-| `opengrep-rules` | `auto` | OpenGrep ruleset or config path |
-| `anthropic-api-key` / `openai-api-key` / `google-api-key` | — | Pass exactly one, matching your `llm-model` provider |
-| `jira-base-url` / `jira-email` / `jira-api-token` | — | Enable Jira ticket compliance |
-| `linear-api-key` | — | Enable Linear ticket compliance |
+| Input | Notes |
+|---|---|
+| `github-token` | Defaults to `${{ github.token }}`; the built-in token works when the `permissions:` block above is set |
+| `anthropic-api-key` | Required when `RUSTY_LLM_MODEL` targets an `anthropic/*` model |
+| `openai-api-key` | Required when `RUSTY_LLM_MODEL` targets an `openai/*` model |
+| `google-api-key` | Required when `RUSTY_LLM_MODEL` targets a `google/*` model |
+| `azure-openai-api-key` | Required when `RUSTY_LLM_MODEL` targets an `azure-openai/*` model |
+| `llm-api-key` | API key for an OpenAI-compatible endpoint (set together with `RUSTY_LLM_BASE_URL`, e.g. LiteLLM, Requesty, vLLM) |
+| `jira-api-token` | Enable Jira ticket compliance (combine with `RUSTY_JIRA_BASE_URL` + `RUSTY_JIRA_EMAIL` env) |
+| `linear-api-key` | Enable Linear ticket compliance |
+
+Everything else — `RUSTY_REVIEW_STYLE`, `RUSTY_FOCUS_AREAS`, `RUSTY_LLM_MODEL`, `RUSTY_JUDGE_*`, `RUSTY_LLM_TRIAGE_MODEL`, temperatures, `RUSTY_OPENGREP_RULES`, `RUSTY_REVIEW_DRAFTS`, etc. — is set per-step via `env:`. See the env-var table below for the full list.
 
 The Action runs inside the published Docker image (`ghcr.io/jegork/ai-review:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
 

--- a/action.yml
+++ b/action.yml
@@ -10,78 +10,45 @@ inputs:
     description: Token used to read the PR diff and post review comments. Requires pull-requests:write, issues:read, contents:read
     required: true
     default: ${{ github.token }}
-  review-style:
-    description: "Review style: strict | balanced | lenient | roast | thorough"
-    required: false
-    default: balanced
-  focus-areas:
-    description: "Comma-separated focus areas (security,performance,bugs,style,tests,docs). Empty = all"
-    required: false
-    default: ""
-  ignore-patterns:
-    description: Comma-separated glob patterns to skip (e.g. "*.lock,dist/**")
-    required: false
-    default: ""
-  llm-model:
-    description: LLM model in provider/model format (e.g. anthropic/claude-sonnet-4-20250514)
-    required: false
-    default: anthropic/claude-sonnet-4-20250514
-  fail-on-critical:
-    description: Exit with code 1 when critical findings are produced (gates the PR)
-    required: false
-    default: "true"
-  generate-description:
-    description: Generate a PR description when it's empty or a placeholder
-    required: false
-    default: "false"
-  review-drafts:
-    description: Review draft PRs (skipped by default)
-    required: false
-    default: "false"
   anthropic-api-key:
-    description: Anthropic API key
+    description: Anthropic API key (set when RUSTY_LLM_MODEL targets an anthropic/* model)
     required: false
   openai-api-key:
-    description: OpenAI API key
+    description: OpenAI API key (set when RUSTY_LLM_MODEL targets an openai/* model)
     required: false
   google-api-key:
-    description: Google Generative AI API key
+    description: Google Generative AI API key (set when RUSTY_LLM_MODEL targets a google/* model)
     required: false
-  opengrep-rules:
-    description: OpenGrep config string (ruleset or path)
+  azure-openai-api-key:
+    description: Azure OpenAI API key (set when RUSTY_LLM_MODEL targets an azure-openai/* model)
     required: false
-    default: auto
-  jira-base-url:
-    description: Jira instance URL for ticket compliance
-    required: false
-  jira-email:
-    description: Jira auth email
+  llm-api-key:
+    description: API key for an OpenAI-compatible endpoint specified via RUSTY_LLM_BASE_URL (e.g. LiteLLM, Requesty, vLLM)
     required: false
   jira-api-token:
-    description: Jira API token
+    description: Jira API token for ticket compliance
     required: false
   linear-api-key:
-    description: Linear API key
+    description: Linear API key for ticket compliance
     required: false
 
+# Non-secret configuration is read from RUSTY_* env vars at runtime.
+# Set them per-step in your workflow, e.g.
+#   env:
+#     RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
+#     RUSTY_REVIEW_STYLE: balanced
+#     RUSTY_FAIL_ON_CRITICAL: "true"
+# See the README for the full list of RUSTY_* env vars.
 runs:
   using: docker
   image: docker://ghcr.io/jegork/ai-review:latest
   env:
     RUSTY_MODE: github-action
     GITHUB_TOKEN: ${{ inputs.github-token }}
-    RUSTY_REVIEW_STYLE: ${{ inputs.review-style }}
-    RUSTY_FOCUS_AREAS: ${{ inputs.focus-areas }}
-    RUSTY_IGNORE_PATTERNS: ${{ inputs.ignore-patterns }}
-    RUSTY_LLM_MODEL: ${{ inputs.llm-model }}
-    RUSTY_FAIL_ON_CRITICAL: ${{ inputs.fail-on-critical }}
-    RUSTY_GENERATE_DESCRIPTION: ${{ inputs.generate-description }}
-    RUSTY_REVIEW_DRAFTS: ${{ inputs.review-drafts }}
-    RUSTY_OPENGREP_RULES: ${{ inputs.opengrep-rules }}
     ANTHROPIC_API_KEY: ${{ inputs.anthropic-api-key }}
     OPENAI_API_KEY: ${{ inputs.openai-api-key }}
     GOOGLE_GENERATIVE_AI_API_KEY: ${{ inputs.google-api-key }}
-    RUSTY_JIRA_BASE_URL: ${{ inputs.jira-base-url }}
-    RUSTY_JIRA_EMAIL: ${{ inputs.jira-email }}
+    AZURE_OPENAI_API_KEY: ${{ inputs.azure-openai-api-key }}
+    RUSTY_LLM_API_KEY: ${{ inputs.llm-api-key }}
     RUSTY_JIRA_API_TOKEN: ${{ inputs.jira-api-token }}
     RUSTY_LINEAR_API_KEY: ${{ inputs.linear-api-key }}

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -372,7 +372,7 @@ export async function runAction(config: ActionConfig): Promise<number> {
   return 0;
 }
 
-async function main(): Promise<void> {
+async function main(): Promise<number> {
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
     throw new Error("GITHUB_EVENT_PATH is not set — this CLI must run inside a GitHub Action");
@@ -383,23 +383,23 @@ async function main(): Promise<void> {
   const skip = shouldSkipEvent(event);
   if (skip.skip) {
     log.info({ reason: skip.reason }, "skipping review");
-    return;
+    return 0;
   }
 
   const config = parseConfig({ event });
-  const exitCode = await runAction(config);
-  if (exitCode !== 0) {
-    flushLogger(() => process.exit(exitCode));
-    // keep the event loop alive until the logger drains
-    await new Promise(() => undefined);
-  }
+  return await runAction(config);
 }
 
 const isDirectRun = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
 
 if (isDirectRun) {
-  main().catch((err: unknown) => {
-    log.fatal({ err }, "fatal error");
-    flushLogger(() => process.exit(2));
-  });
+  // node won't exit on its own once main() resolves — the pino async transport
+  // worker, ai-sdk connection pools, and any leftover libsql/mcp handles keep
+  // the event loop alive. flush logs and force-exit on every termination path.
+  main()
+    .then((code) => flushLogger(() => process.exit(code)))
+    .catch((err: unknown) => {
+      log.fatal({ err }, "fatal error");
+      flushLogger(() => process.exit(2));
+    });
 }


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/rusty-bot-review.yml` that runs `@rusty-bot/github-action` (built in #61) on every PR opened against `main`.
- Uses `uses: ./` so the action runs from the same commit it's defined in — perfect for dogfooding without a release tag.
- Skips PRs from forks (`github.event.pull_request.head.repo.full_name == github.repository`) so the LLM secret can't be exfiltrated.
- Concurrency group cancels in-flight runs when a new push lands on the same PR.
- Permissions limited to `contents:read`, `pull-requests:write`, `issues:read` (the minimum the action declares).

## Required setup (one-time)
The job will fail until the `ANTHROPIC_API_KEY` secret is set on the repo:

```bash
gh secret set ANTHROPIC_API_KEY --repo jegork/ai-review
```

## Test plan
- [ ] Set `ANTHROPIC_API_KEY` secret, then watch this PR's checks: the new workflow should pick up its own diff and post a review summary + inline comments
- [ ] Confirm the existing `rustyrocket-bot` (App-based) review still posts in parallel — they're independent surfaces
- [ ] Decide whether to disable the App-based reviewer once the action is proven on a couple of PRs