### PR TITLE
fix: build action image from Dockerfile

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -23,18 +23,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # the action.yml points at a private GHCR image; the runner's implicit
-      # docker pull during `docker run` doesn't reuse docker/login-action's
-      # credentials, so authenticate and pull explicitly first
-      - uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Pre-pull Rusty Bot image
-        run: docker pull ghcr.io/jegork/ai-review:latest
-
       - name: Run Rusty Bot
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
 # See the README for the full list of RUSTY_* env vars.
 runs:
   using: docker
-  image: docker://ghcr.io/jegork/ai-review:${{ github.action_ref }}
+  image: Dockerfile
   env:
     RUSTY_MODE: github-action
     GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

`action.yml:44` referenced `${{ github.action_ref }}` in the Docker `image:` field, but the `github` context isn't available in that expression scope — the workflow parser rejects it with `Unrecognized named-value: 'github'`. This has been breaking the `review` check on every PR (visible on #70, #71).

Switched to `image: Dockerfile` so GitHub Actions builds the image from the repo's Dockerfile per-ref. The ghcr.io image publish from release-please stays untouched — still useful for standalone `docker run` consumers.

Also dropped the now-unnecessary `docker/login-action` + pre-pull steps from `rusty-bot-review.yml` (we're not pulling a registry image anymore).

## Test plan

- [ ] `Rusty Bot Review` check runs green on this PR (proving the action loads and executes)
- [ ] Action build-from-Dockerfile completes within the 15-minute step timeout