### PR TITLE
docs: polish landing page, add MCP tools guide, document missing env vars

### DIFF
--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -57,7 +57,10 @@ underlying Docker image is published per release tag.
 
 ## Next steps
 
-- [Full GitHub Action reference](/providers/github-action/) — complete inputs, skipped events, and Docker image details
-- [GitHub App (self-hosted)](/providers/github-app/) — run as a webhook server for multiple repos
-- [Azure DevOps](/providers/azure-devops/) — run in Azure Pipelines
-- [LLM providers](/guides/llm-providers/) — connect Azure OpenAI, OpenAI-compatible endpoints, or any of 99+ providers
+- [Full GitHub Action reference](/providers/github-action/) — every input and env var, skipped event types, and how to pin the Docker image
+- [GitHub App (self-hosted)](/providers/github-app/) — run as a webhook server when you want one deployment to cover many repos
+- [Azure DevOps](/providers/azure-devops/) — drop the same review into Azure Pipelines with PR threads instead of GitHub comments
+- [LLM providers](/guides/llm-providers/) — swap to Azure OpenAI, an OpenAI-compatible endpoint, or any of 99+ providers via LiteLLM
+- [Convention files](/guides/convention-files/) — teach the bot your house rules with a `REVIEW-BOT.md` checked into the repo
+- [Gating merges](/guides/gating-merges/) — fail the check on critical findings so PRs can't merge until they're resolved
+- [Tuning cost & noise](/guides/cascading-review/) — control how many files get the deep-review treatment vs. skipped outright

--- a/docs/src/content/docs/guides/mcp-tools.md
+++ b/docs/src/content/docs/guides/mcp-tools.md
@@ -1,0 +1,93 @@
+---
+title: MCP tools
+description: Give the review and triage agents extra tools via Model Context Protocol servers — fetch docs, query Sentry, look up tickets, anything an MCP server can expose.
+---
+
+Rusty Bot can connect to one or more [Model Context Protocol](https://modelcontextprotocol.io/) servers at startup and surface their tools to the review and triage agents. The agents can then call those tools mid-review — to fetch upstream documentation, query an error tracker, look up a related ticket, or anything else an MCP server exposes.
+
+## Why this matters
+
+The default review only sees the diff, the surrounding tree-sitter context, the OpenGrep findings, and (optionally) ticket descriptions. MCP tools widen that view *on demand*: the model decides when it needs to call out, so you don't pay the cost of pulling extra context into every review.
+
+Typical use cases:
+
+- **Internal docs** — point to an MCP docs server so the model can verify a finding against your library's actual API instead of hallucinating.
+- **Observability** — connect a Sentry / Grafana MCP so the model can check whether a code path that "looks fine" is actually the source of recent production errors.
+- **Ticket trackers beyond the built-ins** — Rusty Bot has first-class Linear / Jira / GitHub / Azure DevOps integration, but MCP lets you wire up anything else (Notion, ClickUp, custom internal tools).
+
+## Configuration
+
+Drop a `mcp-servers.json` next to your repo (or anywhere accessible to the action / server) and point Rusty Bot at it with `RUSTY_MCP_CONFIG`:
+
+```bash
+RUSTY_MCP_CONFIG=./mcp-servers.json
+```
+
+When `RUSTY_MCP_CONFIG` is unset, Rusty Bot looks for `./mcp-servers.json` in the current working directory. If that file doesn't exist either, MCP is silently disabled.
+
+## File format
+
+A JSON object keyed by server name. Each server is either a **stdio** transport (a local process Rusty Bot spawns) or an **HTTP/SSE** transport (a remote server):
+
+```json
+{
+  "docs": {
+    "command": "npx",
+    "args": ["-y", "@my-org/mcp-docs-server"],
+    "env": {
+      "DOCS_API_TOKEN": "${DOCS_API_TOKEN}"
+    }
+  },
+  "sentry": {
+    "url": "https://mcp.sentry.io/sse",
+    "requestInit": {
+      "headers": {
+        "Authorization": "Bearer ${SENTRY_MCP_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+| Field (stdio) | Required | Description |
+| --- | --- | --- |
+| `command` | yes | Executable to spawn (e.g. `npx`, `python`, `node`, an absolute path) |
+| `args` | no | Arguments passed to the command |
+| `env` | no | Extra env vars for the spawned process |
+
+| Field (HTTP) | Required | Description |
+| --- | --- | --- |
+| `url` | yes | HTTP/SSE endpoint of the remote MCP server |
+| `requestInit` | no | Extra fetch options — `headers` is the most common use |
+
+The `${VAR}` syntax inside string values is **not** auto-expanded — pass real values from your secrets store, or rely on the spawned process to read its own env.
+
+## How tools reach the agents
+
+On startup, Rusty Bot:
+
+1. Loads the config from `RUSTY_MCP_CONFIG` (or `./mcp-servers.json`).
+2. Connects to each server independently. **A failure on one server is logged and skipped — the rest still contribute their tools.**
+3. Calls `listTools()` on each connected server and merges the results into the tool set passed to the review and triage agents.
+4. Disconnects all servers when the review finishes (including on error).
+
+The merged tool set is also visible to the cascade-triage agent, so a triage model can call out to MCP tools when classifying files.
+
+## Failure modes
+
+- **Invalid JSON** in `mcp-servers.json` → fatal at startup, with the file path in the error message.
+- **Schema violations** (entry without `command` *and* without `url`, non-object entry, etc.) → fatal, with a per-field list of issues.
+- **Server fails to start or list tools** → warning logged (`failed to connect MCP server; skipping`) and the rest of the review proceeds without that server's tools.
+- **Tool call fails mid-review** → handled like any other tool error; the agent decides whether to retry or work around it.
+
+## Performance notes
+
+- Stdio servers add startup latency on every review (the process is spawned fresh). Prefer HTTP for hot-loop servers.
+- Tool calls are billed against your model provider's tokens, not just MCP — every tool result the model reads is input tokens on the next turn.
+- The cascade-triage agent typically does *not* call tools (it's optimized for cheap classification), but it can. If you don't want that, point only the review agent at MCP-heavy servers and keep the triage model lean.
+
+## Related
+
+- [Cascading review](/guides/cascading-review/) — controls which files the deep-review (and therefore MCP-using) agent sees
+- [Ticket integration](/guides/ticket-integration/) — built-in alternative for Linear / Jira / GitHub / ADO without writing an MCP server
+- [`RUSTY_MCP_CONFIG`](/reference/env-vars/#mcp-tools) — env var reference

--- a/docs/src/content/docs/guides/mcp-tools.md
+++ b/docs/src/content/docs/guides/mcp-tools.md
@@ -35,19 +35,25 @@ A JSON object keyed by server name. Each server is either a **stdio** transport 
     "command": "npx",
     "args": ["-y", "@my-org/mcp-docs-server"],
     "env": {
-      "DOCS_API_TOKEN": "${DOCS_API_TOKEN}"
+      "DOCS_API_TOKEN": "<replace-with-real-token-or-templated-by-your-secrets-manager>"
     }
   },
   "sentry": {
     "url": "https://mcp.sentry.io/sse",
     "requestInit": {
       "headers": {
-        "Authorization": "Bearer ${SENTRY_MCP_TOKEN}"
+        "Authorization": "Bearer <replace-with-real-token>"
       }
     }
   }
 }
 ```
+
+:::caution[Don't commit real secrets]
+Strings in `mcp-servers.json` are passed through verbatim — Rusty Bot does **not** expand `${VAR}` or any other shell syntax. If you put a real token in this file, treat the file like any other secret: keep it out of git (add it to `.gitignore`), or template it from your secrets manager / deployment platform at runtime.
+
+For stdio servers, prefer letting the spawned process read its own env vars (don't list them in `env`) so the secret never lands on disk.
+:::
 
 | Field (stdio) | Required | Description |
 | --- | --- | --- |
@@ -59,8 +65,6 @@ A JSON object keyed by server name. Each server is either a **stdio** transport 
 | --- | --- | --- |
 | `url` | yes | HTTP/SSE endpoint of the remote MCP server |
 | `requestInit` | no | Extra fetch options — `headers` is the most common use |
-
-The `${VAR}` syntax inside string values is **not** auto-expanded — pass real values from your secrets store, or rely on the spawned process to read its own env.
 
 ## How tools reach the agents
 

--- a/docs/src/content/docs/guides/mcp-tools.md
+++ b/docs/src/content/docs/guides/mcp-tools.md
@@ -49,17 +49,22 @@ A JSON object keyed by server name. Each server is either a **stdio** transport 
 }
 ```
 
-:::caution[Don't commit real secrets]
-Strings in `mcp-servers.json` are passed through verbatim — Rusty Bot does **not** expand `${VAR}` or any other shell syntax. If you put a real token in this file, treat the file like any other secret: keep it out of git (add it to `.gitignore`), or template it from your secrets manager / deployment platform at runtime.
+:::caution[No `${VAR}` interpolation — render real secrets in, don't commit them]
+String values in `mcp-servers.json` are passed through **verbatim**. Rusty Bot does *not* expand `${VAR}`, `$VAR`, or any other shell syntax — `"FOO": "${MY_TOKEN}"` reaches the spawned process as the literal four-character string `${MY_TOKEN}`, not the value of `$MY_TOKEN`.
 
-For stdio servers, prefer letting the spawned process read its own env vars (don't list them in `env`) so the secret never lands on disk.
+For stdio servers, the spawned process also does *not* automatically inherit arbitrary env vars from Rusty Bot's environment. The underlying MCP SDK only forwards a small safe list (`HOME`, `LOGNAME`, `PATH`, `SHELL`, `TERM`, `USER` on Unix; the equivalent system vars on Windows). Anything else — including any secret you've already exported in your shell or set on the action runner — must be listed explicitly in the `env` block to reach the server.
+
+So real secrets *do* end up in this file. The right move is to:
+
+1. **Render `mcp-servers.json` at startup from your secrets manager / deployment platform** (Kubernetes secrets, GitHub Actions secrets, Azure Key Vault, …) so the rendered file with real values exists only on the running container / runner, never in git.
+2. **Add `mcp-servers.json` to `.gitignore`** alongside any template you check in (e.g. `mcp-servers.example.json`).
 :::
 
 | Field (stdio) | Required | Description |
 | --- | --- | --- |
 | `command` | yes | Executable to spawn (e.g. `npx`, `python`, `node`, an absolute path) |
 | `args` | no | Arguments passed to the command |
-| `env` | no | Extra env vars for the spawned process |
+| `env` | no | Extra env vars set on the spawned process (literal string values; no shell interpolation) |
 
 | Field (HTTP) | Required | Description |
 | --- | --- | --- |

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -22,17 +22,52 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
   <Card title="Cascading triage" icon="puzzle">
     A cheap model classifies files as skip / skim / deep-review so the heavyweight
     model only runs where it pays off.
+
+    [Learn more →](/guides/cascading-review/)
   </Card>
   <Card title="Tree-sitter context" icon="document">
     Hunks expand to enclosing function/class boundaries — the model sees real
     semantic context instead of arbitrary line counts.
+
+    [Learn more →](/guides/tree-sitter/)
   </Card>
   <Card title="OpenGrep pre-scan" icon="seti:lock">
     SAST findings on changed files inform triage before the LLM runs, so
     obvious security issues are never missed.
+
+    [Learn more →](/guides/opengrep/)
   </Card>
   <Card title="Consensus voting" icon="approve-check">
     Multiple review passes vote on each finding; lonely false positives are
     dropped automatically.
+
+    [Learn more →](/guides/consensus-voting/)
+  </Card>
+</CardGrid>
+
+## More to explore
+
+<CardGrid>
+  <Card title="Judge pass" icon="approve-check-circle">
+    A second model re-scores findings against a quality bar and drops the noise.
+
+    [Learn more →](/guides/judge-pass/)
+  </Card>
+  <Card title="Convention files" icon="open-book">
+    Drop a `REVIEW-BOT.md` or `.rusty-bot.md` in your repo to teach the bot your
+    house rules.
+
+    [Learn more →](/guides/convention-files/)
+  </Card>
+  <Card title="Ticket integration" icon="list-format">
+    Pull Linear / Jira / GitHub issue context into the review so findings are
+    judged against actual requirements.
+
+    [Learn more →](/guides/ticket-integration/)
+  </Card>
+  <Card title="Gating merges" icon="error">
+    Fail the check on critical findings to block merges until they're addressed.
+
+    [Learn more →](/guides/gating-merges/)
   </Card>
 </CardGrid>

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -70,4 +70,10 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
 
     [Learn more →](/guides/gating-merges/)
   </Card>
+  <Card title="MCP tools" icon="rocket">
+    Connect MCP servers — internal docs, Sentry, custom tools — and let the
+    review agent call them mid-review when it needs more context.
+
+    [Learn more →](/guides/mcp-tools/)
+  </Card>
 </CardGrid>

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -48,7 +48,7 @@ The managed identity vars (`RUSTY_AZURE_*`) take priority over the API-key vars 
 
 | Variable | Default | Description |
 | --- | --- | --- |
-| `RUSTY_LLM_MAX_RETRIES` | `2` | Max additional retries after a transient LLM error. Clamped to the built-in backoff schedule (currently 2). Set to `0` to disable retries entirely. |
+| `RUSTY_LLM_MAX_RETRIES` | `2` | Max additional retries after a transient LLM error. Capped at the length of the built-in backoff schedule (2 entries today — values higher than that are silently lowered). Set to `0` to disable retries entirely. |
 
 ## Temperature and top-p
 

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -44,6 +44,12 @@ The managed identity vars (`RUSTY_AZURE_*`) take priority over the API-key vars 
 | `RUSTY_LLM_BASE_URL` | Base URL of an OpenAI-compatible endpoint (LiteLLM, vLLM, Ollama, …) |
 | `RUSTY_LLM_API_KEY` | API key for the custom endpoint (optional for unauthenticated local instances) |
 
+## Retries
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_LLM_MAX_RETRIES` | `2` | Max additional retries after a transient LLM error. Clamped to the built-in backoff schedule (currently 2). Set to `0` to disable retries entirely. |
+
 ## Temperature and top-p
 
 | Variable | Default | Description |
@@ -100,6 +106,21 @@ See [PR description generation](/guides/pr-description/).
 | `RUSTY_RENAME_TITLE_TO_CONVENTIONAL` | `false` | Rewrite non-conventional PR titles into Conventional Commits format |
 
 See [PR title rewriting](/guides/pr-title/).
+
+## MCP tools
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_MCP_CONFIG` | `./mcp-servers.json` | Path to a JSON file declaring MCP servers (stdio or HTTP). Missing file disables MCP silently. |
+
+See [MCP tools](/guides/mcp-tools/).
+
+## Dashboard (self-hosted only)
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_DASHBOARD` | `false` | Serve the embedded dashboard from the GitHub App webhook server when set to `true`. |
+| `RUSTY_DASHBOARD_DIR` | bundled | Override the directory served when the dashboard is enabled. Used for development. |
 
 ## Ticket integrations
 


### PR DESCRIPTION
## Summary

**Landing page**
- Splash feature cards now link to their dedicated guides.
- New "More to explore" CardGrid: judge pass, convention files, ticket integration, merge gating, MCP tools.

**Getting started**
- Expanded "Next steps" with one-line context on each link, plus three more entries (convention files, gating merges, cost/noise tuning).

**MCP tools — new page**
- New `guides/mcp-tools.md`: explains why MCP matters, the `mcp-servers.json` format (stdio + HTTP transports), how tools reach the agents, failure modes, and performance notes.

**Reference: env vars**
- Added `RUSTY_LLM_MAX_RETRIES` (was in code but undocumented).
- Added `RUSTY_MCP_CONFIG`.
- Added `RUSTY_DASHBOARD` / `RUSTY_DASHBOARD_DIR` for the embedded dashboard on the self-hosted webhook server.

## Test plan
- [ ] `pnpm run build` in `docs/` succeeds (verified locally — 20 pages, including new `/guides/mcp-tools/`)
- [ ] Click each "Learn more →" link on the landing page
- [ ] Verify the new env-var rows render correctly under MCP tools / Dashboard / Retries sections