### PR TITLE
chore: rename repo from ai-review to rusty-bot

### DIFF
--- a/.github/workflows/cleanup-images.yml
+++ b/.github/workflows/cleanup-images.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/delete-package-versions@v5
         with:
-          package-name: ai-review
+          package-name: rusty-bot
           package-type: container
           min-versions-to-keep: 10
           delete-only-untagged-versions: true

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: jegork/ai-review@v1
+      - uses: jegork/rusty-bot@v1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
         env:
@@ -135,7 +135,7 @@ jobs:
 
 Everything else — `RUSTY_REVIEW_STYLE`, `RUSTY_FOCUS_AREAS`, `RUSTY_LLM_MODEL`, `RUSTY_JUDGE_*`, `RUSTY_LLM_TRIAGE_MODEL`, temperatures, `RUSTY_OPENGREP_RULES`, `RUSTY_REVIEW_DRAFTS`, etc. — is set per-step via `env:`. See the env-var table below for the full list.
 
-The Action runs inside the published Docker image (`ghcr.io/jegork/ai-review:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
+The Action runs inside the published Docker image (`ghcr.io/jegork/rusty-bot:latest`), which includes OpenGrep. First run in a repo adds ~20–40s for the image pull; subsequent runs are cached by the runner.
 
 **Skipped events:** the Action exits early with no error for `closed`/`labeled`/`unlabeled`/`assigned`/`unassigned` and for draft PRs (unless `review-drafts: "true"`).
 
@@ -155,7 +155,7 @@ pool:
   vmImage: ubuntu-latest
 
 container:
-  image: ghcr.io/jegork/ai-review:latest
+  image: ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: pipeline
 
@@ -555,10 +555,10 @@ This repo publishes agent skills under `skills/`. They're indexed by [skills.sh]
 
 ```bash
 # install every skill in this repo
-npx skills add jegork/ai-review
+npx skills add jegork/rusty-bot
 
 # or just one
-npx skills add jegork/ai-review/pr-comment-monitor
+npx skills add jegork/rusty-bot/pr-comment-monitor
 ```
 
 Available skills:

--- a/azure-pipelines-example.yml
+++ b/azure-pipelines-example.yml
@@ -9,7 +9,7 @@ pool:
   vmImage: ubuntu-latest
 
 container:
-  image: ghcr.io/jegork/ai-review:latest
+  image: ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: pipeline
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -4,7 +4,7 @@ import starlight from "@astrojs/starlight";
 
 export default defineConfig({
   site: "https://jegork.github.io",
-  base: "/ai-review",
+  base: "/rusty-bot",
   integrations: [
     starlight({
       title: "Rusty Bot",
@@ -14,11 +14,11 @@ export default defineConfig({
         {
           icon: "github",
           label: "GitHub",
-          href: "https://github.com/jegork/ai-review",
+          href: "https://github.com/jegork/rusty-bot",
         },
       ],
       editLink: {
-        baseUrl: "https://github.com/jegork/ai-review/edit/main/docs/",
+        baseUrl: "https://github.com/jegork/rusty-bot/edit/main/docs/",
       },
       lastUpdated: true,
       pagination: true,

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -25,7 +25,7 @@ jobs:
   review:
     runs-on: ubuntu-latest
     steps:
-      - uses: jegork/ai-review@v1
+      - uses: jegork/rusty-bot@v1
         env:
           RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
           RUSTY_REVIEW_STYLE: balanced

--- a/docs/src/content/docs/guides/gating-merges.md
+++ b/docs/src/content/docs/guides/gating-merges.md
@@ -12,7 +12,7 @@ Setting `RUSTY_FAIL_ON_CRITICAL=true` causes Rusty Bot to exit with code 1 when 
 Add `RUSTY_FAIL_ON_CRITICAL: "true"` to the step `env:`:
 
 ```yaml
-- uses: jegork/ai-review@v1
+- uses: jegork/rusty-bot@v1
   env:
     RUSTY_FAIL_ON_CRITICAL: "true"
   with:

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -9,7 +9,7 @@ hero:
       link: /getting-started/
       icon: right-arrow
     - text: View on GitHub
-      link: https://github.com/jegork/ai-review
+      link: https://github.com/jegork/rusty-bot
       icon: external
       variant: minimal
 ---

--- a/docs/src/content/docs/providers/azure-devops.md
+++ b/docs/src/content/docs/providers/azure-devops.md
@@ -24,7 +24,7 @@ pool:
   vmImage: ubuntu-latest
 
 container:
-  image: ghcr.io/jegork/ai-review:latest
+  image: ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: pipeline
 

--- a/docs/src/content/docs/providers/github-action.md
+++ b/docs/src/content/docs/providers/github-action.md
@@ -22,7 +22,7 @@ jobs:
       contents: read
       issues: read
     steps:
-      - uses: jegork/ai-review@v1
+      - uses: jegork/rusty-bot@v1
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
         env:
@@ -76,4 +76,4 @@ The Action exits early (no error, no review) for these PR event types:
 
 ## Docker image
 
-The Action runs inside `ghcr.io/jegork/ai-review:latest`, which includes OpenGrep. The first run in a fresh runner environment adds roughly 20–40s for the image pull; subsequent runs on cached runners skip this entirely.
+The Action runs inside `ghcr.io/jegork/rusty-bot:latest`, which includes OpenGrep. The first run in a fresh runner environment adds roughly 20–40s for the image pull; subsequent runs on cached runners skip this entirely.

--- a/docs/src/content/docs/providers/github-app.md
+++ b/docs/src/content/docs/providers/github-app.md
@@ -7,7 +7,7 @@ The GitHub Action runs once per PR on a GitHub-hosted runner. If you'd rather ru
 
 ## 1. Create the App
 
-Use the [`github-app-manifest.json`](https://github.com/jegork/ai-review/blob/main/github-app-manifest.json)
+Use the [`github-app-manifest.json`](https://github.com/jegork/rusty-bot/blob/main/github-app-manifest.json)
 template, or create a new App at
 `https://github.com/settings/apps/new` with these permissions:
 

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -118,6 +118,6 @@ See [GitHub App (self-hosted)](/providers/github-app/).
 ---
 
 For the canonical list, see
-[`action.yml`](https://github.com/jegork/ai-review/blob/main/action.yml) and
-[`.env.example`](https://github.com/jegork/ai-review/blob/main/.env.example) in
+[`action.yml`](https://github.com/jegork/rusty-bot/blob/main/action.yml) and
+[`.env.example`](https://github.com/jegork/rusty-bot/blob/main/.env.example) in
 the repo.

--- a/docs/src/content/docs/reference/inputs.md
+++ b/docs/src/content/docs/reference/inputs.md
@@ -1,6 +1,6 @@
 ---
 title: Action inputs
-description: Inputs accepted by the jegork/ai-review GitHub Action.
+description: Inputs accepted by the jegork/rusty-bot GitHub Action.
 ---
 
 Pass these via the `with:` block of the action step. Only `github-token` is

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -10,7 +10,7 @@ const BASE_EVENT: PullRequestEvent = {
 function makeEnv(overrides: Record<string, string | undefined> = {}): NodeJS.ProcessEnv {
   const defaults: Record<string, string> = {
     GITHUB_TOKEN: "ghs_abc123",
-    GITHUB_REPOSITORY: "jegork/ai-review",
+    GITHUB_REPOSITORY: "jegork/rusty-bot",
     ANTHROPIC_API_KEY: "sk-ant-test",
   };
   const merged: NodeJS.ProcessEnv = {};
@@ -37,7 +37,7 @@ describe("parseConfig", () => {
   it("parses a minimal valid config", () => {
     const config = parseConfig({ event: BASE_EVENT, env: makeEnv() });
     expect(config.owner).toBe("jegork");
-    expect(config.repo).toBe("ai-review");
+    expect(config.repo).toBe("rusty-bot");
     expect(config.pullNumber).toBe(42);
     expect(config.token).toBe("ghs_abc123");
     expect(config.review.style).toBe("balanced");

--- a/packages/github-action/src/__tests__/event.test.ts
+++ b/packages/github-action/src/__tests__/event.test.ts
@@ -6,7 +6,7 @@ import { readEventPayload, parseOwnerRepo, extractPullNumber, shouldSkipEvent } 
 
 describe("parseOwnerRepo", () => {
   it("splits a valid owner/repo string", () => {
-    expect(parseOwnerRepo("jegork/ai-review")).toEqual({ owner: "jegork", repo: "ai-review" });
+    expect(parseOwnerRepo("jegork/rusty-bot")).toEqual({ owner: "jegork", repo: "rusty-bot" });
   });
 
   it("throws on missing slash", () => {
@@ -119,7 +119,7 @@ describe("readEventPayload", () => {
           head: { ref: "feat", sha: "abc" },
           base: { ref: "main", sha: "def" },
         },
-        repository: { name: "ai-review", owner: { login: "jegork" } },
+        repository: { name: "rusty-bot", owner: { login: "jegork" } },
       }),
     );
 


### PR DESCRIPTION
Replaces PR #79 (which had merge conflicts after #76 and #78 landed).

## Changes

- All `jegork/ai-review` references → `jegork/rusty-bot`
- All `ghcr.io/jegork/ai-review` → `ghcr.io/jegork/rusty-bot`
- Astro docs `base` path: `/ai-review` → `/rusty-bot`
- `cleanup-images.yml` package name updated (so the cron targets the right GHCR package)
- Test fixtures updated to match new repo name

## Test plan
- [x] 583 tests pass locally
- [x] No remaining `ai-review` references outside of CHANGELOG