### PR TITLE
chore: drop release-as pin now that v1.0.0 is out

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,8 +10,7 @@
   "packages": {
     ".": {
       "package-name": "rusty-bot",
-      "changelog-path": "CHANGELOG.md",
-      "release-as": "1.0.0"
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "changelog-sections": [


### PR DESCRIPTION
## Summary

v1.0.0 has been cut (release #74, tag `v1.0.0`). Removing the `"release-as": "1.0.0"` pin from `release-please-config.json` so future releases calculate their version from commit history instead of always proposing 1.0.0.

With this merged, the next `feat:` commit on main will give `v1.1.0`, next `fix:` will give `v1.0.1`, etc. — normal release-please behavior.

## Test plan

- [ ] After merge, open a trivial `feat:` PR and confirm release-please proposes `v1.1.0` (not `v1.0.0` again)