### PR TITLE
chore: open-source readiness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,10 @@ dist/
 *.db-wal
 *.tsbuildinfo
 .env
-.env.local
+.env.*
+*.pem
+*.key
+*.secret
 mcp-servers.json
 .mastra/
 .claude/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing
+
+## Development setup
+
+```bash
+pnpm install
+pnpm -r build
+cp .env.example .env
+# set at least one LLM API key in .env
+pnpm --filter @rusty-bot/github start
+```
+
+Tests:
+
+```bash
+pnpm test
+```
+
+## Project structure
+
+```
+packages/
+├── core/           # shared review engine (agent, diff, triage, tickets, opengrep)
+├── github/         # GitHub App webhook server
+├── github-action/  # one-shot CLI for GitHub Actions
+├── azure-devops/   # Azure Pipelines container entrypoint
+└── dashboard/      # React SPA for config and history
+docs/               # Astro Starlight documentation site
+```
+
+## Pull requests
+
+- Open an issue first for anything beyond a small bug fix — alignment before implementation saves time.
+- Keep PRs focused; one logical change per PR.
+- Add or update tests for changed behaviour.
+- The pre-commit hook runs `lint-staged` (ESLint + Prettier) and the full test suite. Fix failures before pushing.
+- PR titles should follow conventional commits: `feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `perf:`.
+
+## Reporting security issues
+
+See [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security policy
+
+## Supported versions
+
+| Version | Supported |
+|---------|-----------|
+| 1.x     | ✅        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public GitHub issue for security vulnerabilities.
+
+Report vulnerabilities by emailing **jegor.kitskerkin@gmail.com** with the subject line `[rusty-bot] security disclosure`. Include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce or a proof-of-concept
+- Affected versions
+
+You should receive an acknowledgement within 48 hours and a resolution timeline within 7 days.
+
+## Scope
+
+Rusty Bot handles sensitive material: GitHub App private keys, webhook secrets, and LLM API keys passed via environment variables. The following are in scope:
+
+- Credential or secret leakage through logs, comments, or API responses
+- Authentication or authorisation bypass in the webhook server
+- Code execution via maliciously crafted PR payloads
+- Privilege escalation through the GitHub App or ADO integration
+
+Theoretical denial-of-service issues and vulnerabilities in third-party dependencies (tracked separately via Dependabot) are out of scope for direct reports.
+
+## Known advisories
+
+- `uuid@8.3.2` (bundled in `@azure/msal-node@5.1.2`) — GHSA-w5hq-g745-h8pq, moderate. Not directly exploitable in this project's usage; tracked for upstream fix.

--- a/packages/azure-devops/package.json
+++ b/packages/azure-devops/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rusty-bot/azure-devops",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rusty-bot/core",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/github-action/package.json
+++ b/packages/github-action/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rusty-bot/github-action",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@rusty-bot/github",
   "version": "0.1.0",
+  "license": "MIT",
   "private": true,
   "type": "module",
   "main": "dist/index.js",

--- a/skills/pr-comment-monitor/SKILL.md
+++ b/skills/pr-comment-monitor/SKILL.md
@@ -97,6 +97,6 @@ Always leave a short summary at the end: mode used, how many iterations ran, how
 
 ## Authentication notes
 
-- GitHub MCP tools in this harness are scoped to `jegork/ai-review`. Outside that repo, fall back to `gh` or a `GITHUB_TOKEN` env var.
+- GitHub MCP tools in this harness are scoped to the current repository. If they are not configured for your repo, fall back to `gh` or a `GITHUB_TOKEN` env var.
 - For Azure DevOps use `RUSTY_ADO_PAT` (already documented in this repo's `.env.example`) or `SYSTEM_ACCESSTOKEN` when running in a pipeline.
 - Never echo tokens into the terminal output or commit messages.


### PR DESCRIPTION
## Summary

Addresses all blockers and recommended items from the open-source readiness audit.

**Blockers fixed:**
- `.gitignore` now covers `.env.*`, `*.pem`, `*.key`, `*.secret` — prevents accidentally committing PEM files or extra env variants
- Removed personal-repo scope note from `skills/pr-comment-monitor/SKILL.md` (was hardcoded to `jegork/ai-review`, now says "current repository")

**Recommended fixes:**
- Added `"license": "MIT"` to all four sub-package `package.json` files (`@rusty-bot/core`, `@rusty-bot/github`, `@rusty-bot/github-action`, `@rusty-bot/azure-devops`)
- Added `SECURITY.md` — disclosure email, scope, and documents the known `uuid` advisory via `@azure/msal-node`
- Added `CONTRIBUTING.md` — dev setup, project structure, PR guidelines

## Test plan
- [ ] `pnpm test` passes
- [ ] No `.env.*` / `*.pem` / `*.key` files are trackable by git after this change