### PR TITLE
ci: pull prebuilt action image from GHCR

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,7 @@ inputs:
 # See the README for the full list of RUSTY_* env vars.
 runs:
   using: docker
-  image: Dockerfile
+  image: docker://ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: github-action
     GITHUB_TOKEN: ${{ inputs.github-token }}


### PR DESCRIPTION
## Summary

- `action.yml` declared `image: Dockerfile`, forcing every action run to rebuild the multi-stage image from scratch (apt-get + OpenGrep download + pnpm install ×2 + tsc across 5 packages). That's ~90 s of pure docker-build overhead per PR review, charged to the consumer's Actions quota.
- `publish-image.yml` already ships `ghcr.io/jegork/rusty-bot:latest` on every main push, so we can just pull it. Switches the action to `image: docker://ghcr.io/jegork/rusty-bot:latest` — runners pull (~20–40 s) instead of build.
- Stuck with `:latest` for now because the v1.0.1 release-please run pushed `:v1` / `:v1.0` / `:v1.0.1` to the old `ai-review` GHCR package (it ran before #80's rename), so those tags don't yet exist on `rusty-bot`. The next release-please cut will populate them and we can pin to `:v1`.

## Test plan

- [ ] After merge, confirm `Rusty Bot Review` workflow on the next PR pulls `ghcr.io/jegork/rusty-bot:latest` instead of running `docker build` against `Dockerfile`
- [ ] Verify total job duration drops by ~90 s vs. baseline runs on `main`
- [ ] Confirm action still posts review comments end-to-end (no behavioral regression)