### PR TITLE
fix: drop findings that don't anchor to the diff

### DIFF
--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -24,6 +24,7 @@ import {
   shouldGenerateDescription,
   generateConventionalTitle,
   isConventionalTitle,
+  filterAnchorableFindings,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -286,9 +287,30 @@ async function main(): Promise<void> {
 
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
   await provider.postSummaryComment(summaryMarkdown);
-  await provider.postInlineComments(review.findings);
 
-  log.info({ inlineComments: review.findings.length }, "posted summary and inline comments");
+  const { anchored: inlineFindings, dropped } = filterAnchorableFindings(
+    review.findings,
+    reviewable,
+  );
+  if (dropped.length > 0) {
+    log.warn(
+      {
+        droppedCount: dropped.length,
+        samples: dropped.slice(0, 5).map((d) => ({
+          file: d.finding.file,
+          line: d.finding.line,
+          reason: d.reason,
+        })),
+      },
+      "dropped findings that don't anchor to the diff before posting inline comments",
+    );
+  }
+  await provider.postInlineComments(inlineFindings);
+
+  log.info(
+    { inlineComments: inlineFindings.length, droppedAnchors: dropped.length },
+    "posted summary and inline comments",
+  );
 
   if (failOnCritical && criticalCount > 0) {
     log.warn({ criticalCount }, "failing pipeline due to critical issues");

--- a/packages/core/src/__tests__/anchor.test.ts
+++ b/packages/core/src/__tests__/anchor.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect } from "vitest";
+import { filterAnchorableFindings } from "../diff/anchor.js";
+import type { Finding, FilePatch } from "../types.js";
+
+function makeFinding(overrides: Partial<Finding>): Finding {
+  return {
+    file: "src/foo.ts",
+    line: 10,
+    endLine: null,
+    severity: "warning",
+    category: "bugs",
+    message: "msg",
+    suggestedFix: null,
+    ...overrides,
+  };
+}
+
+function makePatch(path: string, hunks: { newStart: number; newLines: number }[]): FilePatch {
+  return {
+    path,
+    hunks: hunks.map((h) => ({
+      oldStart: h.newStart,
+      oldLines: h.newLines,
+      newStart: h.newStart,
+      newLines: h.newLines,
+      content: "",
+    })),
+    additions: 0,
+    deletions: 0,
+    isBinary: false,
+  };
+}
+
+describe("filterAnchorableFindings", () => {
+  it("keeps a finding within a hunk's new line range", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 5 }])];
+    const finding = makeFinding({ file: "src/foo.ts", line: 12 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([finding]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("drops a finding whose file is not in the diff", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 5 }])];
+    const finding = makeFinding({ file: "src/missing.ts", line: 12 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("unknown-file");
+  });
+
+  it("drops a finding with a wrong file extension (parse.js vs parse.ts)", () => {
+    const patches = [makePatch("src/title/parse.ts", [{ newStart: 1, newLines: 20 }])];
+    const finding = makeFinding({ file: "src/title/parse.js", line: 1 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("unknown-file");
+  });
+
+  it("drops a finding outside any hunk in a known file", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 5 }])];
+    const finding = makeFinding({ file: "src/foo.ts", line: 1 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("outside-hunk");
+  });
+
+  it("anchors at the first and last lines of a hunk inclusively", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 5 }])];
+    const start = makeFinding({ file: "src/foo.ts", line: 10 });
+    const end = makeFinding({ file: "src/foo.ts", line: 14 });
+    const justPastEnd = makeFinding({ file: "src/foo.ts", line: 15 });
+
+    const { anchored, dropped } = filterAnchorableFindings([start, end, justPastEnd], patches);
+
+    expect(anchored).toContain(start);
+    expect(anchored).toContain(end);
+    expect(anchored).not.toContain(justPastEnd);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("outside-hunk");
+  });
+
+  it("requires a multi-line range to fit entirely inside a single hunk", () => {
+    const patches = [
+      makePatch("src/foo.ts", [
+        { newStart: 10, newLines: 5 },
+        { newStart: 30, newLines: 5 },
+      ]),
+    ];
+    const insideOne = makeFinding({ file: "src/foo.ts", line: 11, endLine: 13 });
+    const acrossHunks = makeFinding({ file: "src/foo.ts", line: 12, endLine: 31 });
+
+    const { anchored, dropped } = filterAnchorableFindings([insideOne, acrossHunks], patches);
+
+    expect(anchored).toEqual([insideOne]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("outside-hunk");
+  });
+
+  it("drops a deletion-only hunk (newLines=0) for any inline anchor", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 0 }])];
+    const finding = makeFinding({ file: "src/foo.ts", line: 10 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("outside-hunk");
+  });
+
+  it("ignores binary files even when paths match", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "img/logo.png",
+        hunks: [],
+        additions: 0,
+        deletions: 0,
+        isBinary: true,
+      },
+    ];
+    const finding = makeFinding({ file: "img/logo.png", line: 1 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped).toHaveLength(1);
+    expect(dropped[0].reason).toBe("unknown-file");
+  });
+
+  it("returns empty arrays for empty input", () => {
+    const { anchored, dropped } = filterAnchorableFindings([], []);
+    expect(anchored).toEqual([]);
+    expect(dropped).toEqual([]);
+  });
+
+  it("rejects an inverted range (endLine < line)", () => {
+    const patches = [makePatch("src/foo.ts", [{ newStart: 10, newLines: 5 }])];
+    const finding = makeFinding({ file: "src/foo.ts", line: 13, endLine: 11 });
+
+    const { anchored, dropped } = filterAnchorableFindings([finding], patches);
+
+    expect(anchored).toEqual([]);
+    expect(dropped[0].reason).toBe("outside-hunk");
+  });
+});

--- a/packages/core/src/diff/anchor.ts
+++ b/packages/core/src/diff/anchor.ts
@@ -1,0 +1,60 @@
+import type { Finding, FilePatch } from "../types.js";
+
+export interface DroppedAnchor {
+  finding: Finding;
+  reason: "unknown-file" | "outside-hunk";
+}
+
+export interface AnchorFilterResult {
+  anchored: Finding[];
+  dropped: DroppedAnchor[];
+}
+
+function buildHunkIndex(patches: FilePatch[]): Map<string, { start: number; end: number }[]> {
+  const index = new Map<string, { start: number; end: number }[]>();
+  for (const patch of patches) {
+    if (patch.isBinary) continue;
+    const ranges = patch.hunks.map((h) => ({
+      start: h.newStart,
+      // a hunk with newLines=0 represents a pure deletion at newStart, no addressable lines
+      end: h.newLines > 0 ? h.newStart + h.newLines - 1 : h.newStart - 1,
+    }));
+    if (ranges.length > 0) index.set(patch.path, ranges);
+  }
+  return index;
+}
+
+function isLineAnchorable(
+  line: number,
+  endLine: number | null | undefined,
+  ranges: { start: number; end: number }[],
+): boolean {
+  const lo = line;
+  const hi = endLine ?? line;
+  if (hi < lo) return false;
+  return ranges.some((r) => lo >= r.start && hi <= r.end);
+}
+
+export function filterAnchorableFindings(
+  findings: Finding[],
+  patches: FilePatch[],
+): AnchorFilterResult {
+  const index = buildHunkIndex(patches);
+  const anchored: Finding[] = [];
+  const dropped: DroppedAnchor[] = [];
+
+  for (const finding of findings) {
+    const ranges = index.get(finding.file);
+    if (!ranges) {
+      dropped.push({ finding, reason: "unknown-file" });
+      continue;
+    }
+    if (!isLineAnchorable(finding.line, finding.endLine, ranges)) {
+      dropped.push({ finding, reason: "outside-hunk" });
+      continue;
+    }
+    anchored.push(finding);
+  }
+
+  return { anchored, dropped };
+}

--- a/packages/core/src/diff/index.ts
+++ b/packages/core/src/diff/index.ts
@@ -5,5 +5,7 @@ export { expandContext } from "./context.js";
 export type { FileContentFetcher } from "./context.js";
 export { detectLanguage, summarizeLanguages } from "./language.js";
 export { shufflePatches } from "./shuffle.js";
+export { filterAnchorableFindings } from "./anchor.js";
+export type { AnchorFilterResult, DroppedAnchor } from "./anchor.js";
 export { expandToScopeBoundaries, getGrammarForFile } from "./treesitter.js";
 export type { TreeSitterExpansion, ExpandedScope } from "./treesitter.js";

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -28,6 +28,7 @@ import {
   generateConventionalTitle,
   isConventionalTitle,
   parseDiff,
+  filterAnchorableFindings,
 } from "@rusty-bot/core";
 import { GitHubProvider, createOctokitIssueFetcher } from "@rusty-bot/github";
 import {
@@ -384,12 +385,32 @@ export async function runAction(config: ActionConfig): Promise<number> {
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
   await provider.postSummaryComment(summaryMarkdown);
 
-  const inlineFindings = review.findings.filter((f) => f.line > 0);
+  const inlineCandidates = review.findings.filter((f) => f.line > 0);
+  const { anchored: inlineFindings, dropped } = filterAnchorableFindings(
+    inlineCandidates,
+    reviewable,
+  );
+  if (dropped.length > 0) {
+    log.warn(
+      {
+        droppedCount: dropped.length,
+        samples: dropped.slice(0, 5).map((d) => ({
+          file: d.finding.file,
+          line: d.finding.line,
+          reason: d.reason,
+        })),
+      },
+      "dropped findings that don't anchor to the diff before posting inline comments",
+    );
+  }
   if (inlineFindings.length > 0) {
     await provider.postInlineComments(inlineFindings);
   }
 
-  log.info({ inlineComments: inlineFindings.length }, "posted summary and inline comments");
+  log.info(
+    { inlineComments: inlineFindings.length, droppedAnchors: dropped.length },
+    "posted summary and inline comments",
+  );
 
   if (failOnCritical && criticalCount > 0) {
     log.warn({ criticalCount }, "failing action due to critical issues");

--- a/packages/github/src/orchestrator.ts
+++ b/packages/github/src/orchestrator.ts
@@ -26,6 +26,7 @@ import {
   shouldGenerateDescription,
   generateConventionalTitle,
   isConventionalTitle,
+  filterAnchorableFindings,
 } from "@rusty-bot/core";
 import { GitHubProvider } from "./provider.js";
 import { getRepoConfig, saveReview, getSetting, type ReviewRecord } from "./storage.js";
@@ -286,7 +287,24 @@ export async function orchestrateReview(params: {
     const summary = formatSummaryComment(result, { ticketResolution });
     await provider.postSummaryComment(summary);
 
-    const inlineFindings = result.findings.filter((f) => f.line > 0);
+    const inlineCandidates = result.findings.filter((f) => f.line > 0);
+    const { anchored: inlineFindings, dropped } = filterAnchorableFindings(
+      inlineCandidates,
+      reviewable,
+    );
+    if (dropped.length > 0) {
+      log.warn(
+        {
+          droppedCount: dropped.length,
+          samples: dropped.slice(0, 5).map((d) => ({
+            file: d.finding.file,
+            line: d.finding.line,
+            reason: d.reason,
+          })),
+        },
+        "dropped findings that don't anchor to the diff before posting inline comments",
+      );
+    }
     if (inlineFindings.length > 0) {
       await provider.postInlineComments(inlineFindings);
     }


### PR DESCRIPTION
## Summary

When the LLM emitted findings whose \`(file, line)\` didn't actually exist in the parsed diff (e.g. \`parse.js\` instead of \`parse.ts\`, or \`line: 1\` for a file not in the chunk), the GitHub Reviews API returned 422 \"Path could not be resolved\" and rejected the *entire batch* — including all the valid comments. This is what fataled the action run on #82.

## Fix

- New \`filterAnchorableFindings(findings, patches)\` util in \`packages/core/src/diff/anchor.ts\` that drops findings whose path isn't in the diff or whose line range falls outside any hunk's new-side range.
- Wired into all three call sites before \`postInlineComments\`: GitHub Action CLI, GitHub server-mode orchestrator, Azure DevOps CLI.
- Drops are logged with file/line/reason so the symptom is visible in the action log.

## Test plan

- [x] \`pnpm test\` — 632 passing (10 new tests covering: in-hunk, unknown file, wrong extension, outside hunk, hunk boundaries, multi-line range fitting, deletion-only hunks, binary files, empty inputs, inverted ranges)
- [x] \`pnpm build\` — clean
- [x] \`pnpm lint\` — clean

## Notes

This addresses the root cause of the all-or-nothing failure mode. A separate fix would tighten the reviewer system prompt and add a post-generation filter to stop the model from inventing paths in the first place — tracked separately.