### PR TITLE
feat: incremental review against last-reviewed state

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **OpenGrep pre-scan** — runs [OpenGrep](https://opengrep.dev/) SAST on changed files before LLM review, feeds findings for triage (gracefully skipped when not installed)
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
 - **PR description generation** — optionally generate a structured PR description from the diff when the description is empty or a placeholder (off by default)
+- **Incremental review** — on subsequent pushes the bot reviews only the diff since the previously-reviewed state (commit on GitHub, PR iteration on Azure DevOps) instead of the entire PR, cutting tokens on multi-commit PRs (on by default; opt out with `RUSTY_INCREMENTAL_REVIEW=false`)
 - **GitHub + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps, or a drop-in GitHub Action
 - **Web dashboard** — configure repos, review styles, focus areas, and view history
 
@@ -195,6 +196,7 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_IGNORE_PATTERNS` | comma-separated glob patterns to skip | — |
 | `RUSTY_FAIL_ON_CRITICAL` | exit 1 on critical findings (pipeline/action mode) | `true` |
 | `RUSTY_REVIEW_DRAFTS` | review draft PRs in GitHub Action mode | `false` |
+| `RUSTY_INCREMENTAL_REVIEW` | review only the diff since the last reviewed commit (GitHub) or PR iteration (Azure DevOps) | `true` |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |

--- a/docs/src/content/docs/providers/azure-devops.md
+++ b/docs/src/content/docs/providers/azure-devops.md
@@ -64,3 +64,17 @@ See [Gating merges](/guides/gating-merges/) for the full setup walkthrough.
 ## ADO PAT fallback
 
 For non-container usage (e.g. server mode), set `RUSTY_ADO_PAT` with a Personal Access Token that has **Code: Read** and **Pull Request Threads: Read & Write** scopes. In pipeline mode the `$(System.AccessToken)` is preferred and no PAT is needed.
+
+## Incremental review
+
+When the pipeline runs again after a new iteration is pushed, the task only reviews the diff between the previously-reviewed iteration and the latest iteration instead of re-reviewing the full PR.
+
+How it works:
+
+- After each successful review, the task embeds the latest iteration id in a hidden HTML marker inside the summary thread (`<!-- rusty-bot:last-iteration:7 -->`).
+- On the next run the task reads that marker, calls the iterations changes endpoint with `$compareTo={last-iteration}`, and fetches file contents pinned to each iteration's source-ref commit so old/new are taken from the right commits.
+- If the marker is missing (first run) or the previous iteration can't be resolved, the task falls back to a full review.
+- If the latest iteration is the same as the previously-reviewed one, the run exits without re-posting anything.
+- If the delta has no reviewable files, the task skips the LLM call and posts a one-line summary instead.
+
+Enabled by default. To always review the full PR, set `RUSTY_INCREMENTAL_REVIEW=false` in the step `env:`.

--- a/docs/src/content/docs/providers/github-action.md
+++ b/docs/src/content/docs/providers/github-action.md
@@ -74,6 +74,20 @@ The Action exits early (no error, no review) for these PR event types:
 - `closed`, `labeled`, `unlabeled`, `assigned`, `unassigned`
 - Draft PRs — unless `RUSTY_REVIEW_DRAFTS=true` is set in `env:`
 
+## Incremental review
+
+On `synchronize` events (every push after the first review), the Action only reviews the diff between the previously-reviewed commit and the new HEAD instead of re-reviewing the full PR diff. This typically cuts token usage by 60–80% on multi-commit PRs.
+
+How it works:
+
+- After each successful review, the Action embeds the reviewed commit sha in a hidden HTML marker inside the summary comment (`<!-- rusty-bot:last-sha:abc... -->`).
+- On the next push the Action reads that marker, fetches `git compare {last-sha}...{new-head}` from GitHub, and runs the review against only that delta.
+- If the marker is missing (first run) or the previous sha is no longer reachable (force-push or rebase), the Action falls back to a full review.
+- If the new HEAD is identical to the previously-reviewed sha, the run exits without re-posting anything.
+- If the delta has no reviewable files (e.g. only ignored paths changed), the Action skips the LLM call and posts a one-line summary instead.
+
+Enabled by default. To always review the full PR diff, set `RUSTY_INCREMENTAL_REVIEW=false`.
+
 ## Docker image
 
 The Action runs inside `ghcr.io/jegork/rusty-bot:latest`, which includes OpenGrep. The first run in a fresh runner environment adds roughly 20–40s for the image pull; subsequent runs on cached runners skip this entirely.

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -17,6 +17,7 @@ Non-secret configuration lives in `RUSTY_*` env vars rather than action inputs, 
 | `RUSTY_MODE` | — | Set to `pipeline` in Azure Pipelines container |
 | `RUSTY_FAIL_ON_CRITICAL` | `true` | Exit with code 1 when critical findings are produced |
 | `RUSTY_REVIEW_DRAFTS` | `false` | Review draft PRs (skipped by default) |
+| `RUSTY_INCREMENTAL_REVIEW` | `true` | Review only the diff since the previously-reviewed commit (GitHub Action) or PR iteration (Azure DevOps). Set to `false` to always review the full PR diff |
 
 ## LLM provider — Anthropic / OpenAI / Google
 

--- a/packages/azure-devops/src/__tests__/provider.test.ts
+++ b/packages/azure-devops/src/__tests__/provider.test.ts
@@ -183,6 +183,184 @@ describe("AzureDevOpsProvider", () => {
       const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
       expect(body.comments[0].content).toBe("<!-- rusty-bot-review -->\n");
     });
+
+    it("embeds the last-iteration marker when provided", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({}));
+
+      await provider.postSummaryComment("## Review", { lastReviewedIteration: "7" });
+
+      const body = JSON.parse(fetchSpy.mock.calls[0][1].body);
+      expect(body.comments[0].content).toContain("<!-- rusty-bot-review -->");
+      expect(body.comments[0].content).toContain("<!-- rusty-bot:last-iteration:7 -->");
+      expect(body.comments[0].content).toContain("## Review");
+    });
+  });
+
+  describe("getLastReviewedIteration", () => {
+    it("returns null when no threads have the marker", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            {
+              id: 1,
+              comments: [{ id: 1, content: "<!-- rusty-bot-review -->\nold review" }],
+            },
+            { id: 2, comments: [{ id: 2, content: "human comment" }] },
+          ],
+        }),
+      );
+      const id = await provider.getLastReviewedIteration();
+      expect(id).toBeNull();
+    });
+
+    it("extracts the iteration id from the newest bot thread", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            {
+              id: 1,
+              comments: [
+                {
+                  id: 1,
+                  content:
+                    "<!-- rusty-bot-review -->\n<!-- rusty-bot:last-iteration:3 -->\nReview 1",
+                },
+              ],
+            },
+            { id: 2, comments: [{ id: 2, content: "intermediate human comment" }] },
+            {
+              id: 3,
+              comments: [
+                {
+                  id: 3,
+                  content:
+                    "<!-- rusty-bot-review -->\n<!-- rusty-bot:last-iteration:7 -->\nReview 2",
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      const id = await provider.getLastReviewedIteration();
+      expect(id).toBe("7");
+    });
+
+    it("ignores the marker when no comment in the thread carries the bot marker", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            {
+              id: 1,
+              comments: [
+                {
+                  id: 1,
+                  content: "<!-- rusty-bot:last-iteration:7 -->",
+                },
+              ],
+            },
+          ],
+        }),
+      );
+      const id = await provider.getLastReviewedIteration();
+      expect(id).toBeNull();
+    });
+  });
+
+  describe("getDiffSinceIteration", () => {
+    it("returns null when sinceIterationId is not numeric", async () => {
+      const patches = await provider.getDiffSinceIteration("not-a-number");
+      expect(patches).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns an empty array when sinceIteration equals the latest iteration", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            { id: 5, sourceRefCommit: { commitId: "aaa" } },
+            { id: 7, sourceRefCommit: { commitId: "bbb" } },
+          ],
+        }),
+      );
+      const patches = await provider.getDiffSinceIteration("7");
+      expect(patches).toEqual([]);
+    });
+
+    it("returns null when the since iteration is missing or has no source commit", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            { id: 5, sourceRefCommit: { commitId: "aaa" } },
+            { id: 7, sourceRefCommit: { commitId: "bbb" } },
+          ],
+        }),
+      );
+      const missing = await provider.getDiffSinceIteration("99");
+      expect(missing).toBeNull();
+
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            { id: 5, sourceRefCommit: null },
+            { id: 7, sourceRefCommit: { commitId: "bbb" } },
+          ],
+        }),
+      );
+      const noCommit = await provider.getDiffSinceIteration("5");
+      expect(noCommit).toBeNull();
+    });
+
+    it("queries the changes endpoint with $compareTo and builds patches from commit-pinned content", async () => {
+      // call 1: list iterations
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          value: [
+            { id: 5, sourceRefCommit: { commitId: "old-sha" } },
+            { id: 7, sourceRefCommit: { commitId: "new-sha" } },
+          ],
+        }),
+      );
+      // call 2: changes since iteration 5
+      fetchSpy.mockResolvedValueOnce(
+        mockFetchResponse({
+          changeEntries: [
+            {
+              changeType: "edit",
+              item: { path: "/src/foo.ts", gitObjectType: "blob" },
+            },
+          ],
+        }),
+      );
+      // call 3: new content at new-sha
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("line1\nline2 changed\nline3\n"));
+      // call 4: old content at old-sha
+      fetchSpy.mockResolvedValueOnce(mockFileContentResponse("line1\nline2\nline3\n"));
+
+      const patches = await provider.getDiffSinceIteration("5");
+
+      expect(patches).not.toBeNull();
+      expect(patches).toHaveLength(1);
+      expect(patches?.[0].path).toBe("src/foo.ts");
+      expect(patches?.[0].hunks.length).toBeGreaterThan(0);
+
+      const changesUrl = fetchSpy.mock.calls[1][0] as string;
+      expect(changesUrl).toContain(`/iterations/7/changes`);
+      expect(changesUrl).toContain("$compareTo=5");
+
+      const newContentUrl = fetchSpy.mock.calls[2][0] as string;
+      expect(newContentUrl).toContain("versionDescriptor.versionType=commit");
+      expect(newContentUrl).toContain("versionDescriptor.version=new-sha");
+
+      const oldContentUrl = fetchSpy.mock.calls[3][0] as string;
+      expect(oldContentUrl).toContain("versionDescriptor.versionType=commit");
+      expect(oldContentUrl).toContain("versionDescriptor.version=old-sha");
+    });
+
+    it("returns null when the iterations request errors", async () => {
+      fetchSpy.mockResolvedValueOnce(mockFetchResponse({ message: "boom" }, false, 500));
+      const patches = await provider.getDiffSinceIteration("5");
+      expect(patches).toBeNull();
+    });
   });
 
   describe("postInlineComments", () => {

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -1,4 +1,4 @@
-import type { FocusArea, ReviewConfig, TicketRef } from "@rusty-bot/core";
+import type { FilePatch, FocusArea, ReviewConfig, TicketRef } from "@rusty-bot/core";
 import { ReviewStyleSchema } from "@rusty-bot/core";
 import {
   filterFiles,
@@ -36,6 +36,7 @@ export function parseConfig(): {
   provider: AzureDevOpsProvider;
   config: ReviewConfig;
   failOnCritical: boolean;
+  incrementalReview: boolean;
   env: { orgUrl: string; project: string; accessToken: string };
 } {
   const pullRequestId = process.env.SYSTEM_PULLREQUEST_PULLREQUESTID;
@@ -64,6 +65,7 @@ export function parseConfig(): {
     []) as FocusArea[];
   const ignorePatterns = process.env.RUSTY_IGNORE_PATTERNS?.split(",").filter(Boolean) ?? [];
   const failOnCritical = process.env.RUSTY_FAIL_ON_CRITICAL !== "false";
+  const incrementalReview = process.env.RUSTY_INCREMENTAL_REVIEW !== "false";
 
   return {
     provider: new AzureDevOpsProvider({
@@ -79,12 +81,13 @@ export function parseConfig(): {
       ignorePatterns,
     },
     failOnCritical,
+    incrementalReview,
     env: { orgUrl, project, accessToken },
   };
 }
 
 async function main(): Promise<void> {
-  const { provider, config, failOnCritical, env } = parseConfig();
+  const { provider, config, failOnCritical, incrementalReview, env } = parseConfig();
 
   const metadata = await provider.getPRMetadata();
   log.info(
@@ -100,16 +103,79 @@ async function main(): Promise<void> {
     config.conventionFile = conventionFile;
   }
 
+  // read incremental marker before deleting old bot comments — otherwise we lose the iteration id
+  let lastReviewedIteration: string | null = null;
+  let latestIteration: string | null = null;
+  if (incrementalReview) {
+    try {
+      [lastReviewedIteration, latestIteration] = await Promise.all([
+        provider.getLastReviewedIteration(),
+        provider.getLatestIterationId(),
+      ]);
+    } catch (err) {
+      log.warn({ err }, "failed to read iteration state, falling back to full review");
+    }
+  } else {
+    try {
+      latestIteration = await provider.getLatestIterationId();
+    } catch (err) {
+      log.warn({ err }, "failed to read latest iteration id, marker will not be embedded");
+    }
+  }
+
+  if (lastReviewedIteration && latestIteration && lastReviewedIteration === latestIteration) {
+    log.info(
+      { iteration: latestIteration },
+      "latest iteration matches last reviewed iteration, skipping review",
+    );
+    return;
+  }
+
   await provider.deleteExistingBotComments();
 
-  const rawPatches = await provider.getDiff();
+  let rawPatches: FilePatch[] | null = null;
+  let incrementalUsed = false;
+  if (lastReviewedIteration) {
+    const incremental = await provider.getDiffSinceIteration(lastReviewedIteration);
+    if (incremental) {
+      rawPatches = incremental;
+      incrementalUsed = true;
+      log.info(
+        {
+          lastReviewedIteration,
+          latestIteration,
+          files: incremental.length,
+        },
+        "running incremental review",
+      );
+    }
+  }
+
+  rawPatches ??= await provider.getDiff();
+
   const filtered = filterFiles(rawPatches, config.ignorePatterns);
   const reviewable = stripDeletionOnlyHunks(filtered);
   const skippedCount = rawPatches.length - reviewable.length;
   log.info(
-    { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
+    {
+      total: rawPatches.length,
+      reviewed: reviewable.length,
+      skipped: skippedCount,
+      mode: incrementalUsed ? "incremental" : "full",
+    },
     "files changed",
   );
+
+  if (incrementalUsed && reviewable.length === 0 && latestIteration) {
+    log.info(
+      { lastReviewedIteration, latestIteration },
+      "no reviewable changes in incremental delta, skipping LLM review",
+    );
+    await provider.postSummaryComment("No reviewable changes since the last review.", {
+      lastReviewedIteration: latestIteration,
+    });
+    return;
+  }
 
   if (process.env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true") {
     try {
@@ -286,7 +352,10 @@ async function main(): Promise<void> {
   );
 
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
-  await provider.postSummaryComment(summaryMarkdown);
+  await provider.postSummaryComment(
+    summaryMarkdown,
+    latestIteration ? { lastReviewedIteration: latestIteration } : undefined,
+  );
 
   const { anchored: inlineFindings, dropped } = filterAnchorableFindings(
     review.findings,

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -4,6 +4,7 @@ import type {
   PRMetadata,
   Finding,
   CodeSearchResult,
+  PostSummaryCommentOptions,
 } from "@rusty-bot/core";
 import { formatInlineComment } from "@rusty-bot/core";
 import { structuredPatch } from "diff";
@@ -22,6 +23,15 @@ const BOT_MARKER = "<!-- rusty-bot-review -->";
 const API_VERSION = "api-version=7.0";
 const ADO_MAX_PR_DESCRIPTION_LENGTH = 4000;
 const DESCRIPTION_TRUNCATION_MARKER = "\n\n…(truncated)";
+const LAST_ITERATION_MARKER_RE = /<!--\s*rusty-bot:last-iteration:(\d+)\s*-->/i;
+
+function buildLastShaMarker(sha: string): string {
+  return `<!-- rusty-bot:last-sha:${sha} -->`;
+}
+
+function buildLastIterationMarker(iterationId: string): string {
+  return `<!-- rusty-bot:last-iteration:${iterationId} -->`;
+}
 
 export function truncatePRDescription(
   description: string,
@@ -145,6 +155,27 @@ export class AzureDevOpsProvider implements GitProvider {
     }
   }
 
+  private async getFileContentByCommit(path: string, commitId: string): Promise<string | null> {
+    try {
+      const url =
+        `${this.baseUrl}/items?` +
+        `path=${encodeURIComponent("/" + path)}&` +
+        `versionDescriptor.version=${encodeURIComponent(commitId)}&` +
+        `versionDescriptor.versionType=commit&` +
+        `includeContent=true&${API_VERSION}`;
+      const response = await fetch(url, {
+        headers: {
+          Authorization: `Bearer ${this.accessToken}`,
+          Accept: "application/octet-stream",
+        },
+      });
+      if (!response.ok) return null;
+      return await response.text();
+    } catch {
+      return null;
+    }
+  }
+
   private async request<T extends z.ZodType>(
     url: string,
     schema: T,
@@ -153,6 +184,109 @@ export class AzureDevOpsProvider implements GitProvider {
     const response = await this.fetchApi(url, options);
     const json: unknown = await response.json();
     return schema.parse(json) as z.infer<T>;
+  }
+
+  async getLatestIterationId(): Promise<string | null> {
+    const iterations = await this.request(
+      `${this.baseUrl}/pullRequests/${this.pullRequestId}/iterations?${API_VERSION}`,
+      AdoIterationsSchema,
+    );
+    if (iterations.value.length === 0) return null;
+    const last = iterations.value[iterations.value.length - 1];
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard against schema changes
+    if (!last) return null;
+    return String(last.id);
+  }
+
+  async getLastReviewedIteration(): Promise<string | null> {
+    const threads = await this.request(
+      `${this.baseUrl}/pullRequests/${this.pullRequestId}/threads?${API_VERSION}`,
+      AdoThreadsSchema,
+    );
+
+    // walk newest-first so a fresher marker wins if multiple bot threads survive
+    for (let i = threads.value.length - 1; i >= 0; i--) {
+      const thread = threads.value[i];
+      const hasBotComment = thread.comments.some((c) => c.content?.includes(BOT_MARKER));
+      if (!hasBotComment) continue;
+      for (const comment of thread.comments) {
+        const match = comment.content ? LAST_ITERATION_MARKER_RE.exec(comment.content) : null;
+        if (match) return match[1];
+      }
+    }
+    return null;
+  }
+
+  async getDiffSinceIteration(sinceIterationId: string): Promise<FilePatch[] | null> {
+    const sinceId = parseInt(sinceIterationId, 10);
+    if (Number.isNaN(sinceId)) return null;
+
+    try {
+      const iterations = await this.request(
+        `${this.baseUrl}/pullRequests/${this.pullRequestId}/iterations?${API_VERSION}`,
+        AdoIterationsSchema,
+      );
+      if (iterations.value.length === 0) return null;
+
+      const sinceIteration = iterations.value.find((it) => it.id === sinceId);
+      const latestIteration = iterations.value[iterations.value.length - 1];
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- defensive guard against schema changes
+      if (!sinceIteration || !latestIteration) return null;
+      if (sinceIteration.id === latestIteration.id) return [];
+
+      const sinceCommitId = sinceIteration.sourceRefCommit?.commitId;
+      const latestCommitId = latestIteration.sourceRefCommit?.commitId;
+      if (!sinceCommitId || !latestCommitId) return null;
+
+      const changes = await this.request(
+        `${this.baseUrl}/pullRequests/${this.pullRequestId}/iterations/${latestIteration.id}/changes?$compareTo=${sinceIteration.id}&${API_VERSION}`,
+        AdoChangesSchema,
+      );
+
+      const patches: FilePatch[] = [];
+
+      for (const entry of changes.changeEntries) {
+        if (!entry.item?.path) continue;
+        if (entry.item.gitObjectType === "tree") continue;
+
+        const filePath = entry.item.path.replace(/^\//, "");
+
+        const isDelete = entry.changeType.includes("delete");
+        const isSourceRename = entry.changeType.includes("sourceRename");
+        if (isDelete || isSourceRename) continue;
+
+        const isAdd = entry.changeType.includes("add");
+        const isRename = entry.changeType.includes("rename");
+        const oldPath =
+          isRename && entry.originalPath ? entry.originalPath.replace(/^\//, "") : filePath;
+
+        const [newContent, oldContent] = await Promise.all([
+          this.getFileContentByCommit(filePath, latestCommitId),
+          isAdd ? Promise.resolve(null) : this.getFileContentByCommit(oldPath, sinceCommitId),
+        ]);
+
+        if (newContent !== null) {
+          this.fileLineCache.set(filePath, newContent.split(/\r?\n/));
+          const patch = buildPatchFromContent(filePath, oldContent, newContent);
+          if (patch.hunks.length > 0) {
+            patches.push(patch);
+            continue;
+          }
+        }
+
+        patches.push({
+          path: filePath,
+          hunks: [],
+          additions: 0,
+          deletions: 0,
+          isBinary: false,
+        });
+      }
+
+      return patches;
+    } catch {
+      return null;
+    }
   }
 
   async getDiff(): Promise<FilePatch[]> {
@@ -244,6 +378,9 @@ export class AzureDevOpsProvider implements GitProvider {
       sourceBranch: data.sourceRefName.replace("refs/heads/", ""),
       targetBranch: data.targetRefName.replace("refs/heads/", ""),
       url: `${this.orgUrl}/${this.project}/_git/${this.repoName}/pullrequest/${this.pullRequestId}`,
+      ...(data.lastMergeSourceCommit?.commitId
+        ? { headSha: data.lastMergeSourceCommit.commitId }
+        : {}),
     };
   }
 
@@ -297,7 +434,15 @@ export class AzureDevOpsProvider implements GitProvider {
     }
   }
 
-  async postSummaryComment(markdown: string): Promise<void> {
+  async postSummaryComment(markdown: string, options?: PostSummaryCommentOptions): Promise<void> {
+    const headerLines = [BOT_MARKER];
+    if (options?.lastReviewedSha) {
+      headerLines.push(buildLastShaMarker(options.lastReviewedSha));
+    }
+    if (options?.lastReviewedIteration) {
+      headerLines.push(buildLastIterationMarker(options.lastReviewedIteration));
+    }
+    const header = headerLines.join("\n");
     await this.fetchApi(
       `${this.baseUrl}/pullRequests/${this.pullRequestId}/threads?${API_VERSION}`,
       {
@@ -306,7 +451,7 @@ export class AzureDevOpsProvider implements GitProvider {
           comments: [
             {
               parentCommentId: 0,
-              content: `${BOT_MARKER}\n${markdown}`,
+              content: `${header}\n${markdown}`,
               commentType: 1,
             },
           ],

--- a/packages/azure-devops/src/schemas.ts
+++ b/packages/azure-devops/src/schemas.ts
@@ -13,6 +13,12 @@ export const AdoPullRequestSchema = z.object({
     .optional(),
   sourceRefName: z.string(),
   targetRefName: z.string(),
+  lastMergeSourceCommit: z
+    .object({
+      commitId: z.string(),
+    })
+    .nullable()
+    .optional(),
   repository: z
     .object({
       webUrl: z.string().optional(),
@@ -20,8 +26,18 @@ export const AdoPullRequestSchema = z.object({
     .optional(),
 });
 
+export const AdoIterationSchema = z.object({
+  id: z.number(),
+  sourceRefCommit: z
+    .object({
+      commitId: z.string(),
+    })
+    .nullable()
+    .optional(),
+});
+
 export const AdoIterationsSchema = z.object({
-  value: z.array(z.object({ id: z.number() })),
+  value: z.array(AdoIterationSchema),
 });
 
 export const AdoChangeEntrySchema = z.object({

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export type {
   TicketRef,
   CodeSearchResult,
   GitProvider,
+  PostSummaryCommentOptions,
   TicketProvider,
   DroppedFinding,
   ConsensusMetadata,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -103,6 +103,15 @@ export interface PRMetadata {
   sourceBranch: string;
   targetBranch: string;
   url: string;
+  /** sha at the head of the source branch — populated by providers that can fetch it cheaply */
+  headSha?: string;
+}
+
+export interface PostSummaryCommentOptions {
+  /** when set, providers embed a hidden marker so the next run can resume incrementally */
+  lastReviewedSha?: string;
+  /** ADO equivalent of lastReviewedSha — iteration id of the just-completed review */
+  lastReviewedIteration?: string;
 }
 
 export interface Hunk {
@@ -164,11 +173,15 @@ export interface GitProvider {
   getPRMetadata(): Promise<PRMetadata>;
   getFileContent(path: string, ref: string): Promise<string | null>;
   searchCode(query: string): Promise<CodeSearchResult[]>;
-  postSummaryComment(markdown: string): Promise<void>;
+  postSummaryComment(markdown: string, options?: PostSummaryCommentOptions): Promise<void>;
   postInlineComments(findings: Finding[]): Promise<void>;
   deleteExistingBotComments(): Promise<void>;
   updatePRDescription(description: string): Promise<void>;
   updatePRTitle(title: string): Promise<void>;
+  /** read the sha embedded in a previously-posted summary comment, if any */
+  getLastReviewedSha?(): Promise<string | null>;
+  /** fetch only the diff between an earlier sha and the current head; null if unreachable */
+  getDiffSinceSha?(sinceSha: string, headSha: string): Promise<FilePatch[] | null>;
 }
 
 export interface TicketProvider {

--- a/packages/github-action/src/__tests__/cli.test.ts
+++ b/packages/github-action/src/__tests__/cli.test.ts
@@ -52,6 +52,7 @@ describe("parseConfig", () => {
     expect(config.failOnCritical).toBe(true);
     expect(config.generateDescription).toBe(false);
     expect(config.renameTitleToConventional).toBe(false);
+    expect(config.incrementalReview).toBe(true);
   });
 
   it("throws when GITHUB_TOKEN is missing", () => {
@@ -261,6 +262,25 @@ describe("parseConfig", () => {
     ).toBe(false);
 
     expect(parseConfig({ event: BASE_EVENT, env: makeEnv() }).generateDescription).toBe(false);
+  });
+
+  it("enables incremental review by default and disables only on explicit 'false'", () => {
+    expect(parseConfig({ event: BASE_EVENT, env: makeEnv() }).incrementalReview).toBe(true);
+
+    expect(
+      parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_INCREMENTAL_REVIEW: "false" }),
+      }).incrementalReview,
+    ).toBe(false);
+
+    for (const value of ["true", "1", "yes", ""]) {
+      const config = parseConfig({
+        event: BASE_EVENT,
+        env: makeEnv({ RUSTY_INCREMENTAL_REVIEW: value }),
+      });
+      expect(config.incrementalReview).toBe(true);
+    }
   });
 
   it("enables conventional title rename only on exact 'true'", () => {

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -1,5 +1,11 @@
 import { Octokit } from "octokit";
-import type { FocusArea, ReviewConfig, TicketProvider, TicketRef } from "@rusty-bot/core";
+import type {
+  FilePatch,
+  FocusArea,
+  ReviewConfig,
+  TicketProvider,
+  TicketRef,
+} from "@rusty-bot/core";
 import {
   ReviewStyleSchema,
   filterFiles,
@@ -54,6 +60,7 @@ export interface ActionConfig {
   failOnCritical: boolean;
   generateDescription: boolean;
   renameTitleToConventional: boolean;
+  incrementalReview: boolean;
 }
 
 interface ParseConfigOptions {
@@ -134,6 +141,7 @@ export function parseConfig({ event, env = process.env }: ParseConfigOptions): A
   const failOnCritical = env.RUSTY_FAIL_ON_CRITICAL !== "false";
   const generateDescription = env.RUSTY_GENERATE_DESCRIPTION === "true";
   const renameTitleToConventional = env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true";
+  const incrementalReview = env.RUSTY_INCREMENTAL_REVIEW !== "false";
 
   const octokit = new Octokit({ auth: token });
 
@@ -151,6 +159,7 @@ export function parseConfig({ event, env = process.env }: ParseConfigOptions): A
     failOnCritical,
     generateDescription,
     renameTitleToConventional,
+    incrementalReview,
   };
 }
 
@@ -214,17 +223,65 @@ export async function runAction(config: ActionConfig): Promise<number> {
     reviewConfig.conventionFile = conventionFile;
   }
 
+  // read incremental marker before deleting old bot comments — otherwise we lose the sha
+  let lastReviewedSha: string | null = null;
+  if (config.incrementalReview && metadata.headSha) {
+    try {
+      lastReviewedSha = await provider.getLastReviewedSha();
+    } catch (err) {
+      log.warn({ err }, "failed to read last-reviewed sha, falling back to full review");
+    }
+  }
+
+  if (lastReviewedSha && lastReviewedSha === metadata.headSha) {
+    log.info({ sha: metadata.headSha }, "head sha matches last reviewed sha, skipping review");
+    return 0;
+  }
+
   await provider.deleteExistingBotComments();
 
-  const rawDiff = await provider.getRawDiff();
-  const rawPatches = parseDiff(rawDiff);
+  let rawPatches: FilePatch[] | null = null;
+  let incrementalUsed = false;
+  if (lastReviewedSha && metadata.headSha) {
+    const incremental = await provider.getDiffSinceSha(lastReviewedSha, metadata.headSha);
+    if (incremental) {
+      rawPatches = incremental;
+      incrementalUsed = true;
+      log.info(
+        { lastReviewedSha, headSha: metadata.headSha, files: incremental.length },
+        "running incremental review",
+      );
+    }
+  }
+
+  if (!rawPatches) {
+    const rawDiff = await provider.getRawDiff();
+    rawPatches = parseDiff(rawDiff);
+  }
+
   const filtered = filterFiles(rawPatches, reviewConfig.ignorePatterns);
   const reviewable = stripDeletionOnlyHunks(filtered);
   const skippedCount = rawPatches.length - reviewable.length;
   log.info(
-    { total: rawPatches.length, reviewed: reviewable.length, skipped: skippedCount },
+    {
+      total: rawPatches.length,
+      reviewed: reviewable.length,
+      skipped: skippedCount,
+      mode: incrementalUsed ? "incremental" : "full",
+    },
     "files changed",
   );
+
+  if (incrementalUsed && reviewable.length === 0 && metadata.headSha) {
+    log.info(
+      { lastReviewedSha, headSha: metadata.headSha },
+      "no reviewable changes in incremental delta, skipping LLM review",
+    );
+    await provider.postSummaryComment("No reviewable changes since the last review.", {
+      lastReviewedSha: metadata.headSha,
+    });
+    return 0;
+  }
 
   if (config.renameTitleToConventional) {
     try {
@@ -383,7 +440,10 @@ export async function runAction(config: ActionConfig): Promise<number> {
   );
 
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
-  await provider.postSummaryComment(summaryMarkdown);
+  await provider.postSummaryComment(
+    summaryMarkdown,
+    metadata.headSha ? { lastReviewedSha: metadata.headSha } : undefined,
+  );
 
   const inlineCandidates = review.findings.filter((f) => f.line > 0);
   const { anchored: inlineFindings, dropped } = filterAnchorableFindings(

--- a/packages/github/src/__tests__/provider.test.ts
+++ b/packages/github/src/__tests__/provider.test.ts
@@ -39,7 +39,7 @@ describe("GitHubProvider", () => {
           title: "feat: add feature",
           body: "some description",
           user: { login: "octocat" },
-          head: { ref: "feature-branch" },
+          head: { ref: "feature-branch", sha: "deadbeef0000000000000000000000000000beef" },
           base: { ref: "main" },
           html_url: "https://github.com/test-owner/test-repo/pull/42",
         },
@@ -55,6 +55,7 @@ describe("GitHubProvider", () => {
         sourceBranch: "feature-branch",
         targetBranch: "main",
         url: "https://github.com/test-owner/test-repo/pull/42",
+        headSha: "deadbeef0000000000000000000000000000beef",
       });
 
       expect(octokit.request).toHaveBeenCalledWith(
@@ -74,7 +75,7 @@ describe("GitHubProvider", () => {
           title: "pr",
           body: null,
           user: null,
-          head: { ref: "src" },
+          head: { ref: "src", sha: "0".repeat(40) },
           base: { ref: "dst" },
           html_url: "https://example.com",
         },
@@ -102,6 +103,136 @@ describe("GitHubProvider", () => {
           body: "<!-- rusty-bot-review -->\n## Review\nLooks good!",
         }),
       );
+    });
+
+    it("embeds the last-reviewed-sha marker when provided", async () => {
+      octokit.request.mockResolvedValueOnce({ data: {} });
+
+      await provider.postSummaryComment("## Review\nLooks good!", {
+        lastReviewedSha: "abc123def4560000000000000000000000000000",
+      });
+
+      const call = octokit.request.mock.calls[0][1] as { body: string };
+      expect(call.body).toContain("<!-- rusty-bot-review -->");
+      expect(call.body).toContain(
+        "<!-- rusty-bot:last-sha:abc123def4560000000000000000000000000000 -->",
+      );
+      expect(call.body).toContain("## Review\nLooks good!");
+    });
+  });
+
+  describe("getLastReviewedSha", () => {
+    it("returns null when no comments exist", async () => {
+      octokit.request.mockResolvedValueOnce({ data: [] });
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBeNull();
+    });
+
+    it("returns null when no bot comment carries the marker", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          { id: 1, body: "<!-- rusty-bot-review -->\nold review without marker" },
+          { id: 2, body: "human comment" },
+        ],
+      });
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBeNull();
+    });
+
+    it("extracts the sha when a bot comment carries the marker", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body:
+              "<!-- rusty-bot-review -->\n" +
+              "<!-- rusty-bot:last-sha:abc123def4560000000000000000000000000000 -->\n" +
+              "## Review",
+          },
+        ],
+      });
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBe("abc123def4560000000000000000000000000000");
+    });
+
+    it("prefers the newest matching comment when multiple bot comments exist", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body:
+              "<!-- rusty-bot-review -->\n" +
+              "<!-- rusty-bot:last-sha:1111111111111111111111111111111111111111 -->",
+          },
+          { id: 2, body: "an unrelated human comment" },
+          {
+            id: 3,
+            body:
+              "<!-- rusty-bot-review -->\n" +
+              "<!-- rusty-bot:last-sha:2222222222222222222222222222222222222222 -->",
+          },
+        ],
+      });
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBe("2222222222222222222222222222222222222222");
+    });
+
+    it("ignores the marker when it isn't inside a bot comment", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body: "<!-- rusty-bot:last-sha:abc123def4560000000000000000000000000000 -->",
+          },
+        ],
+      });
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBeNull();
+    });
+  });
+
+  describe("getDiffSinceSha", () => {
+    const HEAD_SHA = "feedface0000000000000000000000000000face";
+    const SINCE_SHA = "deadbeef0000000000000000000000000000beef";
+
+    it("returns an empty array when sinceSha equals headSha without calling the API", async () => {
+      const patches = await provider.getDiffSinceSha(HEAD_SHA, HEAD_SHA);
+      expect(patches).toEqual([]);
+      expect(octokit.request).not.toHaveBeenCalled();
+    });
+
+    it("calls the compare API with basehead and parses the resulting diff", async () => {
+      const rawDiff = [
+        "diff --git a/file.ts b/file.ts",
+        "--- a/file.ts",
+        "+++ b/file.ts",
+        "@@ -1,2 +1,2 @@",
+        "-old",
+        "+new",
+        " keep",
+      ].join("\n");
+      octokit.request.mockResolvedValueOnce({ data: rawDiff });
+
+      const patches = await provider.getDiffSinceSha(SINCE_SHA, HEAD_SHA);
+
+      expect(patches).not.toBeNull();
+      expect(patches).toHaveLength(1);
+      expect(patches?.[0].path).toBe("file.ts");
+      expect(octokit.request).toHaveBeenCalledWith(
+        "GET /repos/{owner}/{repo}/compare/{basehead}",
+        expect.objectContaining({
+          owner: OWNER,
+          repo: REPO,
+          basehead: `${SINCE_SHA}...${HEAD_SHA}`,
+        }),
+      );
+    });
+
+    it("returns null when the compare API errors (force-push or unreachable sha)", async () => {
+      octokit.request.mockRejectedValueOnce(Object.assign(new Error("Not Found"), { status: 404 }));
+
+      const patches = await provider.getDiffSinceSha(SINCE_SHA, HEAD_SHA);
+      expect(patches).toBeNull();
     });
   });
 

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -6,10 +6,17 @@ import type {
   Finding,
   Hunk,
   CodeSearchResult,
+  PostSummaryCommentOptions,
 } from "@rusty-bot/core";
-import { formatInlineComment } from "@rusty-bot/core";
+import { formatInlineComment, logger } from "@rusty-bot/core";
 
 const BOT_MARKER = "<!-- rusty-bot-review -->";
+const LAST_SHA_MARKER_RE = /<!--\s*rusty-bot:last-sha:([0-9a-f]{40})\s*-->/i;
+const log = logger.child({ package: "github", component: "provider" });
+
+function buildLastShaMarker(sha: string): string {
+  return `<!-- rusty-bot:last-sha:${sha} -->`;
+}
 
 interface GitHubProviderConfig {
   octokit: Octokit;
@@ -130,6 +137,47 @@ export class GitHubProvider implements GitProvider {
     return parseDiff(raw);
   }
 
+  async getDiffSinceSha(sinceSha: string, headSha: string): Promise<FilePatch[] | null> {
+    if (sinceSha === headSha) return [];
+    try {
+      const response = await this.octokit.request("GET /repos/{owner}/{repo}/compare/{basehead}", {
+        owner: this.owner,
+        repo: this.repo,
+        basehead: `${sinceSha}...${headSha}`,
+        headers: {
+          accept: "application/vnd.github.v3.diff",
+        },
+      });
+      return parseDiff(response.data as unknown as string);
+    } catch (err) {
+      log.warn(
+        { err, sinceSha, headSha },
+        "could not fetch incremental diff (sha unreachable, force-push, or rebase)",
+      );
+      return null;
+    }
+  }
+
+  async getLastReviewedSha(): Promise<string | null> {
+    const { data: comments } = await this.octokit.request(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      {
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: this.pullNumber,
+      },
+    );
+
+    // walk newest-first so a fresher marker wins if multiple bot comments survive
+    for (let i = comments.length - 1; i >= 0; i--) {
+      const body = comments[i].body;
+      if (!body?.includes(BOT_MARKER)) continue;
+      const match = LAST_SHA_MARKER_RE.exec(body);
+      if (match) return match[1].toLowerCase();
+    }
+    return null;
+  }
+
   async getPRMetadata(): Promise<PRMetadata> {
     const { data } = await this.octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}", {
       owner: this.owner,
@@ -146,6 +194,7 @@ export class GitHubProvider implements GitProvider {
       sourceBranch: data.head.ref,
       targetBranch: data.base.ref,
       url: data.html_url,
+      headSha: data.head.sha,
     };
   }
 
@@ -182,12 +231,15 @@ export class GitHubProvider implements GitProvider {
     }
   }
 
-  async postSummaryComment(markdown: string): Promise<void> {
+  async postSummaryComment(markdown: string, options?: PostSummaryCommentOptions): Promise<void> {
+    const header = options?.lastReviewedSha
+      ? `${BOT_MARKER}\n${buildLastShaMarker(options.lastReviewedSha)}`
+      : BOT_MARKER;
     await this.octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
       owner: this.owner,
       repo: this.repo,
       issue_number: this.pullNumber,
-      body: `${BOT_MARKER}\n${markdown}`,
+      body: `${header}\n${markdown}`,
     });
   }
 


### PR DESCRIPTION
## Summary

- Re-reviewing the entire PR diff on every push is wasteful; this change reviews only the delta since the previously-reviewed state.
- **GitHub**: stores the reviewed HEAD SHA in a hidden marker (`<!-- rusty-bot:last-sha:abc... -->`) inside the summary comment. On the next run, fetches `git compare {last-sha}...{head}` and reviews only that diff.
- **Azure DevOps**: stores the reviewed iteration id (`<!-- rusty-bot:last-iteration:7 -->`) in the summary thread. On the next run, calls `iterations/{latest}/changes?$compareTo={last}` and rebuilds patches from file contents pinned to each iteration's source-ref commit.
- Enabled by default on both providers. Opt out with `RUSTY_INCREMENTAL_REVIEW=false`.

## Behavior

- First run, missing marker, force-push, rebase, or unreachable since-state → falls back to full review.
- Latest state matches the previously-reviewed state → exit cleanly without re-posting (preserves the marker).
- Incremental delta has no reviewable files → post a one-line summary and skip the LLM call.
- The marker is always read **before** old bot comments are deleted, so state survives across runs.

## Test plan

- [ ] Open a fresh PR — first run does a full review and embeds the marker
- [ ] Push another commit — verify logs show `mode: "incremental"` and only the new files are reviewed
- [ ] Push a no-op commit (e.g. only ignored files) — verify the LLM call is skipped and a short summary is posted
- [ ] Push twice with the same HEAD (e.g. duplicate webhook delivery) — verify the run exits early without re-posting
- [ ] Force-push to rewrite history — verify the run logs the warning and falls back to a full review
- [ ] Set `RUSTY_INCREMENTAL_REVIEW=false` — verify the full diff is reviewed every time
- [ ] Repeat the above on Azure DevOps with a multi-iteration PR