### PR TITLE
fix: truncate generated PR description to ADO 4000-char limit

### DIFF
--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { AzureDevOpsProvider } from "../provider.js";
+import { AzureDevOpsProvider, truncatePRDescription } from "../provider.js";
 import type { Finding } from "@rusty-bot/core";
 
 const ORG_URL = "https://dev.azure.com/test-org";
@@ -819,6 +819,81 @@ describe("AzureDevOpsProvider", () => {
       const oldContentUrl = decodeURIComponent(fetchSpy.mock.calls[4][0] as string);
       expect(oldContentUrl).toContain("src/original.ts");
       expect(oldContentUrl).not.toContain("src/renamed.ts");
+    });
+  });
+
+  describe("updatePRDescription", () => {
+    it("posts the description verbatim when within the 4000-char limit", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({}));
+
+      const description = "## Summary\n\nA short description.";
+      await provider.updatePRDescription(description);
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        `${BASE_URL}/pullRequests/${PULL_REQUEST_ID}?${API_VERSION}`,
+        expect.objectContaining({ method: "PATCH" }),
+      );
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.description).toBe(description);
+    });
+
+    it("posts a description of exactly 4000 chars verbatim", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({}));
+
+      const description = "x".repeat(4000);
+      await provider.updatePRDescription(description);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.description).toBe(description);
+      expect(body.description.length).toBe(4000);
+    });
+
+    it("truncates a description longer than 4000 chars and appends a marker", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({}));
+
+      const description = "y".repeat(5000);
+      await provider.updatePRDescription(description);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.description.length).toBe(4000);
+      expect(body.description.endsWith("\n\n…(truncated)")).toBe(true);
+    });
+
+    it("truncates a 4001-char description to 4000 chars", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({}));
+
+      const description = "z".repeat(4001);
+      await provider.updatePRDescription(description);
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.description.length).toBe(4000);
+      expect(body.description.endsWith("\n\n…(truncated)")).toBe(true);
+    });
+  });
+
+  describe("truncatePRDescription", () => {
+    it("returns the input unchanged when shorter than the limit", () => {
+      expect(truncatePRDescription("hello")).toBe("hello");
+    });
+
+    it("returns the input unchanged at exactly the limit", () => {
+      const s = "a".repeat(4000);
+      expect(truncatePRDescription(s)).toBe(s);
+      expect(truncatePRDescription(s).length).toBe(4000);
+    });
+
+    it("truncates and appends the marker for inputs over the limit", () => {
+      const result = truncatePRDescription("b".repeat(10_000));
+      expect(result.length).toBe(4000);
+      expect(result.endsWith("\n\n…(truncated)")).toBe(true);
+      expect(result.startsWith("b".repeat(100))).toBe(true);
+    });
+
+    it("respects a custom maxLength", () => {
+      const result = truncatePRDescription("c".repeat(500), 100);
+      expect(result.length).toBe(100);
+      expect(result.endsWith("\n\n…(truncated)")).toBe(true);
     });
   });
 

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -20,6 +20,19 @@ import {
 
 const BOT_MARKER = "<!-- rusty-bot-review -->";
 const API_VERSION = "api-version=7.0";
+const ADO_MAX_PR_DESCRIPTION_LENGTH = 4000;
+const DESCRIPTION_TRUNCATION_MARKER = "\n\n…(truncated)";
+
+export function truncatePRDescription(
+  description: string,
+  maxLength: number = ADO_MAX_PR_DESCRIPTION_LENGTH,
+): string {
+  if (description.length <= maxLength) return description;
+  return (
+    description.slice(0, maxLength - DESCRIPTION_TRUNCATION_MARKER.length) +
+    DESCRIPTION_TRUNCATION_MARKER
+  );
+}
 
 interface AzureDevOpsProviderConfig {
   orgUrl: string;
@@ -378,9 +391,10 @@ export class AzureDevOpsProvider implements GitProvider {
   }
 
   async updatePRDescription(description: string): Promise<void> {
+    const safeDescription = truncatePRDescription(description);
     await this.fetchApi(`${this.baseUrl}/pullRequests/${this.pullRequestId}?${API_VERSION}`, {
       method: "PATCH",
-      body: JSON.stringify({ description }),
+      body: JSON.stringify({ description: safeDescription }),
     });
   }
 


### PR DESCRIPTION
## Summary

Azure DevOps rejects PR description updates longer than 4000 characters with HTTP 400. `updatePRDescription` was sending the generated description verbatim, so for any PR where the generator produced a longer body the description silently failed to update — the error surfaced only as a `failed to generate PR description, continuing with review` line in pipeline logs.

Truncate to 4000 chars (the ADO hard cap) and append a visible `\n\n…(truncated)` marker so reviewers can tell when the description was clipped. The truncation lives at the provider edge in a small exported helper so it's testable in isolation.

Closes #86.

## Test plan

- [x] `truncatePRDescription` returns input unchanged below and at the limit.
- [x] `truncatePRDescription` truncates and marks oversized inputs to exactly 4000 chars.
- [x] `truncatePRDescription` honors a custom maxLength.
- [x] `updatePRDescription` posts the body verbatim when within the limit.
- [x] `updatePRDescription` posts a 4000-char body verbatim.
- [x] `updatePRDescription` truncates a 5000-char and 4001-char body to 4000 chars with the marker.
- [x] All ADO tests pass (47/47), repo lint and build clean.