### PR TITLE
fix: prefix docs base path on getting-started links

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -6,7 +6,7 @@ hero:
   tagline: Cascading triage, OpenGrep pre-scan, and consensus voting — runs as a GitHub Action or webhook server.
   actions:
     - text: Get started
-      link: /getting-started/
+      link: /rusty-bot/getting-started/
       icon: right-arrow
     - text: View on GitHub
       link: https://github.com/jegork/rusty-bot

--- a/docs/src/content/docs/providers/github-action.md
+++ b/docs/src/content/docs/providers/github-action.md
@@ -32,7 +32,7 @@ jobs:
           RUSTY_FAIL_ON_CRITICAL: "true"
 ```
 
-The [Getting started](/getting-started/) page has the bare minimum to get running. This page is the complete reference.
+The [Getting started](/rusty-bot/getting-started/) page has the bare minimum to get running. This page is the complete reference.
 
 ## Required permissions
 


### PR DESCRIPTION
## Summary
- The Starlight site is served from `https://jegork.github.io/rusty-bot/` (base = `/rusty-bot`), but the splash hero and a cross-link used `/getting-started/`, which resolved to `https://jegork.github.io/getting-started/` (404).
- Updated both links to include the `/rusty-bot` base.

## Test plan
- [ ] Build docs and confirm the "Get started" hero button on the landing page navigates to `/rusty-bot/getting-started/`
- [ ] Confirm the same link on `providers/github-action` works