### PR TITLE
feat: rewrite non-conventional PR titles into conventional commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,12 +213,14 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_CASCADE_ENABLED` | explicitly enable/disable cascading (`true`/`false`) | auto (enabled when triage model is set) |
 | `RUSTY_OPENGREP_RULES` | OpenGrep config string (ruleset or path to rule file) | `auto` |
 | `RUSTY_GENERATE_DESCRIPTION` | generate PR description when empty/placeholder | `false` |
+| `RUSTY_RENAME_TITLE_TO_CONVENTIONAL` | rewrite non-conventional PR titles into Conventional Commits format | `false` |
 | `RUSTY_LLM_TEMPERATURE` | global LLM temperature | provider default |
 | `RUSTY_LLM_TOP_P` | global LLM top-p | provider default |
 | `RUSTY_REVIEW_TEMPERATURE` | temperature override for the review agent | `RUSTY_LLM_TEMPERATURE` |
 | `RUSTY_TRIAGE_TEMPERATURE` | temperature override for the triage agent | `RUSTY_LLM_TEMPERATURE` |
 | `RUSTY_JUDGE_TEMPERATURE` | temperature override for the judge agent | `RUSTY_LLM_TEMPERATURE` |
 | `RUSTY_DESCRIPTION_TEMPERATURE` | temperature override for the description agent | `RUSTY_LLM_TEMPERATURE` |
+| `RUSTY_TITLE_TEMPERATURE` | temperature override for the title-rename agent | `RUSTY_LLM_TEMPERATURE` |
 
 ### LLM Provider Configuration
 
@@ -494,6 +496,25 @@ Or per-repo in the dashboard (PR Description checkbox).
 5. The review then runs with the generated description visible in the PR metadata
 
 **Safety:** The bot never overwrites a human-written description. The detection is conservative — any description with meaningful prose, issue references, or structured content is left untouched. Bot-generated descriptions (identified by an HTML marker) can be regenerated on subsequent runs.
+
+### Conventional Commit Title Rewriting
+
+When a PR title does not already follow the [Conventional Commits](https://www.conventionalcommits.org/) spec (e.g. `feat: add login`, `fix(auth): handle expired tokens`), Rusty Bot can rewrite it into one before the review starts. Useful when squash-merging into a repo that derives changelog/release notes from PR titles.
+
+Off by default. Enable via:
+
+```bash
+RUSTY_RENAME_TITLE_TO_CONVENTIONAL=true
+```
+
+**How it works:**
+
+1. Before the review starts, the bot inspects the current PR title
+2. If the title already matches the Conventional Commits regex (`type(scope)?!?: subject`), it is left untouched
+3. Otherwise, a dedicated agent picks a `type` (`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`), an optional `scope`, a cleaned subject line, and a breaking-change flag based on the diff and metadata
+4. The new title is written back to the PR via the platform API and used for the rest of the run
+
+**Safety:** Already-conventional titles are never modified. The agent reuses wording from the original title and only adjusts the prefix, scope, and casing. The rewrite is wrapped in a try/catch — failures are logged and the review continues with the original title.
 
 ### Tree-sitter Context Expansion
 

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -22,6 +22,8 @@ import {
   extractChangedFilePaths,
   generatePRDescription,
   shouldGenerateDescription,
+  generateConventionalTitle,
+  isConventionalTitle,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -107,6 +109,27 @@ async function main(): Promise<void> {
     { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
     "files changed",
   );
+
+  if (process.env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true") {
+    try {
+      if (!isConventionalTitle(metadata.title)) {
+        const titleResult = await generateConventionalTitle(reviewable, metadata);
+        await provider.updatePRTitle(titleResult.title);
+        log.info(
+          {
+            originalTitle: metadata.title,
+            newTitle: titleResult.title,
+            model: titleResult.modelUsed,
+            tokens: titleResult.tokenCount,
+          },
+          "renamed PR title to conventional commit format",
+        );
+        metadata.title = titleResult.title;
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to rename PR title, continuing with review");
+    }
+  }
 
   if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
     try {

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -383,4 +383,11 @@ export class AzureDevOpsProvider implements GitProvider {
       body: JSON.stringify({ description }),
     });
   }
+
+  async updatePRTitle(title: string): Promise<void> {
+    await this.fetchApi(`${this.baseUrl}/pullRequests/${this.pullRequestId}?${API_VERSION}`, {
+      method: "PATCH",
+      body: JSON.stringify({ title }),
+    });
+  }
 }

--- a/packages/core/src/__tests__/title.test.ts
+++ b/packages/core/src/__tests__/title.test.ts
@@ -233,6 +233,22 @@ describe("formatConventionalTitle", () => {
     expect(result.startsWith("refactor!: ")).toBe(true);
     expect(isConventionalTitle(result)).toBe(true);
   });
+
+  it("drops the scope and then truncates when both are needed", () => {
+    const scope = "a".repeat(50);
+    const subject = "b".repeat(MAX_TITLE_LENGTH + 100);
+    const result = formatConventionalTitle({
+      type: "feat",
+      scope,
+      subject,
+      isBreaking: false,
+    });
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(result).not.toContain("(");
+    expect(result.startsWith("feat: ")).toBe(true);
+    expect(result.endsWith("…")).toBe(true);
+    expect(isConventionalTitle(result)).toBe(true);
+  });
 });
 
 describe("ConventionalTitleOutputSchema", () => {

--- a/packages/core/src/__tests__/title.test.ts
+++ b/packages/core/src/__tests__/title.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { z } from "zod";
-import { isConventionalTitle, formatConventionalTitle } from "../title/parse.js";
+import { isConventionalTitle, formatConventionalTitle, MAX_TITLE_LENGTH } from "../title/parse.js";
 import { ConventionalTitleOutputSchema } from "../title/schema.js";
 import { buildTitleUserMessage } from "../title/prompt.js";
 import type { PRMetadata } from "../types.js";
@@ -180,6 +180,59 @@ describe("formatConventionalTitle", () => {
     });
     expect(isConventionalTitle(output)).toBe(true);
   });
+
+  it("leaves a title that fits within the limit unchanged", () => {
+    const subject = "a".repeat(200);
+    const result = formatConventionalTitle({
+      type: "feat",
+      scope: "auth",
+      subject,
+      isBreaking: false,
+    });
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(result).toBe(`feat(auth): ${subject}`);
+  });
+
+  it("drops the scope when including it would exceed the title limit", () => {
+    const scope = "a".repeat(50);
+    const subject = "b".repeat(MAX_TITLE_LENGTH - 10);
+    const result = formatConventionalTitle({
+      type: "feat",
+      scope,
+      subject,
+      isBreaking: false,
+    });
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(result).not.toContain("(");
+    expect(result).toBe(`feat: ${subject}`);
+  });
+
+  it("truncates the subject when it alone overflows the title limit", () => {
+    const subject = "a".repeat(MAX_TITLE_LENGTH + 100);
+    const result = formatConventionalTitle({
+      type: "feat",
+      scope: null,
+      subject,
+      isBreaking: false,
+    });
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(result.startsWith("feat: ")).toBe(true);
+    expect(result.endsWith("…")).toBe(true);
+    expect(isConventionalTitle(result)).toBe(true);
+  });
+
+  it("preserves the breaking marker after truncation", () => {
+    const subject = "a".repeat(MAX_TITLE_LENGTH + 50);
+    const result = formatConventionalTitle({
+      type: "refactor",
+      scope: "api",
+      subject,
+      isBreaking: true,
+    });
+    expect(result.length).toBeLessThanOrEqual(MAX_TITLE_LENGTH);
+    expect(result.startsWith("refactor!: ")).toBe(true);
+    expect(isConventionalTitle(result)).toBe(true);
+  });
 });
 
 describe("ConventionalTitleOutputSchema", () => {
@@ -215,6 +268,26 @@ describe("ConventionalTitleOutputSchema", () => {
 
   it("rejects missing required fields", () => {
     expect(ConventionalTitleOutputSchema.safeParse({ type: "feat" }).success).toBe(false);
+  });
+
+  it("rejects empty subject", () => {
+    const invalid = {
+      type: "feat",
+      scope: null,
+      subject: "",
+      isBreaking: false,
+    };
+    expect(ConventionalTitleOutputSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects empty scope (must be null instead)", () => {
+    const invalid = {
+      type: "feat",
+      scope: "",
+      subject: "do thing",
+      isBreaking: false,
+    };
+    expect(ConventionalTitleOutputSchema.safeParse(invalid).success).toBe(false);
   });
 
   it("passes openai strict mode — all properties in required", () => {

--- a/packages/core/src/__tests__/title.test.ts
+++ b/packages/core/src/__tests__/title.test.ts
@@ -1,0 +1,283 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { isConventionalTitle, formatConventionalTitle } from "../title/parse.js";
+import { ConventionalTitleOutputSchema } from "../title/schema.js";
+import { buildTitleUserMessage } from "../title/prompt.js";
+import type { PRMetadata } from "../types.js";
+
+const prMetadata: PRMetadata = {
+  id: "42",
+  title: "Add user authentication",
+  description: "",
+  author: "dev123",
+  sourceBranch: "feature/auth",
+  targetBranch: "main",
+  url: "https://github.com/org/repo/pull/42",
+};
+
+describe("isConventionalTitle", () => {
+  it("accepts simple type + subject", () => {
+    expect(isConventionalTitle("feat: add login flow")).toBe(true);
+  });
+
+  it("accepts type with scope", () => {
+    expect(isConventionalTitle("fix(auth): handle expired tokens")).toBe(true);
+  });
+
+  it("accepts breaking change marker", () => {
+    expect(isConventionalTitle("feat!: drop node 18 support")).toBe(true);
+  });
+
+  it("accepts breaking change with scope", () => {
+    expect(isConventionalTitle("refactor(api)!: rename /v1 endpoints")).toBe(true);
+  });
+
+  it("accepts every supported type", () => {
+    const types = [
+      "feat",
+      "fix",
+      "docs",
+      "style",
+      "refactor",
+      "perf",
+      "test",
+      "build",
+      "ci",
+      "chore",
+      "revert",
+    ];
+    for (const t of types) {
+      expect(isConventionalTitle(`${t}: do something`)).toBe(true);
+    }
+  });
+
+  it("is case-insensitive on the type", () => {
+    expect(isConventionalTitle("Fix: use bcrypt")).toBe(true);
+    expect(isConventionalTitle("FEAT: add OAuth")).toBe(true);
+  });
+
+  it("trims surrounding whitespace before matching", () => {
+    expect(isConventionalTitle("  feat: trimmed  ")).toBe(true);
+  });
+
+  it("rejects unknown types", () => {
+    expect(isConventionalTitle("wip: something")).toBe(false);
+    expect(isConventionalTitle("update: something")).toBe(false);
+  });
+
+  it("rejects missing colon", () => {
+    expect(isConventionalTitle("feat add login flow")).toBe(false);
+  });
+
+  it("rejects missing space after colon", () => {
+    expect(isConventionalTitle("feat:add login flow")).toBe(false);
+  });
+
+  it("rejects missing subject after colon", () => {
+    expect(isConventionalTitle("feat: ")).toBe(false);
+    expect(isConventionalTitle("feat:")).toBe(false);
+  });
+
+  it("rejects empty scope", () => {
+    expect(isConventionalTitle("feat(): add login")).toBe(false);
+  });
+
+  it("rejects type that only starts with a conventional prefix", () => {
+    expect(isConventionalTitle("feature: add login")).toBe(false);
+    expect(isConventionalTitle("fixes: a thing")).toBe(false);
+  });
+
+  it("rejects plain prose", () => {
+    expect(isConventionalTitle("Add user authentication")).toBe(false);
+    expect(isConventionalTitle("Bump dependencies")).toBe(false);
+  });
+});
+
+describe("formatConventionalTitle", () => {
+  it("formats type + subject", () => {
+    expect(
+      formatConventionalTitle({
+        type: "feat",
+        scope: null,
+        subject: "add login flow",
+        isBreaking: false,
+      }),
+    ).toBe("feat: add login flow");
+  });
+
+  it("formats type + scope + subject", () => {
+    expect(
+      formatConventionalTitle({
+        type: "fix",
+        scope: "auth",
+        subject: "handle expired tokens",
+        isBreaking: false,
+      }),
+    ).toBe("fix(auth): handle expired tokens");
+  });
+
+  it("appends breaking change marker without scope", () => {
+    expect(
+      formatConventionalTitle({
+        type: "feat",
+        scope: null,
+        subject: "drop node 18",
+        isBreaking: true,
+      }),
+    ).toBe("feat!: drop node 18");
+  });
+
+  it("appends breaking change marker with scope", () => {
+    expect(
+      formatConventionalTitle({
+        type: "refactor",
+        scope: "api",
+        subject: "rename /v1",
+        isBreaking: true,
+      }),
+    ).toBe("refactor(api)!: rename /v1");
+  });
+
+  it("treats blank scope as no scope", () => {
+    expect(
+      formatConventionalTitle({
+        type: "chore",
+        scope: "   ",
+        subject: "bump deps",
+        isBreaking: false,
+      }),
+    ).toBe("chore: bump deps");
+  });
+
+  it("strips trailing period from subject", () => {
+    expect(
+      formatConventionalTitle({
+        type: "docs",
+        scope: null,
+        subject: "update changelog.",
+        isBreaking: false,
+      }),
+    ).toBe("docs: update changelog");
+  });
+
+  it("trims surrounding whitespace from subject and scope", () => {
+    expect(
+      formatConventionalTitle({
+        type: "fix",
+        scope: "  cli  ",
+        subject: "  handle empty args  ",
+        isBreaking: false,
+      }),
+    ).toBe("fix(cli): handle empty args");
+  });
+
+  it("produces output that round-trips through isConventionalTitle", () => {
+    const output = formatConventionalTitle({
+      type: "feat",
+      scope: "auth",
+      subject: "add OAuth flow",
+      isBreaking: true,
+    });
+    expect(isConventionalTitle(output)).toBe(true);
+  });
+});
+
+describe("ConventionalTitleOutputSchema", () => {
+  it("validates a well-formed output", () => {
+    const valid = {
+      type: "feat",
+      scope: "auth",
+      subject: "add OAuth login",
+      isBreaking: false,
+    };
+    expect(ConventionalTitleOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("validates output with null scope", () => {
+    const valid = {
+      type: "chore",
+      scope: null,
+      subject: "bump deps",
+      isBreaking: false,
+    };
+    expect(ConventionalTitleOutputSchema.safeParse(valid).success).toBe(true);
+  });
+
+  it("rejects unknown type", () => {
+    const invalid = {
+      type: "wip",
+      scope: null,
+      subject: "something",
+      isBreaking: false,
+    };
+    expect(ConventionalTitleOutputSchema.safeParse(invalid).success).toBe(false);
+  });
+
+  it("rejects missing required fields", () => {
+    expect(ConventionalTitleOutputSchema.safeParse({ type: "feat" }).success).toBe(false);
+  });
+
+  it("passes openai strict mode — all properties in required", () => {
+    interface JsonSchemaObject {
+      properties?: Record<string, JsonSchemaObject>;
+      required?: string[];
+      items?: JsonSchemaObject;
+      additionalProperties?: boolean;
+      anyOf?: JsonSchemaObject[];
+    }
+
+    function collectViolations(schema: JsonSchemaObject, path = ""): string[] {
+      const violations: string[] = [];
+      if (schema.properties) {
+        const propKeys = Object.keys(schema.properties);
+        const required = new Set(schema.required ?? []);
+        for (const key of propKeys) {
+          if (!required.has(key)) {
+            violations.push(`${path}.${key} missing from required`);
+          }
+        }
+        if (schema.additionalProperties !== false) {
+          violations.push(`${path} must set additionalProperties to false`);
+        }
+        for (const [key, value] of Object.entries(schema.properties)) {
+          violations.push(...collectViolations(value, `${path}.${key}`));
+        }
+      }
+      if (schema.items) violations.push(...collectViolations(schema.items, `${path}[]`));
+      for (const branch of schema.anyOf ?? []) {
+        violations.push(...collectViolations(branch, path));
+      }
+      return violations;
+    }
+
+    const jsonSchema = z.toJSONSchema(ConventionalTitleOutputSchema) as JsonSchemaObject;
+    const violations = collectViolations(jsonSchema);
+    expect(violations, violations.join("\n")).toEqual([]);
+  });
+});
+
+describe("buildTitleUserMessage", () => {
+  it("includes the current title and branch info", () => {
+    const msg = buildTitleUserMessage("diff content", prMetadata);
+    expect(msg).toContain("Add user authentication");
+    expect(msg).toContain("feature/auth");
+    expect(msg).toContain("main");
+  });
+
+  it("includes the diff", () => {
+    const msg = buildTitleUserMessage("+ new line\n- old line", prMetadata);
+    expect(msg).toContain("+ new line");
+    expect(msg).toContain("- old line");
+  });
+
+  it("includes description when present", () => {
+    const msg = buildTitleUserMessage("diff", { ...prMetadata, description: "Adds OAuth" });
+    expect(msg).toContain("## Description");
+    expect(msg).toContain("Adds OAuth");
+  });
+
+  it("omits description section when blank", () => {
+    const msg = buildTitleUserMessage("diff", { ...prMetadata, description: "   " });
+    expect(msg).not.toContain("## Description");
+  });
+});

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -115,13 +115,14 @@ export interface ModelSettings {
   topP?: number;
 }
 
-type AgentKind = "review" | "triage" | "judge" | "description";
+type AgentKind = "review" | "triage" | "judge" | "description" | "title";
 
 const AGENT_ENV_PREFIX: Record<AgentKind, string> = {
   review: "RUSTY_REVIEW",
   triage: "RUSTY_TRIAGE",
   judge: "RUSTY_JUDGE",
   description: "RUSTY_DESCRIPTION",
+  title: "RUSTY_TITLE",
 };
 
 function readNumericEnv(

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,4 +40,5 @@ export * from "./mcp/index.js";
 export * from "./triage/index.js";
 export * from "./opengrep/index.js";
 export * from "./description/index.js";
+export * from "./title/index.js";
 export { fetchConventionFile } from "./convention-file.js";

--- a/packages/core/src/title/generate.ts
+++ b/packages/core/src/title/generate.ts
@@ -1,0 +1,59 @@
+import { Agent } from "@mastra/core/agent";
+import { compressDiff } from "../diff/compress.js";
+import {
+  resolveModelConfig,
+  resolveModel,
+  getModelDisplayName,
+  resolveModelSettings,
+} from "../agent/model.js";
+import { ConventionalTitleOutputSchema, type ConventionalTitleOutput } from "./schema.js";
+import { buildTitleSystemPrompt, buildTitleUserMessage } from "./prompt.js";
+import { formatConventionalTitle, isConventionalTitle } from "./parse.js";
+import type { FilePatch, PRMetadata } from "../types.js";
+
+const MAX_TITLE_TOKENS = 12_000;
+
+export interface GenerateTitleResult {
+  title: string;
+  output: ConventionalTitleOutput;
+  modelUsed: string;
+  tokenCount: number;
+}
+
+export async function generateConventionalTitle(
+  patches: FilePatch[],
+  prMetadata: PRMetadata,
+): Promise<GenerateTitleResult> {
+  const { compressed } = compressDiff(patches, MAX_TITLE_TOKENS);
+
+  const modelConfig = resolveModelConfig();
+  const model = resolveModel(modelConfig);
+  const modelName = getModelDisplayName(modelConfig);
+
+  const agent = new Agent({
+    id: "title-agent",
+    name: "Rusty Bot Title Generator",
+    instructions: buildTitleSystemPrompt(),
+    model,
+  });
+
+  const userMessage = buildTitleUserMessage(compressed, prMetadata);
+
+  const modelSettings = resolveModelSettings("title");
+  const response = await agent.generate(userMessage, {
+    structuredOutput: { schema: ConventionalTitleOutputSchema },
+    ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+  });
+
+  const parsed = response.object;
+  const tokenCount = response.usage.totalTokens ?? 0;
+
+  return {
+    title: formatConventionalTitle(parsed),
+    output: parsed,
+    modelUsed: modelName,
+    tokenCount,
+  };
+}
+
+export { isConventionalTitle, formatConventionalTitle };

--- a/packages/core/src/title/generate.ts
+++ b/packages/core/src/title/generate.ts
@@ -48,8 +48,13 @@ export async function generateConventionalTitle(
   const parsed = response.object;
   const tokenCount = response.usage.totalTokens ?? 0;
 
+  const title = formatConventionalTitle(parsed);
+  if (!isConventionalTitle(title)) {
+    throw new Error(`generated title failed conventional commit validation: ${title}`);
+  }
+
   return {
-    title: formatConventionalTitle(parsed),
+    title,
     output: parsed,
     modelUsed: modelName,
     tokenCount,

--- a/packages/core/src/title/index.ts
+++ b/packages/core/src/title/index.ts
@@ -1,0 +1,9 @@
+export {
+  ConventionalTitleOutputSchema,
+  ConventionalCommitTypeSchema,
+  CONVENTIONAL_COMMIT_TYPES,
+} from "./schema.js";
+export type { ConventionalTitleOutput, ConventionalCommitType } from "./schema.js";
+export { isConventionalTitle, formatConventionalTitle } from "./parse.js";
+export { generateConventionalTitle } from "./generate.js";
+export type { GenerateTitleResult } from "./generate.js";

--- a/packages/core/src/title/parse.ts
+++ b/packages/core/src/title/parse.ts
@@ -1,0 +1,19 @@
+import { CONVENTIONAL_COMMIT_TYPES, type ConventionalTitleOutput } from "./schema.js";
+
+const TYPE_PATTERN = CONVENTIONAL_COMMIT_TYPES.join("|");
+const CONVENTIONAL_TITLE_REGEX = new RegExp(
+  `^(?:${TYPE_PATTERN})(?:\\([^)\\s][^)]*\\))?!?: \\S.*$`,
+  "i",
+);
+
+export function isConventionalTitle(title: string): boolean {
+  return CONVENTIONAL_TITLE_REGEX.test(title.trim());
+}
+
+export function formatConventionalTitle(output: ConventionalTitleOutput): string {
+  const scope = output.scope?.trim();
+  const scopePart = scope ? `(${scope})` : "";
+  const breakingMarker = output.isBreaking ? "!" : "";
+  const subject = output.subject.trim().replace(/\.$/, "");
+  return `${output.type}${scopePart}${breakingMarker}: ${subject}`;
+}

--- a/packages/core/src/title/parse.ts
+++ b/packages/core/src/title/parse.ts
@@ -6,14 +6,37 @@ const CONVENTIONAL_TITLE_REGEX = new RegExp(
   "i",
 );
 
+// github caps PR titles at 256, ado at 400. cap at the tighter limit so the same
+// rewritten title is safe to push to either provider.
+export const MAX_TITLE_LENGTH = 256;
+
 export function isConventionalTitle(title: string): boolean {
   return CONVENTIONAL_TITLE_REGEX.test(title.trim());
 }
 
-export function formatConventionalTitle(output: ConventionalTitleOutput): string {
-  const scope = output.scope?.trim();
+function buildTitle(
+  type: string,
+  scope: string | undefined,
+  breakingMarker: string,
+  subject: string,
+): string {
   const scopePart = scope ? `(${scope})` : "";
+  return `${type}${scopePart}${breakingMarker}: ${subject}`;
+}
+
+export function formatConventionalTitle(output: ConventionalTitleOutput): string {
+  const scope = output.scope?.trim() || undefined;
   const breakingMarker = output.isBreaking ? "!" : "";
   const subject = output.subject.trim().replace(/\.$/, "");
-  return `${output.type}${scopePart}${breakingMarker}: ${subject}`;
+
+  const full = buildTitle(output.type, scope, breakingMarker, subject);
+  if (full.length <= MAX_TITLE_LENGTH) return full;
+
+  const withoutScope = buildTitle(output.type, undefined, breakingMarker, subject);
+  if (withoutScope.length <= MAX_TITLE_LENGTH) return withoutScope;
+
+  const prefixLen = `${output.type}${breakingMarker}: `.length;
+  const room = MAX_TITLE_LENGTH - prefixLen - 1;
+  const truncatedSubject = room > 0 ? `${subject.slice(0, room).trimEnd()}…` : "…";
+  return buildTitle(output.type, undefined, breakingMarker, truncatedSubject);
 }

--- a/packages/core/src/title/prompt.ts
+++ b/packages/core/src/title/prompt.ts
@@ -1,0 +1,49 @@
+import type { PRMetadata } from "../types.js";
+import { CONVENTIONAL_COMMIT_TYPES } from "./schema.js";
+
+const TYPES_LIST = CONVENTIONAL_COMMIT_TYPES.join(", ");
+
+const SYSTEM_PROMPT = `You rewrite pull request titles into the Conventional Commits format.
+
+Output a structured object with: type, scope, subject, isBreaking.
+
+Rules:
+- type must be one of: ${TYPES_LIST}
+  - feat: a new user-facing feature or capability
+  - fix: a bug fix
+  - docs: docs/comments-only changes
+  - style: formatting/whitespace changes that do not affect behavior
+  - refactor: internal restructuring with no behavior change
+  - perf: performance improvements
+  - test: adding or updating tests only
+  - build: build system, packaging, or dependency changes
+  - ci: CI/CD pipeline changes
+  - chore: maintenance, tooling, or miscellaneous changes that do not fit elsewhere
+  - revert: reverts a previous commit
+- scope: a short single-token descriptor of the affected area (e.g. "auth", "api", "parser"). Use null when no clear scope applies — do NOT invent one.
+- subject: imperative mood, lowercase first letter, no trailing period, no type prefix. Reuse wording from the original title where possible; rewrite only to drop redundant prefixes ("Fix:", "Update:") and to switch to imperative mood.
+- isBreaking: true only when the diff clearly introduces an API/contract/schema/CLI break.
+
+Choose the type from the diff and metadata, not from the original title's wording.`;
+
+export function buildTitleSystemPrompt(): string {
+  return SYSTEM_PROMPT;
+}
+
+export function buildTitleUserMessage(diff: string, prMetadata: PRMetadata): string {
+  const parts: string[] = [];
+
+  parts.push("## Pull Request");
+  parts.push(`**Current title:** ${prMetadata.title}`);
+  parts.push(`**Branch:** ${prMetadata.sourceBranch} → ${prMetadata.targetBranch}`);
+
+  if (prMetadata.description.trim()) {
+    parts.push("\n## Description");
+    parts.push(prMetadata.description.trim());
+  }
+
+  parts.push("\n## Diff\n");
+  parts.push(diff);
+
+  return parts.join("\n");
+}

--- a/packages/core/src/title/schema.ts
+++ b/packages/core/src/title/schema.ts
@@ -24,12 +24,14 @@ export const ConventionalTitleOutputSchema = z.object({
   ),
   scope: z
     .string()
+    .min(1)
     .nullable()
     .describe(
       "optional short scope describing the area of the codebase affected (lowercase, no spaces); null when no clear scope applies",
     ),
   subject: z
     .string()
+    .min(1)
     .describe(
       "concise imperative-mood subject line, lowercase first letter, no trailing period, no type prefix",
     ),

--- a/packages/core/src/title/schema.ts
+++ b/packages/core/src/title/schema.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+export const CONVENTIONAL_COMMIT_TYPES = [
+  "feat",
+  "fix",
+  "docs",
+  "style",
+  "refactor",
+  "perf",
+  "test",
+  "build",
+  "ci",
+  "chore",
+  "revert",
+] as const;
+
+export type ConventionalCommitType = (typeof CONVENTIONAL_COMMIT_TYPES)[number];
+
+export const ConventionalCommitTypeSchema = z.enum(CONVENTIONAL_COMMIT_TYPES);
+
+export const ConventionalTitleOutputSchema = z.object({
+  type: ConventionalCommitTypeSchema.describe(
+    "the conventional commit type that best matches the change",
+  ),
+  scope: z
+    .string()
+    .nullable()
+    .describe(
+      "optional short scope describing the area of the codebase affected (lowercase, no spaces); null when no clear scope applies",
+    ),
+  subject: z
+    .string()
+    .describe(
+      "concise imperative-mood subject line, lowercase first letter, no trailing period, no type prefix",
+    ),
+  isBreaking: z
+    .boolean()
+    .describe("true when the change introduces a breaking API/contract/schema change"),
+});
+
+export type ConventionalTitleOutput = z.infer<typeof ConventionalTitleOutputSchema>;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -168,6 +168,7 @@ export interface GitProvider {
   postInlineComments(findings: Finding[]): Promise<void>;
   deleteExistingBotComments(): Promise<void>;
   updatePRDescription(description: string): Promise<void>;
+  updatePRTitle(title: string): Promise<void>;
 }
 
 export interface TicketProvider {

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -51,6 +51,7 @@ describe("parseConfig", () => {
     ]);
     expect(config.failOnCritical).toBe(true);
     expect(config.generateDescription).toBe(false);
+    expect(config.renameTitleToConventional).toBe(false);
   });
 
   it("throws when GITHUB_TOKEN is missing", () => {
@@ -260,5 +261,25 @@ describe("parseConfig", () => {
     ).toBe(false);
 
     expect(parseConfig({ event: BASE_EVENT, env: makeEnv() }).generateDescription).toBe(false);
+  });
+
+  it("enables conventional title rename only on exact 'true'", () => {
+    expect(
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_RENAME_TITLE_TO_CONVENTIONAL: "true" }),
+      }).renameTitleToConventional,
+    ).toBe(true);
+
+    expect(
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_RENAME_TITLE_TO_CONVENTIONAL: "1" }),
+      }).renameTitleToConventional,
+    ).toBe(false);
+
+    expect(parseConfig({ event: BASE_EVENT, env: makeEnv() }).renameTitleToConventional).toBe(
+      false,
+    );
   });
 });

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -25,6 +25,8 @@ import {
   extractChangedFilePaths,
   generatePRDescription,
   shouldGenerateDescription,
+  generateConventionalTitle,
+  isConventionalTitle,
   parseDiff,
 } from "@rusty-bot/core";
 import { GitHubProvider, createOctokitIssueFetcher } from "@rusty-bot/github";
@@ -50,6 +52,7 @@ export interface ActionConfig {
   review: ReviewConfig;
   failOnCritical: boolean;
   generateDescription: boolean;
+  renameTitleToConventional: boolean;
 }
 
 interface ParseConfigOptions {
@@ -129,6 +132,7 @@ export function parseConfig({ event, env = process.env }: ParseConfigOptions): A
       .filter(Boolean) ?? [];
   const failOnCritical = env.RUSTY_FAIL_ON_CRITICAL !== "false";
   const generateDescription = env.RUSTY_GENERATE_DESCRIPTION === "true";
+  const renameTitleToConventional = env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true";
 
   const octokit = new Octokit({ auth: token });
 
@@ -145,6 +149,7 @@ export function parseConfig({ event, env = process.env }: ParseConfigOptions): A
     },
     failOnCritical,
     generateDescription,
+    renameTitleToConventional,
   };
 }
 
@@ -219,6 +224,27 @@ export async function runAction(config: ActionConfig): Promise<number> {
     { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
     "files changed",
   );
+
+  if (config.renameTitleToConventional) {
+    try {
+      if (!isConventionalTitle(metadata.title)) {
+        const titleResult = await generateConventionalTitle(reviewable, metadata);
+        await provider.updatePRTitle(titleResult.title);
+        log.info(
+          {
+            originalTitle: metadata.title,
+            newTitle: titleResult.title,
+            model: titleResult.modelUsed,
+            tokens: titleResult.tokenCount,
+          },
+          "renamed PR title to conventional commit format",
+        );
+        metadata.title = titleResult.title;
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to rename PR title, continuing with review");
+    }
+  }
 
   if (config.generateDescription) {
     try {

--- a/packages/github/src/__tests__/provider.test.ts
+++ b/packages/github/src/__tests__/provider.test.ts
@@ -393,4 +393,22 @@ describe("GitHubProvider", () => {
       expect(patches).toHaveLength(0);
     });
   });
+
+  describe("updatePRTitle", () => {
+    it("PATCHes the pull request with the new title", async () => {
+      octokit.request.mockResolvedValueOnce({ data: {} });
+
+      await provider.updatePRTitle("feat: new feature");
+
+      expect(octokit.request).toHaveBeenCalledWith(
+        "PATCH /repos/{owner}/{repo}/pulls/{pull_number}",
+        {
+          owner: OWNER,
+          repo: REPO,
+          pull_number: PULL_NUMBER,
+          title: "feat: new feature",
+        },
+      );
+    });
+  });
 });

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -24,6 +24,8 @@ import {
   extractChangedFilePaths,
   generatePRDescription,
   shouldGenerateDescription,
+  generateConventionalTitle,
+  isConventionalTitle,
 } from "@rusty-bot/core";
 import { GitHubProvider } from "./provider.js";
 import { getRepoConfig, saveReview, getSetting, type ReviewRecord } from "./storage.js";
@@ -125,6 +127,31 @@ export async function orchestrateReview(params: {
     const patches = parseDiff(rawDiff);
     const filtered = filterFiles(patches, config.ignorePatterns);
     const reviewable = stripDeletionOnlyHunks(filtered);
+
+    const shouldRenameTitle =
+      repoConfig?.renameTitleToConventional ??
+      process.env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true";
+
+    if (shouldRenameTitle) {
+      try {
+        if (!isConventionalTitle(metadata.title)) {
+          const titleResult = await generateConventionalTitle(reviewable, metadata);
+          await provider.updatePRTitle(titleResult.title);
+          log.info(
+            {
+              originalTitle: metadata.title,
+              newTitle: titleResult.title,
+              model: titleResult.modelUsed,
+              tokens: titleResult.tokenCount,
+            },
+            "renamed PR title to conventional commit format",
+          );
+          metadata.title = titleResult.title;
+        }
+      } catch (err) {
+        log.warn({ err }, "failed to rename PR title, continuing with review");
+      }
+    }
 
     const shouldGenerate =
       repoConfig?.generateDescription ?? process.env.RUSTY_GENERATE_DESCRIPTION === "true";

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -274,4 +274,13 @@ export class GitHubProvider implements GitProvider {
       body: description,
     });
   }
+
+  async updatePRTitle(title: string): Promise<void> {
+    await this.octokit.request("PATCH /repos/{owner}/{repo}/pulls/{pull_number}", {
+      owner: this.owner,
+      repo: this.repo,
+      pull_number: this.pullNumber,
+      title,
+    });
+  }
 }

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -11,6 +11,7 @@ export interface RepoConfig {
   consensusPasses?: number;
   consensusThreshold?: number | null;
   generateDescription?: boolean;
+  renameTitleToConventional?: boolean;
 }
 
 export interface RepoConfigWithId extends RepoConfig {


### PR DESCRIPTION
## Summary

- New feature flag `RUSTY_RENAME_TITLE_TO_CONVENTIONAL=true` (off by default) that detects non-conventional PR titles and rewrites them via the LLM before the review starts.
- Adds `updatePRTitle` to the `GitProvider` interface, implemented for both GitHub and Azure DevOps.
- Wired through all three entry points (GitHub Action CLI, GitHub server-mode orchestrator, Azure DevOps CLI). Per-repo `renameTitleToConventional` flag added to `RepoConfig` for the orchestrator path.
- New `title` agent kind so `RUSTY_TITLE_TEMPERATURE` works alongside the existing per-agent overrides.

## How it works

1. Inspects the current title against a strict Conventional Commits regex (`type(scope)?!?: subject`).
2. If already conventional → no-op.
3. Otherwise, a dedicated agent picks `type` + optional `scope` + cleaned subject + breaking flag from the diff and metadata, and the new title is PATCHed onto the PR.
4. Failures are caught and logged; the review continues with the original title.

## Test plan

- [x] `pnpm test` — 617 passing (30 new tests for parse, format, schema, prompt; 1 for `updatePRTitle`; 1 for env-var parsing)
- [x] `pnpm build` — clean
- [x] `pnpm lint` — clean
- [ ] Smoke test on a real PR with a non-conventional title (e.g. "Add login flow") with `RUSTY_RENAME_TITLE_TO_CONVENTIONAL=true`
- [ ] Verify already-conventional titles are left untouched