### PR TITLE
docs: full documentation overhaul

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,6 +25,14 @@ export default defineConfig({
       sidebar: [
         { label: "Getting started", slug: "getting-started" },
         {
+          label: "Providers",
+          items: [
+            { label: "GitHub Action", slug: "providers/github-action" },
+            { label: "GitHub App (self-hosted)", slug: "providers/github-app" },
+            { label: "Azure DevOps", slug: "providers/azure-devops" },
+          ],
+        },
+        {
           label: "Guides",
           autogenerate: { directory: "guides" },
         },

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -54,3 +54,10 @@ a summary comment plus inline findings on the diff.
 
 Pinning to a specific SHA is supported only for the action repo itself; the
 underlying Docker image is published per release tag.
+
+## Next steps
+
+- [Full GitHub Action reference](/providers/github-action/) — complete inputs, skipped events, and Docker image details
+- [GitHub App (self-hosted)](/providers/github-app/) — run as a webhook server for multiple repos
+- [Azure DevOps](/providers/azure-devops/) — run in Azure Pipelines
+- [LLM providers](/guides/llm-providers/) — connect Azure OpenAI, OpenAI-compatible endpoints, or any of 99+ providers

--- a/docs/src/content/docs/guides/cascading-review.md
+++ b/docs/src/content/docs/guides/cascading-review.md
@@ -1,0 +1,47 @@
+---
+title: Cascading review
+description: Use a cheap triage model to classify files before review, cutting token usage by 30–50%.
+---
+
+By default every file in a PR gets the same deep review treatment. Cascading adds a triage step that classifies each file as `skip`, `skim`, or `deep-review` before the main review runs, so cheap files don't consume the same token budget as critical ones.
+
+## Tiers
+
+| Tier | What happens |
+| --- | --- |
+| `skip` | File is excluded entirely — lock files, auto-generated code, vendored deps |
+| `skim` | Lightweight single-pass review — diff-only context, no tools, simplified output schema (no `suggestedFix`, no ticket compliance) |
+| `deep-review` | Full review pipeline — tree-sitter context expansion, code search tools, consensus voting, ticket compliance |
+
+## Enabling it
+
+Set a triage model to enable cascading automatically:
+
+```bash
+RUSTY_LLM_TRIAGE_MODEL=anthropic/claude-3-5-haiku-20241022
+```
+
+Or toggle explicitly:
+
+```bash
+RUSTY_CASCADE_ENABLED=true   # force on (requires RUSTY_LLM_TRIAGE_MODEL)
+RUSTY_CASCADE_ENABLED=false  # force off even if triage model is set
+```
+
+## How it works
+
+1. The triage agent receives a truncated version of each file's diff (≤200 tokens per file, 30k token budget total) and classifies it
+2. Files that overflow the triage budget default to `deep-review`
+3. Files the triage model misses also default to `deep-review`
+4. Safety net: if triage classifies all files as `skip`, the top 20% by additions are force-promoted to `deep-review`
+5. Skim-tier and deep-tier files are reviewed in parallel
+6. Results from both tiers are merged, then passed through the judge (if enabled)
+7. If triage fails entirely, the bot falls back to the standard full-review pipeline
+
+## Summary comment
+
+When cascading is active, the PR comment includes a collapsible **Triage Summary** showing how many files were skipped, skimmed, and deep-reviewed, plus the triage model and token usage.
+
+## Cost
+
+The triage call itself is cheap — truncated diffs and a small output schema. The savings come from skipping context expansion and tool calls for skim-tier files. For a typical PR where roughly 40% of files are config, docs, or tests, expect around 30–50% token reduction on the review calls.

--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -1,0 +1,39 @@
+---
+title: Consensus voting
+description: Run multiple independent review passes and keep only findings that appear in a majority — reduces false positives.
+---
+
+By default, each review runs 3 independent passes with shuffled diff ordering (file and hunk order randomized per pass). Findings are clustered across passes using file match, line proximity (±5 lines), and message similarity (Jaccard ≥ 0.3). Only findings that appear in a majority of passes survive — the rest are dropped as likely false positives.
+
+## Configuration
+
+Configure via per-repo config in the dashboard or API:
+
+| Setting | Description | Default |
+| --- | --- | --- |
+| `consensusPasses` | Number of independent review passes (set to `1` to disable) | `3` |
+| `consensusThreshold` | Minimum votes to keep a finding | `ceil(passes/2)` |
+
+## How it works
+
+1. The diff is shuffled N times (seeded PRNG for reproducibility) to produce N different orderings
+2. Each ordering is reviewed independently in parallel
+3. Findings from all passes are clustered by file + line proximity + message similarity
+4. Clusters with votes below the threshold are dropped
+5. Surviving findings include a `voteCount` showing how many passes flagged them
+
+## Fault tolerance
+
+Consensus uses `Promise.allSettled` so a single flaky pass does not fail the whole review:
+
+- Each pass retries once on `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED` (common with models that have inconsistent structured-output support). Other errors are not retried.
+- If at least `consensusThreshold` passes succeed, consensus is formed from the surviving passes and `consensusMetadata.failedPasses` records how many threw.
+- If fewer than `consensusThreshold` passes succeed, the review throws an `AggregateError` containing every pass failure.
+
+## Cost
+
+With the default 3 passes, LLM cost per review triples. Combine with [cascading review](/guides/cascading-review/) and/or the [judge pass](/guides/judge-pass/) (using a cheaper model) to offset costs.
+
+## Disabling
+
+Set `consensusPasses` to `1` to get the original single-pass behaviour with zero overhead.

--- a/docs/src/content/docs/guides/convention-files.md
+++ b/docs/src/content/docs/guides/convention-files.md
@@ -1,0 +1,36 @@
+---
+title: Convention files
+description: Check in a .rusty-bot.md to inject repo-specific review rules into the system prompt.
+---
+
+Add a markdown file to your repo root and Rusty Bot will inject its content into the system prompt on every review. This is the primary way to encode stack conventions, severity guidance, and domain terminology without touching any configuration UI.
+
+## Priority
+
+When multiple files are present, the first match wins:
+
+| File | Priority |
+| --- | --- |
+| `.rusty-bot.md` | Highest |
+| `REVIEW-BOT.md` | Medium |
+| `AGENTS.md` | Lowest |
+
+## Security
+
+:::caution
+The convention file is fetched from the **target branch** of the PR, not from the PR branch. PR authors cannot tamper with review rules by modifying the file in their own branch.
+:::
+
+## What to put in it
+
+```markdown
+- We use Effect-TS, don't flag `.pipe()` chains as complexity issues
+- All API endpoints must have Zod validation — flag missing schemas as warnings
+- Ignore `generated/` and `__snapshots__/` directories
+- Security findings in `scripts/` are low priority, it's internal tooling
+- Be lenient on style, strict on security
+```
+
+Good candidates: stack conventions, directories to ignore, severity guidance (e.g. "treat missing tests as warnings, not errors"), domain terminology the LLM might misinterpret.
+
+Do not put secrets or sensitive configuration in this file — it is a plaintext file checked into the repo and visible to anyone with read access.

--- a/docs/src/content/docs/guides/gating-merges.md
+++ b/docs/src/content/docs/guides/gating-merges.md
@@ -1,0 +1,41 @@
+---
+title: Gating merges
+description: Block PR merges when critical findings are found.
+---
+
+## How it works
+
+Setting `RUSTY_FAIL_ON_CRITICAL=true` causes Rusty Bot to exit with code 1 when any finding at the `critical` severity level is produced. A non-zero exit code fails the CI job, which can be required as a branch protection check — blocking the merge until the critical finding is resolved or dismissed.
+
+## GitHub Actions
+
+Add `RUSTY_FAIL_ON_CRITICAL: "true"` to the step `env:`:
+
+```yaml
+- uses: jegork/ai-review@v1
+  env:
+    RUSTY_FAIL_ON_CRITICAL: "true"
+  with:
+    anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+```
+
+Then require the job as a status check: **Settings → Branches** (or **Rules**) → add a branch protection rule → enable "Require status checks to pass" and select the Rusty Bot job.
+
+## Azure DevOps
+
+Add `RUSTY_FAIL_ON_CRITICAL: "true"` to the step `env:` in your pipeline YAML (it is already included in the [minimal example](/providers/azure-devops/)).
+
+To enforce it as a merge gate: **Project Settings → Repositories → Policies → Branch policies → Build validation**, then point to the Rusty Bot pipeline.
+
+## What counts as critical
+
+Rusty Bot uses a four-level severity ladder:
+
+| Severity | Description |
+| --- | --- |
+| `info` | Stylistic suggestions or observations |
+| `warning` | Potential issues worth addressing |
+| `error` | Likely bugs or significant problems |
+| `critical` | High-confidence bugs, security vulnerabilities, or data-loss risks |
+
+Only findings at the `critical` level trigger the non-zero exit. `error` and below are reported but do not block the merge.

--- a/docs/src/content/docs/guides/judge-pass.md
+++ b/docs/src/content/docs/guides/judge-pass.md
@@ -1,0 +1,37 @@
+---
+title: Judge / filter pass
+description: Add a self-reflection stage that scores and drops low-confidence findings before they reach developers.
+---
+
+By default, every finding the LLM produces is posted directly to the PR. The judge pass adds a second agent that scores each finding 0–10 for confidence and drops anything below a configurable threshold. This catches hallucinated findings, speculative claims, and low-value noise before they reach developers.
+
+## Enabling it
+
+```bash
+RUSTY_JUDGE_ENABLED=true
+RUSTY_JUDGE_THRESHOLD=6
+RUSTY_JUDGE_MODEL=anthropic/claude-3-5-haiku-20241022
+```
+
+`RUSTY_JUDGE_MODEL` is optional — defaults to the same model as `RUSTY_LLM_MODEL`. Using a cheaper model is recommended to keep costs low.
+
+## How it works
+
+1. The reviewer generates findings as normal
+2. The judge agent receives the diff and all findings, then scores each one 0–10
+3. Findings below the threshold are filtered out and logged at `debug` level
+4. The merge recommendation is recalculated based on the surviving findings
+5. The summary footer shows token usage for review and judge separately, plus how many findings were filtered
+
+## Tuning the threshold
+
+| Threshold | Behaviour |
+| --- | --- |
+| 3–4 | Permissive — only drops clearly hallucinated findings |
+| 5–6 | Balanced — removes speculative and low-confidence noise |
+| 7–8 | Strict — only high-confidence, evidence-backed findings survive |
+| 9–10 | Very strict — likely over-filters; use only in low-noise environments |
+
+## Cost
+
+The judge uses a single structured-output call with no tools. Using a cheap model like `claude-3-5-haiku` adds roughly 1–3% to total cost. Using the same model as the reviewer adds roughly 30–50%.

--- a/docs/src/content/docs/guides/llm-providers.md
+++ b/docs/src/content/docs/guides/llm-providers.md
@@ -1,0 +1,70 @@
+---
+title: LLM providers
+description: Connect Rusty Bot to any LLM — Anthropic, OpenAI, Azure OpenAI, or an OpenAI-compatible endpoint.
+---
+
+Rusty Bot resolves the LLM provider through four paths, tried in order. The first path whose required environment variables are set wins.
+
+## 1. Azure OpenAI with API key
+
+For Azure AI Foundry deployments:
+
+```bash
+RUSTY_LLM_MODEL=azure-openai/gpt-5.3-codex
+AZURE_OPENAI_API_KEY=your-key
+AZURE_OPENAI_RESOURCE_NAME=ai-code-review-foundry
+```
+
+The resource name is the subdomain from your endpoint URL — for example, `https://ai-code-review-foundry.cognitiveservices.azure.com` → `ai-code-review-foundry`. Uses `@ai-sdk/azure` directly.
+
+## 2. Azure OpenAI with Managed Identity
+
+No API keys needed when running on Azure:
+
+```bash
+RUSTY_AZURE_RESOURCE_NAME=my-openai-resource
+RUSTY_AZURE_DEPLOYMENT=gpt-4o
+```
+
+Uses `DefaultAzureCredential` from `@azure/identity`, which automatically picks up managed identity on AKS, App Service, Azure Functions, and Azure Pipelines. Also works with `az login` locally.
+
+## 3. OpenAI-compatible endpoint
+
+For LiteLLM, vLLM, Ollama, or any proxy:
+
+```bash
+RUSTY_LLM_BASE_URL=http://localhost:4000/v1
+RUSTY_LLM_MODEL=gpt-4o
+RUSTY_LLM_API_KEY=optional-key
+```
+
+`RUSTY_LLM_API_KEY` is optional; omit it for unauthenticated local endpoints.
+
+## 4. Mastra router (default)
+
+Direct provider API keys with 99+ providers supported:
+
+```bash
+RUSTY_LLM_MODEL=anthropic/claude-sonnet-4-20250514
+ANTHROPIC_API_KEY=sk-ant-...
+```
+
+Other supported providers: `openai/gpt-4o`, `google/gemini-2.5-flash`, `openrouter/...`, and many more. Set the matching API key (`OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, etc.) for whichever model you choose.
+
+## Temperature and top-p
+
+Set global defaults for all agents, or override per agent. Per-agent values take priority over the global setting; omitting any value falls back to the provider default.
+
+```bash
+# global defaults
+RUSTY_LLM_TEMPERATURE=0.3
+RUSTY_LLM_TOP_P=0.9
+
+# per-agent overrides
+RUSTY_REVIEW_TEMPERATURE=0.3
+RUSTY_TRIAGE_TEMPERATURE=0
+RUSTY_JUDGE_TEMPERATURE=0
+RUSTY_DESCRIPTION_TEMPERATURE=0.5
+```
+
+Some models enforce a fixed temperature — for example, `moonshot/kimi-k2.5` only accepts `temperature=1`. Use per-agent overrides when running different models per agent to work around such restrictions.

--- a/docs/src/content/docs/guides/opengrep.md
+++ b/docs/src/content/docs/guides/opengrep.md
@@ -1,0 +1,43 @@
+---
+title: OpenGrep pre-scan
+description: Run deterministic SAST on changed files before the LLM review to catch secrets, SQLi, and XSS.
+---
+
+Rusty Bot can run [OpenGrep](https://opengrep.dev/) (LGPL-2.1 fork of Semgrep) on changed files before the LLM review. OpenGrep findings are fed to the LLM as structured context so the model can confirm true positives or dismiss false positives with an explanation. This combines deterministic SAST coverage with LLM-powered triage — catching patterns LLMs detect inconsistently (hardcoded secrets, SQL injection, XSS) while filtering false positive noise.
+
+## Requirements
+
+`opengrep` must be available in `PATH`. The Docker image used by the GitHub Action and Azure Pipelines includes it by default. If it's not installed, the review continues LLM-only with a logged notice — no action required.
+
+## Installation (outside Docker)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/opengrep/opengrep/main/install.sh | bash
+```
+
+## Configuration
+
+```bash
+# use curated ruleset (default)
+RUSTY_OPENGREP_RULES=auto
+
+# use a custom config file from the repo
+RUSTY_OPENGREP_RULES=.semgrep.yml
+
+# use a specific registry ruleset
+RUSTY_OPENGREP_RULES=p/security-audit
+```
+
+## How it works
+
+1. Changed file paths (excluding binaries) are written to a temp file
+2. `opengrep scan --config <rules> --json --quiet --target-list <file>` runs with a 2-minute timeout
+3. JSON output is parsed into structured findings (rule ID, file, line range, message, severity, snippet)
+4. Findings are injected into the LLM user prompt before the diff, with instructions to confirm or dismiss each one
+5. When the diff is split into token-aware chunks, OpenGrep findings are filtered to only the files in each chunk
+
+The PR summary comment includes an OpenGrep stats line showing finding count, availability, and any errors.
+
+## Cost
+
+OpenGrep runs locally in seconds with zero LLM cost. The only added token cost is the findings injected into the prompt — roughly 50–200 tokens per finding.

--- a/docs/src/content/docs/guides/pr-description.md
+++ b/docs/src/content/docs/guides/pr-description.md
@@ -1,0 +1,26 @@
+---
+title: PR description generation
+description: Automatically generate a structured PR description from the diff when it's empty or a placeholder.
+---
+
+Off by default. When enabled, Rusty Bot generates a structured PR description before the review runs — so both human reviewers and the review agent see a clear summary of what changed.
+
+## Enabling it
+
+```bash
+RUSTY_GENERATE_DESCRIPTION=true
+```
+
+Or enable per-repo via the dashboard (PR Description checkbox).
+
+## How it works
+
+1. Before the review starts, the bot checks the current PR description
+2. If the description is empty, whitespace-only, a short placeholder (e.g. "TODO", "WIP"), or a previously bot-generated description, it proceeds
+3. A dedicated agent produces a structured description: summary, per-file change table, breaking changes, and migration notes (sections are omitted when not applicable)
+4. The description is updated on the PR via the platform API
+5. The review then runs with the generated description visible in the PR metadata
+
+## Safety
+
+The bot never overwrites a human-written description. The detection is conservative — any description with meaningful prose, issue references, or structured content is left untouched. Bot-generated descriptions are identified by an HTML marker, so they can be safely regenerated on subsequent runs.

--- a/docs/src/content/docs/guides/ticket-integration.md
+++ b/docs/src/content/docs/guides/ticket-integration.md
@@ -1,0 +1,36 @@
+---
+title: Ticket integration
+description: Link Jira, Linear, GitHub Issues, or ADO work items to PRs for requirements-compliance checks.
+---
+
+When linked tickets are found and the corresponding provider is configured, Rusty Bot fetches the ticket content and checks whether the PR implements what the ticket describes. The compliance assessment is included in the review summary.
+
+## Discovery mechanisms
+
+Rusty Bot discovers linked tickets through three mechanisms:
+
+1. **Regex extraction** — scans PR descriptions and branch names for ticket patterns:
+   - GitHub Issues: `#123`, `owner/repo#123`, full URL
+   - Jira: `PROJ-123`, Jira browse URL
+   - Linear: Linear issue URL
+   - Azure DevOps: `AB#123`, ADO work item URL
+   - Branch names: `feature/123-desc`, `fix/PROJ-123-title`
+
+2. **GitHub linked issues** — queries the `closingIssuesReferences` GraphQL field to find issues linked via closing keywords (`Closes #123`, `Fixes #456`) or the PR Development sidebar.
+
+3. **Azure DevOps linked work items** — calls the PR work items API endpoint to find work items formally linked through the ADO UI, even when not mentioned in the description or branch name.
+
+All three sources are merged and deduplicated before resolution.
+
+## Configuration
+
+| Provider | Required variables |
+| --- | --- |
+| Jira | `RUSTY_JIRA_BASE_URL` + `RUSTY_JIRA_EMAIL` + `RUSTY_JIRA_API_TOKEN` (or `jira-api-token` action input) |
+| Linear | `RUSTY_LINEAR_API_KEY` (or `linear-api-key` action input) |
+| GitHub Issues | No config needed — uses `GITHUB_TOKEN` |
+| ADO work items | No config needed — uses `SYSTEM_ACCESSTOKEN` |
+
+## Output
+
+When tickets are found and the provider is configured, the review summary includes a compliance assessment — whether the PR addresses what the ticket describes, with any gaps or mismatches called out as findings.

--- a/docs/src/content/docs/guides/tree-sitter.md
+++ b/docs/src/content/docs/guides/tree-sitter.md
@@ -1,0 +1,22 @@
+---
+title: Tree-sitter context expansion
+description: Diff hunks automatically expand to enclosing function or class boundaries for better review accuracy.
+---
+
+Automatic, no configuration needed. When the LLM reviews a diff hunk, the surrounding context is expanded to the enclosing function, method, or class boundary using [tree-sitter](https://tree-sitter.github.io/tree-sitter/) AST parsing. This means the model sees complete semantic units — full functions instead of fragments cut mid-logic.
+
+## Supported languages
+
+TypeScript, TSX, JavaScript, Python, Go, Java, Rust.
+
+## How it works
+
+1. Each changed file is parsed with a WASM-based tree-sitter grammar (no native compilation needed)
+2. For each changed line range, the smallest enclosing scope (function, method, class) is found in the AST
+3. The hunk expands to include the full enclosing scope
+4. Collapsed signatures of sibling functions/methods are prepended for orientation (e.g. `// ... export function otherFn()`)
+5. The expanded context replaces the raw hunk in the prompt
+
+## Fallback
+
+If the enclosing scope exceeds 200 lines, or if the language is unsupported (CSS, JSON, YAML, etc.), the bot falls back to a fixed ±10 line expansion with zero overhead.

--- a/docs/src/content/docs/providers/azure-devops.md
+++ b/docs/src/content/docs/providers/azure-devops.md
@@ -1,0 +1,66 @@
+---
+title: Azure DevOps
+description: Run Rusty Bot as a container task in Azure Pipelines.
+---
+
+Azure DevOps is a first-class integration alongside GitHub. Rusty Bot runs as a container task in Azure Pipelines, reads `SYSTEM_PULLREQUEST_*` variables automatically, and gates merges via exit code.
+
+## Prerequisites
+
+- An Azure DevOps project with a pipeline that targets pull requests
+- "Allow scripts to access the OAuth token" must be enabled for the agent pool (Settings → Agent pool → Allow in the pipeline settings), so `$(System.AccessToken)` can post comments on PRs
+
+## Minimal pipeline YAML
+
+```yaml
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+
+pool:
+  vmImage: ubuntu-latest
+
+container:
+  image: ghcr.io/jegork/ai-review:latest
+  env:
+    RUSTY_MODE: pipeline
+
+steps:
+  - script: node /app/packages/azure-devops/dist/cli.js
+    displayName: Rusty Bot PR Review
+    env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+      RUSTY_LLM_MODEL: $(RUSTY_LLM_MODEL)
+      ANTHROPIC_API_KEY: $(ANTHROPIC_API_KEY)
+      RUSTY_REVIEW_STYLE: $(RUSTY_REVIEW_STYLE)
+      RUSTY_FOCUS_AREAS: $(RUSTY_FOCUS_AREAS)
+      RUSTY_FAIL_ON_CRITICAL: "true"
+```
+
+## LLM provider
+
+**Direct API key** — set `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) as a pipeline variable in Azure DevOps and pass it through `env:` as shown above.
+
+**Azure OpenAI with Managed Identity** — replace the API key vars with:
+
+```bash
+RUSTY_AZURE_RESOURCE_NAME=my-openai-resource
+RUSTY_AZURE_DEPLOYMENT=gpt-4o
+```
+
+No key needed; `DefaultAzureCredential` picks up the managed identity automatically when the pipeline runs on Azure. See [LLM providers](/guides/llm-providers/) for full details.
+
+## Gating merges
+
+Add `RUSTY_FAIL_ON_CRITICAL: "true"` to the step `env:` (already in the example above). The task exits with code 1 when critical findings are found, which fails the pipeline job.
+
+To block PR merges, add a build validation policy: **Project Settings → Repositories → Policies → Branch policies → Build validation**, and point it to the Rusty Bot pipeline.
+
+See [Gating merges](/guides/gating-merges/) for the full setup walkthrough.
+
+## ADO PAT fallback
+
+For non-container usage (e.g. server mode), set `RUSTY_ADO_PAT` with a Personal Access Token that has **Code: Read** and **Pull Request Threads: Read & Write** scopes. In pipeline mode the `$(System.AccessToken)` is preferred and no PAT is needed.

--- a/docs/src/content/docs/providers/github-action.md
+++ b/docs/src/content/docs/providers/github-action.md
@@ -1,0 +1,79 @@
+---
+title: GitHub Action
+description: Run Rusty Bot as a drop-in GitHub Action — no hosting required.
+---
+
+The GitHub Action is the easiest way to get started. Reviews run on GitHub-hosted runners — no server to provision or maintain.
+
+## Minimal workflow
+
+Create `.github/workflows/rusty-bot-review.yml`:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: read
+    steps:
+      - uses: jegork/ai-review@v1
+        with:
+          anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
+        env:
+          RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
+          RUSTY_REVIEW_STYLE: balanced
+          RUSTY_FOCUS_AREAS: security,bugs,performance
+          RUSTY_FAIL_ON_CRITICAL: "true"
+```
+
+The [Getting started](/getting-started/) page has the bare minimum to get running. This page is the complete reference.
+
+## Required permissions
+
+Set these on the job (not the whole workflow):
+
+| Permission | Reason |
+| --- | --- |
+| `pull-requests: write` | Post the summary comment and inline review findings |
+| `issues: read` | Read linked issues for ticket compliance checks |
+| `contents: read` | Read the diff and fetch the convention file from the target branch |
+
+## Inputs reference
+
+Secret-bearing inputs only — everything else flows through `env:`. See [Environment variables](/reference/env-vars/) for non-secret config.
+
+| Input | Required | Default | Description |
+| --- | --- | --- | --- |
+| `github-token` | No | `${{ github.token }}` | GitHub token; the built-in token works when the `permissions:` block above is set |
+| `anthropic-api-key` | Conditional | — | Required when `RUSTY_LLM_MODEL` targets an `anthropic/*` model |
+| `openai-api-key` | Conditional | — | Required when `RUSTY_LLM_MODEL` targets an `openai/*` model |
+| `google-api-key` | Conditional | — | Required when `RUSTY_LLM_MODEL` targets a `google/*` model |
+| `azure-openai-api-key` | Conditional | — | Required when `RUSTY_LLM_MODEL` targets an `azure-openai/*` model |
+| `llm-api-key` | Conditional | — | API key for an OpenAI-compatible endpoint (set together with `RUSTY_LLM_BASE_URL`) |
+| `jira-api-token` | No | — | Enable Jira ticket compliance; combine with `RUSTY_JIRA_BASE_URL` + `RUSTY_JIRA_EMAIL` |
+| `linear-api-key` | No | — | Enable Linear ticket compliance |
+
+## Pinning
+
+| Pin | Behaviour |
+| --- | --- |
+| `@v1` | Floats to the latest `1.x.x` release. **Recommended.** |
+| `@v1.2.3` | Pinned to an exact release. |
+| `@main` | Tracks `main`. Use only for development. |
+
+## Skipped events
+
+The Action exits early (no error, no review) for these PR event types:
+
+- `closed`, `labeled`, `unlabeled`, `assigned`, `unassigned`
+- Draft PRs — unless `RUSTY_REVIEW_DRAFTS=true` is set in `env:`
+
+## Docker image
+
+The Action runs inside `ghcr.io/jegork/ai-review:latest`, which includes OpenGrep. The first run in a fresh runner environment adds roughly 20–40s for the image pull; subsequent runs on cached runners skip this entirely.

--- a/docs/src/content/docs/providers/github-app.md
+++ b/docs/src/content/docs/providers/github-app.md
@@ -1,11 +1,9 @@
 ---
-title: Self-hosted GitHub App
-description: Run Rusty Bot as a GitHub App webhook server instead of a per-PR Action.
+title: GitHub App (self-hosted)
+description: Run Rusty Bot as a long-lived webhook server — single install across all your repos.
 ---
 
-The GitHub Action is the easy path. If you'd rather run Rusty Bot as a
-long-lived webhook server (single install across many repos, no per-PR
-Action minutes), set it up as a GitHub App.
+The GitHub Action runs once per PR on a GitHub-hosted runner. If you'd rather run Rusty Bot as a persistent webhook server — a single install that covers all repos in your org without per-PR Action minutes — set it up as a GitHub App.
 
 ## 1. Create the App
 
@@ -50,3 +48,7 @@ The dashboard is at `/`, health check at `/health`, and webhooks at
 
 Install the App on any repo from the App's public install URL. PRs in those
 repos will get reviewed automatically.
+
+:::note
+The webhook server also supports Azure DevOps — see [Azure DevOps](/providers/azure-devops/).
+:::

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -3,32 +3,119 @@ title: Environment variables
 description: RUSTY_* variables read at runtime by the action and webhook server.
 ---
 
-Non-secret configuration lives in `RUSTY_*` env vars rather than action inputs,
-so the same values can be reused between the GitHub Action, the webhook
-server, and the Azure DevOps task without duplication.
+Non-secret configuration lives in `RUSTY_*` env vars rather than action inputs, so the same values can be reused between the GitHub Action, the webhook server, and the Azure DevOps task without duplication.
 
-## Common
+## Core
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `RUSTY_LLM_MODEL` | `anthropic/claude-sonnet-4-20250514` | Provider/model in `provider/model` form. |
-| `RUSTY_LLM_BASE_URL` | — | Base URL of an OpenAI-compatible endpoint (LiteLLM, Requesty, vLLM, …). |
-| `RUSTY_REVIEW_STYLE` | `balanced` | One of `strict`, `balanced`, `lenient`, `roast`, `thorough`. |
-| `RUSTY_FOCUS_AREAS` | _all_ | Comma-separated: `security,performance,bugs,style,tests,docs`. |
-| `RUSTY_IGNORE_PATTERNS` | — | Comma-separated globs to skip (e.g. `*.lock,dist/**`). |
-| `RUSTY_FAIL_ON_CRITICAL` | `true` | Exit with code 1 when critical findings are produced (gates the PR). |
-| `RUSTY_GENERATE_DESCRIPTION` | `false` | Generate a PR description when it's empty or a placeholder. |
-| `RUSTY_REVIEW_DRAFTS` | `false` | Review draft PRs (skipped by default). |
-| `RUSTY_OPENGREP_RULES` | `auto` | OpenGrep config string (ruleset id or path). |
+| `RUSTY_LLM_MODEL` | `anthropic/claude-sonnet-4-20250514` | LLM model in `provider/model` format |
+| `RUSTY_REVIEW_STYLE` | `balanced` | One of `strict`, `balanced`, `lenient`, `roast`, `thorough` |
+| `RUSTY_FOCUS_AREAS` | all enabled | Comma-separated: `security,performance,bugs,style,tests,docs` |
+| `RUSTY_IGNORE_PATTERNS` | — | Comma-separated globs to skip (e.g. `*.lock,dist/**`) |
+| `RUSTY_DB_URL` | `file:./rusty.db` | libSQL database URL |
+| `RUSTY_MODE` | — | Set to `pipeline` in Azure Pipelines container |
+| `RUSTY_FAIL_ON_CRITICAL` | `true` | Exit with code 1 when critical findings are produced |
+| `RUSTY_REVIEW_DRAFTS` | `false` | Review draft PRs (skipped by default) |
 
-## Ticket compliance
+## LLM provider — Anthropic / OpenAI / Google
 
 | Variable | Description |
 | --- | --- |
-| `RUSTY_JIRA_BASE_URL` | Jira instance URL. |
-| `RUSTY_JIRA_EMAIL` | Jira auth email. |
-| `RUSTY_JIRA_API_TOKEN` | Jira API token (also exposed as the `jira-api-token` action input). |
-| `RUSTY_LINEAR_API_KEY` | Linear API key (also exposed as the `linear-api-key` action input). |
+| `ANTHROPIC_API_KEY` | Anthropic API key |
+| `OPENAI_API_KEY` | OpenAI API key |
+| `GOOGLE_GENERATIVE_AI_API_KEY` | Google AI API key |
+
+## LLM provider — Azure OpenAI
+
+| Variable | Description |
+| --- | --- |
+| `AZURE_OPENAI_API_KEY` | Azure OpenAI API key (also accepted as `AZURE_API_KEY`) |
+| `AZURE_OPENAI_RESOURCE_NAME` | Azure OpenAI resource name (API key path) |
+| `RUSTY_AZURE_RESOURCE_NAME` | Azure OpenAI resource name (managed identity path) |
+| `RUSTY_AZURE_DEPLOYMENT` | Azure OpenAI deployment name (managed identity path) |
+
+The managed identity vars (`RUSTY_AZURE_*`) take priority over the API-key vars when both are set. See [LLM providers](/guides/llm-providers/) for details.
+
+## LLM provider — OpenAI-compatible
+
+| Variable | Description |
+| --- | --- |
+| `RUSTY_LLM_BASE_URL` | Base URL of an OpenAI-compatible endpoint (LiteLLM, vLLM, Ollama, …) |
+| `RUSTY_LLM_API_KEY` | API key for the custom endpoint (optional for unauthenticated local instances) |
+
+## Temperature and top-p
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_LLM_TEMPERATURE` | provider default | Global temperature for all agents |
+| `RUSTY_LLM_TOP_P` | provider default | Global top-p for all agents |
+| `RUSTY_REVIEW_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the review agent |
+| `RUSTY_TRIAGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the triage agent |
+| `RUSTY_JUDGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the judge agent |
+| `RUSTY_DESCRIPTION_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the description agent |
+
+Per-agent values override the global setting; omitting any value falls back to the provider default.
+
+## Judge pass
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_JUDGE_ENABLED` | `false` | Enable the post-generation judge / filter pass |
+| `RUSTY_JUDGE_THRESHOLD` | `6` | Minimum confidence score (0–10) to keep a finding |
+| `RUSTY_JUDGE_MODEL` | same as `RUSTY_LLM_MODEL` | Model for the judge (can be a cheaper model) |
+
+See [Judge / filter pass](/guides/judge-pass/).
+
+## Cascading triage
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_LLM_TRIAGE_MODEL` | — | LLM model for triage classification; setting this enables cascading |
+| `RUSTY_CASCADE_ENABLED` | auto | Explicitly enable (`true`) or disable (`false`) cascading; default is auto (enabled when triage model is set) |
+
+See [Cascading review](/guides/cascading-review/).
+
+## OpenGrep
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_OPENGREP_RULES` | `auto` | OpenGrep config string — ruleset ID (e.g. `p/security-audit`) or path to a rule file (e.g. `.semgrep.yml`) |
+
+See [OpenGrep pre-scan](/guides/opengrep/).
+
+## PR description generation
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_GENERATE_DESCRIPTION` | `false` | Generate a PR description when it's empty or a placeholder |
+
+See [PR description generation](/guides/pr-description/).
+
+## Ticket integrations
+
+| Variable | Description |
+| --- | --- |
+| `RUSTY_JIRA_BASE_URL` | Jira instance URL |
+| `RUSTY_JIRA_EMAIL` | Jira auth email |
+| `RUSTY_JIRA_API_TOKEN` | Jira API token (also exposed as the `jira-api-token` action input) |
+| `RUSTY_LINEAR_API_KEY` | Linear API key (also exposed as the `linear-api-key` action input) |
+| `RUSTY_ADO_PAT` | Azure DevOps PAT for non-container / server mode usage |
+
+See [Ticket integration](/guides/ticket-integration/).
+
+## GitHub App (self-hosted only)
+
+| Variable | Description |
+| --- | --- |
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_PRIVATE_KEY_PATH` | Path to the GitHub App private key PEM file |
+| `GITHUB_PRIVATE_KEY` | Inline PEM string (alternative to `GITHUB_PRIVATE_KEY_PATH`) |
+| `GITHUB_WEBHOOK_SECRET` | GitHub webhook secret |
+
+See [GitHub App (self-hosted)](/providers/github-app/).
+
+---
 
 For the canonical list, see
 [`action.yml`](https://github.com/jegork/ai-review/blob/main/action.yml) and


### PR DESCRIPTION
## Summary

- **New Providers section** in sidebar (GitHub Action, GitHub App, Azure DevOps) with fixed ordering alongside autogenerated Guides and Reference groups
- **13 new pages**: three provider pages + 10 guide pages covering every major feature (judge pass, cascading review, OpenGrep, consensus voting, convention files, gating merges, LLM providers, PR description generation, ticket integration, tree-sitter)
- **Rewritten `reference/env-vars.md`** — 11 logical groups with cross-links instead of a flat table
- **`guides/github-app.md` moved** to `providers/github-app.md`; getting-started gets a "Next steps" block

## Test plan

- [ ] `pnpm build` in `docs/` passes with no warnings — verified locally (18 pages built clean)
- [ ] Sidebar renders: Getting started → Providers (3 items) → Guides (10 items) → Reference (2 items)
- [ ] All cross-links resolve (no 404s in the built output)
- [ ] Old `guides/github-app` URL gone from sidebar; no broken links in existing pages