### PR TITLE
chore: rename repo from ai-review to rusty-bot

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/delete-package-versions@v5
         with:
-          package-name: ai-review
+          package-name: rusty-bot
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: jegork/ai-review@v1
+      - uses: jegork/rusty-bot@v1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
         env:
@@ -135,7 +135,7 @@ jobs:
 
 Everything else — `RUSTY_REVIEW_STYLE`, `RUSTY_FOCUS_AREAS`, `RUSTY_LLM_MODEL`, `RUSTY_JUDGE_*`, `RUSTY_LLM_TRIAGE_MODEL`, temperatures, `RUSTY_OPENGREP_RULES`, `RUSTY_REVIEW_DRAFTS`, etc. — is set per-step via `env:`. See the env-var table below for the full list.
 
-The Action runs inside the published Docker image (`ghcr.io/jegork/ai-review:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
+The Action runs inside the published Docker image (`ghcr.io/jegork/rusty-bot:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
 
 **Skipped events:** the Action exits early with no error for `closed`/`labeled`/`unlabeled`/`assigned`/`unassigned` and for draft PRs (unless `review-drafts: "true"`).
 
@@ -155,7 +155,7 @@ pool:
   vmImage: ubuntu-latest
 
 container:
-  image: ghcr.io/jegork/ai-review:latest
+  image: ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: pipeline
 
@@ -555,10 +555,10 @@ This repo publishes agent skills under `skills/`. They're indexed by [skills.sh]
 
 ```bash
 # install every skill in this repo
-npx skills add jegork/ai-review
+npx skills add jegork/rusty-bot
 
 # or just one
-npx skills add jegork/ai-review/pr-comment-monitor
+npx skills add jegork/rusty-bot/pr-comment-monitor
 ```
 
 Available skills:

--- a/azure-pipelines-example.yml
+++ b/azure-pipelines-example.yml
@@ -9,7 +9,7 @@ pool:
   vmImage: ubuntu-latest
 
 container:
-  image: ghcr.io/jegork/ai-review:latest
+  image: ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: pipeline
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: "https://jegork.github.io",
-  base: "/ai-review",
+  base: "/rusty-bot",
   integrations: [
     starlight({
       title: "Rusty Bot",
@@ -14,11 +14,11 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/jegork/ai-review",
+          href: "https://github.com/jegork/rusty-bot",
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/jegork/ai-review/edit/main/docs/",
+        baseUrl: "https://github.com/jegork/rusty-bot/edit/main/docs/",
       },
       lastUpdated: true,
       pagination: true,

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -25,7 +25,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: jegork/ai-review@v1
+      - uses: jegork/rusty-bot@v1
         env:
           RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
           RUSTY_REVIEW_STYLE: balanced

--- a/docs/src/content/docs/guides/github-app.md
+++ b/docs/src/content/docs/guides/github-app.md
@@ -9,7 +9,7 @@ Action minutes), set it up as a GitHub App.
 
 ## 1. Create the App
 
-Use the [`github-app-manifest.json`](https://github.com/jegork/ai-review/blob/main/github-app-manifest.json)
+Use the [`github-app-manifest.json`](https://github.com/jegork/rusty-bot/blob/main/github-app-manifest.json)
 template, or create a new App at
 `https://github.com/settings/apps/new` with these permissions:
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
       link: /getting-started/
       icon: right-arrow
     - text: View on GitHub
-      link: https://github.com/jegork/ai-review
+      link: https://github.com/jegork/rusty-bot
       icon: external
       variant: minimal
 ---

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -31,6 +31,6 @@ server, and the Azure DevOps task without duplication.
 | `RUSTY_LINEAR_API_KEY` | Linear API key (also exposed as the `linear-api-key` action input). |
 
 For the canonical list, see
-[`action.yml`](https://github.com/jegork/ai-review/blob/main/action.yml) and
-[`.env.example`](https://github.com/jegork/ai-review/blob/main/.env.example) in
+[`action.yml`](https://github.com/jegork/rusty-bot/blob/main/action.yml) and
+[`.env.example`](https://github.com/jegork/rusty-bot/blob/main/.env.example) in
 the repo.

--- a/docs/src/content/docs/reference/inputs.md
+++ b/docs/src/content/docs/reference/inputs.md
@@ -1,6 +1,6 @@
 ---
 title: Action inputs
-description: Inputs accepted by the jegork/ai-review GitHub Action.
+description: Inputs accepted by the jegork/rusty-bot GitHub Action.
 ---
 
 Pass these via the `with:` block of the action step. Only `github-token` is

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -10,7 +10,7 @@ const BASE_EVENT: PullRequestEvent = {
 function makeEnv(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
   const defaults: Record<string, string> = {
     GITHUB_TOKEN: "ghs_abc123",
-    GITHUB_REPOSITORY: "jegork/ai-review",
+    GITHUB_REPOSITORY: "jegork/rusty-bot",
     ANTHROPIC_API_KEY: "sk-ant-test",
   };
   const merged: NodeJS.ProcessEnv = {};
@@ -37,7 +37,7 @@ describe("parseConfig", () => {
   it("parses a minimal valid config", () => {
     const config = parseConfig({ event: BASE_EVENT, env: makeEnv() });
     expect(config.owner).toBe("jegork");
-    expect(config.repo).toBe("ai-review");
+    expect(config.repo).toBe("rusty-bot");
     expect(config.pullNumber).toBe(42);
     expect(config.token).toBe("ghs_abc123");
     expect(config.review.style).toBe("balanced");

--- a/packages/github-action/src/__tests__/event.test.ts
+++ b/packages/github-action/src/__tests__/event.test.ts
@@ -6,7 +6,7 @@ import { readEventPayload, parseOwnerRepo, extractPullNumber, shouldSkipEvent } 
 
 describe("parseOwnerRepo", () => {
   it("splits a valid owner/repo string", () => {
-    expect(parseOwnerRepo("jegork/ai-review")).toEqual({ owner: "jegork", repo: "ai-review" });
+    expect(parseOwnerRepo("jegork/rusty-bot")).toEqual({ owner: "jegork", repo: "rusty-bot" });
   });
 
   it("throws on missing slash", () => {
@@ -119,7 +119,7 @@ describe("readEventPayload", () => {
           head: { ref: "feat", sha: "abc" },
           base: { ref: "main", sha: "def" },
         },
-        repository: { name: "ai-review", owner: { login: "jegork" } },
+        repository: { name: "rusty-bot", owner: { login: "jegork" } },
       }),
     );
 

--- a/skills/pr-comment-monitor/SKILL.md
+++ b/skills/pr-comment-monitor/SKILL.md
@@ -97,6 +97,6 @@ Always leave a short summary at the end: mode used, how many iterations ran, how
 
 ## Authentication notes
 
-- GitHub MCP tools in this harness are scoped to `jegork/ai-review`. Outside that repo, fall back to `gh` or a `GITHUB_TOKEN` env var.
+- GitHub MCP tools in this harness are scoped to `jegork/rusty-bot`. Outside that repo, fall back to `gh` or a `GITHUB_TOKEN` env var.
 - For Azure DevOps use `RUSTY_ADO_PAT` (already documented in this repo's `.env.example`) or `SYSTEM_ACCESSTOKEN` when running in a pipeline.
 - Never echo tokens into the terminal output or commit messages.


### PR DESCRIPTION
## Summary

- Updates all references to `jegork/ai-review` → `jegork/rusty-bot` and `ghcr.io/jegork/ai-review` → `ghcr.io/jegork/rusty-bot`
- Fixes the Astro docs `base` path: `/ai-review` → `/rusty-bot`
- Updates `cleanup-images.yml` package name so the container cleanup cron targets the right GHCR package after rename
- Updates test fixtures to match the new repo name

## After merging

1. Rename the GitHub repo: **Settings → General → Repository name → `rusty-bot`**
2. GitHub will automatically redirect the old URL and update the Pages deployment path to `jegork.github.io/rusty-bot/`
3. Update the local remote: `git remote set-url origin git@github.com:jegork/rusty-bot.git`
4. Re-tag and push the Docker image to `ghcr.io/jegork/rusty-bot` (the old package will keep serving from the redirect until you archive it)

## Test plan
- [ ] `pnpm test` — 583 tests pass ✅ (verified locally)
- [ ] Docs build clean — verified locally
- [ ] No remaining `ai-review` references outside of CHANGELOG