### PR TITLE
fix: constrain reviewer finding paths to the chunk's file set

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -222,6 +222,51 @@ describe("buildUserMessage", () => {
     const diffIdx = msg.indexOf("## Diff");
     expect(otherFilesIdx).toBeLessThan(diffIdx);
   });
+
+  it("includes 'Files in this chunk' section when chunkFiles is provided", () => {
+    const msg = buildUserMessage("diff", prMetadata, undefined, undefined, undefined, undefined, [
+      "packages/core/src/title/parse.ts",
+      "packages/core/src/title/schema.ts",
+    ]);
+    expect(msg).toContain("## Files in this chunk");
+    expect(msg).toContain("`packages/core/src/title/parse.ts`");
+    expect(msg).toContain("`packages/core/src/title/schema.ts`");
+    expect(msg).toContain("Copy each path exactly as written");
+  });
+
+  it("omits 'Files in this chunk' section when chunkFiles is empty", () => {
+    const msg = buildUserMessage(
+      "diff",
+      prMetadata,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      [],
+    );
+    expect(msg).not.toContain("## Files in this chunk");
+  });
+
+  it("omits 'Files in this chunk' section when chunkFiles is undefined", () => {
+    const msg = buildUserMessage("diff", prMetadata);
+    expect(msg).not.toContain("## Files in this chunk");
+  });
+
+  it("places 'Files in this chunk' before the diff", () => {
+    const msg = buildUserMessage(
+      "diff content here",
+      prMetadata,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ["src/foo.ts"],
+    );
+    const chunkIdx = msg.indexOf("## Files in this chunk");
+    const diffIdx = msg.indexOf("## Diff");
+    expect(chunkIdx).toBeGreaterThan(-1);
+    expect(chunkIdx).toBeLessThan(diffIdx);
+  });
 });
 
 describe("ReviewOutputSchema", () => {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -251,7 +251,10 @@ async function runTieredReview(
   if (tier === "skim") {
     const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
     if (skippedFiles.length === 0) {
-      const result = await runReview(config, compressed, prMetadata, ticketContext, tierOptions);
+      const result = await runReview(config, compressed, prMetadata, ticketContext, {
+        ...tierOptions,
+        chunkFiles: patches.map((p) => p.path),
+      });
       return [result];
     }
     const groups = splitIntoGroups(patches, maxTokens);
@@ -264,6 +267,7 @@ async function runTieredReview(
       const result = await runReview(config, groupDiff, prMetadata, groupTickets, {
         ...tierOptions,
         openGrepFindings: groupOpenGrep,
+        chunkFiles: [...groupPaths],
       });
       results.push(result);
     }
@@ -279,7 +283,7 @@ async function runTieredReview(
       prMetadata,
       compressed,
       ticketContext,
-      tierOptions,
+      { ...tierOptions, chunkFiles: patches.map((p) => p.path) },
     );
     return [result];
   }
@@ -296,7 +300,7 @@ async function runTieredReview(
       prMetadata,
       groupCompressed,
       ticketContext,
-      { ...tierOptions, openGrepFindings: groupOpenGrep },
+      { ...tierOptions, openGrepFindings: groupOpenGrep, chunkFiles: [...groupPaths] },
     );
     results.push(groupResult);
   }
@@ -335,14 +339,10 @@ export async function runMultiCallReview(
     let result: ReviewResult;
 
     if (skippedFiles.length === 0) {
-      result = await runConsensusReview(
-        patches,
-        config,
-        prMetadata,
-        compressed,
-        ticketContext,
-        resolvedOptions,
-      );
+      result = await runConsensusReview(patches, config, prMetadata, compressed, ticketContext, {
+        ...resolvedOptions,
+        chunkFiles: patches.map((p) => p.path),
+      });
     } else {
       const groups = splitIntoGroups(patches, maxTokens);
 
@@ -372,7 +372,12 @@ export async function runMultiCallReview(
           prMetadata,
           groupCompressed,
           ticketContext,
-          { ...resolvedOptions, otherPrFiles, openGrepFindings: groupOpenGrep },
+          {
+            ...resolvedOptions,
+            otherPrFiles,
+            openGrepFindings: groupOpenGrep,
+            chunkFiles: [...groupPaths],
+          },
         );
         results.push(groupResult);
       }

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -69,6 +69,7 @@ export function buildUserMessage(
   languageSummary?: string,
   otherPrFiles?: string[],
   openGrepFindings?: OpenGrepFinding[],
+  chunkFiles?: string[],
 ): string {
   const parts: string[] = [];
 
@@ -83,6 +84,17 @@ export function buildUserMessage(
 
   if (prMetadata.description) {
     parts.push(`\n**Description:**\n${prMetadata.description}`);
+  }
+
+  if (chunkFiles && chunkFiles.length > 0) {
+    parts.push("\n## Files in this chunk");
+    parts.push(
+      "These are the only paths your `findings` may reference. Copy each path exactly as written — " +
+        "do not change extensions (e.g. `.ts` → `.js`), do not normalize separators, do not invent " +
+        "siblings. If you cannot anchor an issue to one of these paths and a line in the diff, " +
+        "describe it in the summary or as an `observation` instead of a finding.\n",
+    );
+    parts.push(chunkFiles.map((f) => `- \`${f}\``).join("\n"));
   }
 
   if (ticketContext && ticketContext.length > 0) {

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -49,6 +49,8 @@ export interface RunReviewOptions {
   tier?: ReviewTier;
   /** Files changed in the PR but not present in the current review chunk. */
   otherPrFiles?: string[];
+  /** Files actually present in the current review chunk; used to constrain finding paths. */
+  chunkFiles?: string[];
   /** OpenGrep findings to feed to the LLM for triage. */
   openGrepFindings?: OpenGrepFinding[];
 }
@@ -82,6 +84,7 @@ export async function runReview(
     options?.languageSummary,
     options?.otherPrFiles,
     options?.openGrepFindings,
+    options?.chunkFiles,
   );
   const modelConfig = resolveModelConfig();
   const model = resolveModel(modelConfig);

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -28,6 +28,7 @@ Important rules:
 - ALWAYS emit a structured finding for every issue you describe in the summary. If your summary mentions a problem, there MUST be a corresponding entry in the findings array. A finding without a suggestedFix is far more valuable than an issue mentioned only in prose.
 - For structural or cross-cutting issues (resource leaks, missing error handling, control flow problems), emit a finding pointing to the most relevant line with a descriptive message. Use `endLine` to indicate the affected range. Set `suggestedFix` to null if the fix cannot be expressed as a localized line replacement.
 - Be precise with line numbers — they must match the new file's line numbers shown in the diff.
+- Every `file` field in a finding MUST be an exact path that appears in the "Files in this chunk" section (when provided) or in a diff header above. Copy paths character-for-character; never alter extensions (e.g. do not change `.ts` to `.js`), case, or directory separators. If you cannot map an issue to one of those paths and a line in the diff, omit the finding or move the comment to the summary or `observations` instead.
 - Do not fabricate issues. If the code is clean, say so. Quality over quantity.
 - Do not speculate about broken imports or unused exports without using searchCode to verify.
 - Do not comment on formatting or trivial style issues unless specifically asked to review code style.


### PR DESCRIPTION
## Summary

The reviewer agent has been hallucinating file paths — emitting findings against \`packages/core/src/title/parse.js\` (the \`.ts\` file exists), or \`line: 1\` of files not even in the current chunk. The post-finding anchor filter (#87) drops these so the GitHub Reviews API doesn't 422, but they're still wasting tokens and cluttering the model's output.

## How

- New \`chunkFiles?: string[]\` option on \`RunReviewOptions\` carrying the exact paths in the current review chunk.
- Threaded through \`runMultiCallReview\` → \`runTieredReview\` → \`runConsensusReview\` → \`runReview\`. Set from the deduplicated path set used elsewhere for opengrep/ticket filtering.
- Renders a new \`## Files in this chunk\` section in the user message listing the paths verbatim, with explicit instructions to copy them character-for-character (no \`.ts\` → \`.js\` swaps, no case changes).
- Adds a parallel rule in \`base.txt\` system prompt requiring every \`finding.file\` to match a path from this section or a diff header.

## What's not in scope

The complementary post-generation filter already landed in #87 — this PR is the preventive side: the model is told what's allowed *before* it generates, vs. dropping bad output afterward. Both are useful: the prompt change saves tokens; the filter catches what slips through.

## Test plan

- [x] \`pnpm test\` — 634 passing (4 new tests covering: chunk files rendered, omitted on empty/undefined, placed before diff, includes the copy-exactly instruction)
- [x] \`pnpm build\` — clean
- [x] \`pnpm lint\` — clean