### PR TITLE
fix: preserve droppedFindings through mergeResults

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -453,4 +453,22 @@ describe("judgeReviewResult", () => {
     expect(result.judgeTokenCount).toBe(200);
     expect(result.summary).toBe("test review");
   });
+
+  it("passes droppedFindings through unchanged when judge runs", async () => {
+    const review: ReviewResult = {
+      ...makeReviewResult([makeFinding()]),
+      droppedFindings: [
+        { file: "x.ts", line: 1, severity: "warning", message: "dropped 1", voteCount: 1 },
+        { file: "y.ts", line: 2, severity: "critical", message: "dropped 2", voteCount: 1 },
+      ],
+    };
+
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "valid" }] },
+      usage: { totalTokens: 50 },
+    });
+
+    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    expect(result.droppedFindings).toEqual(review.droppedFindings);
+  });
 });

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -550,6 +550,122 @@ describe("mergeResults", () => {
     const merged = mergeResults([result1, result2], "test-model");
     expect(merged.recommendation).toBe("looks_good");
   });
+
+  it("carries droppedFindings from each input result through into the merged result", () => {
+    const skimResult: ReviewResult = {
+      summary: "skim",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["a.ts"],
+      modelUsed: "test-model",
+      tokenCount: 10,
+    };
+
+    const deepResult: ReviewResult = {
+      summary: "deep elevated",
+      recommendation: "address_before_merge",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["b.ts"],
+      modelUsed: "test-model",
+      tokenCount: 50,
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0,
+        recommendationElevated: true,
+        passRecommendations: [
+          "address_before_merge",
+          "address_before_merge",
+          "address_before_merge",
+        ],
+        failedPasses: 0,
+      },
+      droppedFindings: [
+        { file: "b.ts", line: 10, severity: "warning", message: "fallback bug", voteCount: 1 },
+        {
+          file: "c.ts",
+          line: 20,
+          severity: "warning",
+          message: "dao delete helper safety",
+          voteCount: 1,
+        },
+      ],
+    };
+
+    const merged = mergeResults([skimResult, deepResult], "test-model");
+
+    expect(merged.droppedFindings).toBeDefined();
+    expect(merged.droppedFindings).toHaveLength(2);
+    expect(merged.droppedFindings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ file: "b.ts", line: 10, message: "fallback bug" }),
+        expect.objectContaining({ file: "c.ts", line: 20, message: "dao delete helper safety" }),
+      ]),
+    );
+  });
+
+  it("merges droppedFindings across multiple results and deduplicates by file:line:message", () => {
+    const r1: ReviewResult = {
+      summary: "r1",
+      recommendation: "address_before_merge",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["a.ts"],
+      modelUsed: "test-model",
+      tokenCount: 10,
+      droppedFindings: [
+        { file: "a.ts", line: 5, severity: "warning", message: "shared finding", voteCount: 1 },
+        { file: "a.ts", line: 8, severity: "warning", message: "r1 only", voteCount: 1 },
+      ],
+    };
+
+    const r2: ReviewResult = {
+      summary: "r2",
+      recommendation: "address_before_merge",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["a.ts"],
+      modelUsed: "test-model",
+      tokenCount: 10,
+      droppedFindings: [
+        { file: "a.ts", line: 5, severity: "warning", message: "shared finding", voteCount: 1 },
+        { file: "a.ts", line: 12, severity: "critical", message: "r2 only", voteCount: 1 },
+      ],
+    };
+
+    const merged = mergeResults([r1, r2], "test-model");
+
+    expect(merged.droppedFindings).toHaveLength(3);
+    const messages = (merged.droppedFindings ?? []).map((d) => d.message).sort();
+    expect(messages).toEqual(["r1 only", "r2 only", "shared finding"]);
+  });
+
+  it("omits droppedFindings when no input result has any", () => {
+    const r1: ReviewResult = {
+      summary: "r1",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["a.ts"],
+      modelUsed: "test-model",
+      tokenCount: 10,
+    };
+
+    const merged = mergeResults([r1, r1], "test-model");
+    expect(merged.droppedFindings).toBeUndefined();
+  });
 });
 
 describe("runCascadeReview", () => {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -10,6 +10,7 @@ import type {
   TicketComplianceItem,
   TicketComplianceStatus,
   MissingTestItem,
+  DroppedFinding,
 } from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 import { runReview, type RunReviewOptions, type ReviewTier } from "./review.js";
@@ -122,6 +123,17 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
     return true;
   });
 
+  const droppedSeen = new Set<string>();
+  const dedupedDropped: DroppedFinding[] = [];
+  for (const r of results) {
+    for (const d of r.droppedFindings ?? []) {
+      const key = `${d.file}:${d.line}:${d.message}`;
+      if (droppedSeen.has(key)) continue;
+      droppedSeen.add(key);
+      dedupedDropped.push(d);
+    }
+  }
+
   const criticalCount = dedupedFindings.filter((f) => f.severity === "critical").length;
 
   const summaries = results.map((r) => r.summary).filter(Boolean);
@@ -158,6 +170,7 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
     tokenCount: totalTokens,
     ...(triageStats ? { triageStats } : {}),
     ...(consensusMetadata && { consensusMetadata }),
+    ...(dedupedDropped.length > 0 && { droppedFindings: dedupedDropped }),
   };
 }
 


### PR DESCRIPTION
## Summary

`mergeResults` was discarding `droppedFindings` when combining `ReviewResult`s from the triage cascade and the chunked-diff path. The formatter's `isElevatedWithoutSurvivors` gate requires `droppedCount > 0`, so the `## Elevated Concerns` section was silently skipped even when consensus had elevated the recommendation. Carry the field through, deduplicated by `file:line:message` to match the existing finding dedupe key.

Closes #84.

## Test plan

- [x] New unit test: `mergeResults` carries `droppedFindings` from each input result through into the merged result.
- [x] New unit test: `mergeResults` deduplicates `droppedFindings` across results by `file:line:message`.
- [x] New unit test: `mergeResults` omits `droppedFindings` when no input has any.
- [x] New regression test: `judgeReviewResult` passes `droppedFindings` through unchanged.
- [x] Existing `mergeResults` and consensus tests still pass (541/541).
- [x] `pnpm lint` and `pnpm build` clean.