### PR TITLE
fix: retry consensus passes on transient LLM errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_OPENGREP_RULES` | OpenGrep config string (ruleset or path to rule file) | `auto` |
 | `RUSTY_GENERATE_DESCRIPTION` | generate PR description when empty/placeholder | `false` |
 | `RUSTY_RENAME_TITLE_TO_CONVENTIONAL` | rewrite non-conventional PR titles into Conventional Commits format | `false` |
+| `RUSTY_LLM_MAX_RETRIES` | application-level retries on transient LLM errors (max 2) | `2` |
 | `RUSTY_LLM_TEMPERATURE` | global LLM temperature | provider default |
 | `RUSTY_LLM_TOP_P` | global LLM top-p | provider default |
 | `RUSTY_REVIEW_TEMPERATURE` | temperature override for the review agent | `RUSTY_LLM_TEMPERATURE` |

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ReviewConfig, PRMetadata } from "../types.js";
 
 const generateMock = vi.fn();
@@ -140,5 +140,107 @@ describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => 
 
     await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("provider timeout");
     expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+class FakeApiCallError extends Error {
+  isRetryable: boolean;
+  constructor(message: string, isRetryable: boolean) {
+    super(message);
+    this.name = "AI_APICallError";
+    this.isRetryable = isRetryable;
+  }
+}
+
+describe("runReview retry on transient LLM errors", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+    delete process.env.RUSTY_LLM_MAX_RETRIES;
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  async function settle<T>(promise: Promise<T>): Promise<T> {
+    // attach a noop rejection handler so vitest doesn't flag this as
+    // an unhandled rejection while the test suite is awaiting timers
+    promise.catch(() => undefined);
+    await vi.advanceTimersByTimeAsync(10_000);
+    return promise;
+  }
+
+  it("retries when the call throws an isRetryable=true error", async () => {
+    generateMock
+      .mockRejectedValueOnce(new FakeApiCallError("Headers Timeout Error", true))
+      .mockResolvedValueOnce(makeValidResponse());
+
+    const result = await settle(runReview(config, "diff", prMetadata));
+
+    expect(generateMock).toHaveBeenCalledTimes(2);
+    expect(result.recommendation).toBe("looks_good");
+  });
+
+  it("does not retry an error with isRetryable=false", async () => {
+    generateMock.mockRejectedValueOnce(new FakeApiCallError("auth failed", false));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow("auth failed");
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry generic errors that lack the isRetryable marker", async () => {
+    generateMock.mockRejectedValueOnce(new Error("misc network glitch"));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow(
+      "misc network glitch",
+    );
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries up to the default cap (3 attempts total) before giving up", async () => {
+    generateMock.mockRejectedValue(new FakeApiCallError("upstream timeout", true));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow("upstream timeout");
+    expect(generateMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("respects RUSTY_LLM_MAX_RETRIES=0 (no retries)", async () => {
+    process.env.RUSTY_LLM_MAX_RETRIES = "0";
+    generateMock.mockRejectedValueOnce(new FakeApiCallError("upstream timeout", true));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow("upstream timeout");
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("clamps RUSTY_LLM_MAX_RETRIES above the built-in backoff schedule", async () => {
+    process.env.RUSTY_LLM_MAX_RETRIES = "99";
+    generateMock.mockRejectedValue(new FakeApiCallError("upstream timeout", true));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow("upstream timeout");
+    // built-in schedule has 2 retry slots so total attempts = 1 + 2 = 3
+    expect(generateMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("ignores a non-numeric RUSTY_LLM_MAX_RETRIES and uses the default", async () => {
+    process.env.RUSTY_LLM_MAX_RETRIES = "abc";
+    generateMock
+      .mockRejectedValueOnce(new FakeApiCallError("upstream timeout", true))
+      .mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("treats a transient retry as compatible with the structured-output retry", async () => {
+    generateMock
+      .mockRejectedValueOnce(new FakeApiCallError("upstream timeout", true))
+      .mockRejectedValueOnce(
+        new FakeMastraError("STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", "validation failed once"),
+      )
+      .mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -26,6 +26,29 @@ function isStructuredOutputValidationError(err: unknown): boolean {
   );
 }
 
+// AI SDK marks transient upstream failures (headers timeout, 5xx, connection reset)
+// with isRetryable=true. Mastra's internal pRetry handles per-request retries; this
+// catches the case where its retries exhausted within a single tight timeout window
+// and gives the caller a fresh request budget.
+function isTransientRetryableError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "isRetryable" in err &&
+    (err as { isRetryable: unknown }).isRetryable === true
+  );
+}
+
+const TRANSIENT_RETRY_BACKOFF_MS = [500, 2_000];
+
+function readMaxTransientRetries(): number {
+  const raw = process.env.RUSTY_LLM_MAX_RETRIES;
+  if (raw === undefined) return TRANSIENT_RETRY_BACKOFF_MS.length;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return TRANSIENT_RETRY_BACKOFF_MS.length;
+  return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
+}
+
 async function generateWithStructuredOutputRetry<T>(fn: () => Promise<T>): Promise<T> {
   try {
     return await fn();
@@ -37,6 +60,26 @@ async function generateWithStructuredOutputRetry<T>(fn: () => Promise<T>): Promi
     );
     return await fn();
   }
+}
+
+async function generateWithTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+  const maxRetries = readMaxTransientRetries();
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      if (!isTransientRetryableError(err) || attempt === maxRetries) throw err;
+      const backoffMs = TRANSIENT_RETRY_BACKOFF_MS[attempt];
+      log.warn(
+        { err, attempt: attempt + 1, maxRetries, backoffMs },
+        "transient LLM error, retrying after backoff",
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+  throw lastErr;
 }
 
 export type ReviewTier = "skim" | "deep-review";
@@ -101,11 +144,13 @@ export async function runReview(
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;
 
   const modelSettings = resolveModelSettings("review");
-  const response = await generateWithStructuredOutputRetry(() =>
-    agent.generate(userMessage, {
-      structuredOutput: { schema },
-      ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-    }),
+  const response = await generateWithTransientRetry(() =>
+    generateWithStructuredOutputRetry(() =>
+      agent.generate(userMessage, {
+        structuredOutput: { schema },
+        ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+      }),
+    ),
   );
 
   const parsed = response.object;


### PR DESCRIPTION
## Summary

A single transient \`Headers Timeout Error\` from the LLM router caused one of three consensus passes on PR #82 to fail outright. The pass was retried by Mastra/AI SDK's internal \`pRetry\` (visible in the stack trace) but exhausted within the same tight timeout window. Adds an application-level retry on top with fresh request budget per attempt.

## How

- New \`generateWithTransientRetry\` helper in \`packages/core/src/agent/review.ts\` — catches errors with \`isRetryable === true\` (the AI SDK marker for transient upstream failures: 5xx, headers timeout, connection reset) and retries with exponential backoff (500ms, 2s).
- Composes with the existing structured-output retry, so a pass can survive: transient → validation → success.
- Configurable via new \`RUSTY_LLM_MAX_RETRIES\` env var (default: 2 retries = 3 total attempts; clamps to the built-in backoff schedule of 2 slots).

## What's not in scope

- The other agent paths (\`triage\`, \`description\`, \`title\`, \`judge\`) all fail soft — their callers catch and continue with a degraded result. Adding the same retry there is reasonable but a separate change to keep this targeted.
- Doesn't address the \`pRetry\` exhaustion root cause (the SDK's per-request budget) — that's an SDK config concern.

## Test plan

- [x] \`pnpm test\` — 640 passing (8 new tests covering: retry on isRetryable=true, no retry on isRetryable=false, no retry on generic errors, default cap of 3 attempts, RUSTY_LLM_MAX_RETRIES=0, clamping at the upper bound, non-numeric value falls back to default, composition with structured-output retry)
- [x] \`pnpm build\` — clean
- [x] \`pnpm lint\` — clean