### PR TITLE
fix: configure provider cache options dynamically

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -1,5 +1,9 @@
-import { describe, it, expect } from "vitest";
-import { buildSystemPrompt, buildUserMessage } from "../agent/prompts.js";
+import { describe, it, expect, afterEach } from "vitest";
+import {
+  buildSystemPrompt,
+  buildUserMessage,
+  buildCachedSystemMessages,
+} from "../agent/prompts.js";
 import { ReviewOutputSchema } from "../agent/schema.js";
 import type { ReviewConfig, PRMetadata, TicketInfo } from "../types.js";
 
@@ -123,6 +127,40 @@ describe("buildSystemPrompt", () => {
   it("omits convention instructions section when not provided", () => {
     const prompt = buildSystemPrompt(baseConfig);
     expect(prompt).not.toContain("repository maintainer");
+  });
+});
+
+describe("buildCachedSystemMessages", () => {
+  afterEach(() => {
+    delete process.env.RUSTY_PROMPT_CACHE;
+  });
+
+  it("wraps the prompt with anthropic ephemeral cacheControl by default", () => {
+    const messages = buildCachedSystemMessages("hello");
+    expect(messages).toEqual([
+      {
+        role: "system",
+        content: "hello",
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      },
+    ]);
+  });
+
+  it("omits providerOptions when RUSTY_PROMPT_CACHE=false (kill switch)", () => {
+    process.env.RUSTY_PROMPT_CACHE = "false";
+    const messages = buildCachedSystemMessages("hello");
+    expect(messages).toEqual([{ role: "system", content: "hello" }]);
+  });
+
+  it("omits providerOptions when Anthropic cache control is unsupported", () => {
+    const messages = buildCachedSystemMessages("hello", { anthropicCacheControl: false });
+    expect(messages).toEqual([{ role: "system", content: "hello" }]);
+  });
+
+  it("treats unrecognized RUSTY_PROMPT_CACHE values as enabled", () => {
+    process.env.RUSTY_PROMPT_CACHE = "yes";
+    const messages = buildCachedSystemMessages("hello");
+    expect(messages[0].providerOptions?.anthropic?.cacheControl.type).toBe("ephemeral");
   });
 });
 

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -19,6 +19,7 @@ vi.mock("../agent/model.js", () => ({
     config.type === "router" ? (config.model ?? "test-model") : "test-model",
   ),
   resolveModelSettings: vi.fn(() => ({})),
+  resolveDefaultAgentOptions: vi.fn(() => undefined),
 }));
 
 const { judgeFindings, judgeReviewResult, resolveJudgeConfig } = await import("../agent/judge.js");
@@ -268,9 +269,10 @@ describe("judgeFindings", () => {
       model: "anthropic/claude-haiku",
     });
 
-    expect(Agent).toHaveBeenCalledWith(
-      expect.objectContaining({ model: "anthropic/claude-haiku" }),
-    );
+    const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
+    expect(agentConfig?.model).toEqual(expect.any(Function));
+    const resolveAgentModel = agentConfig?.model as (() => unknown) | undefined;
+    expect(resolveAgentModel?.()).toBe("anthropic/claude-haiku");
   });
 
   it("routes override model through provider resolution (azure-openai prefix)", async () => {

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -4,6 +4,8 @@ import {
   resolveTriageModelConfig,
   resolveModelConfigWithOverride,
   getModelDisplayName,
+  resolveDefaultAgentOptions,
+  supportsAnthropicCacheControl,
 } from "../agent/model.js";
 
 function clearEnv() {
@@ -16,6 +18,8 @@ function clearEnv() {
   delete process.env.RUSTY_AZURE_DEPLOYMENT;
   delete process.env.RUSTY_LLM_BASE_URL;
   delete process.env.RUSTY_LLM_API_KEY;
+  delete process.env.REQUESTY_API_KEY;
+  delete process.env.RUSTY_PROMPT_CACHE;
 }
 
 describe("resolveModelConfig", () => {
@@ -68,6 +72,109 @@ describe("resolveModelConfig", () => {
 
     const config = resolveModelConfig();
     expect(config.type).toBe("router");
+  });
+
+  it("leaves requesty/ models on the native mastra router", () => {
+    process.env.RUSTY_LLM_MODEL = "requesty/anthropic/claude-sonnet-4";
+
+    const config = resolveModelConfig();
+    expect(config).toEqual({ type: "router", model: "requesty/anthropic/claude-sonnet-4" });
+  });
+});
+
+describe("resolveDefaultAgentOptions", () => {
+  beforeEach(clearEnv);
+
+  it("returns auto_cache providerOptions for requesty/ router models", () => {
+    const opts = resolveDefaultAgentOptions({
+      type: "router",
+      model: "requesty/anthropic/claude-sonnet-4",
+    });
+    expect(opts).toEqual({
+      providerOptions: { requesty: { auto_cache: true } },
+    });
+  });
+
+  it("returns undefined for non-requesty router models", () => {
+    expect(
+      resolveDefaultAgentOptions({ type: "router", model: "anthropic/claude-sonnet" }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for non-router configs", () => {
+    expect(
+      resolveDefaultAgentOptions({
+        type: "azure-api-key",
+        resourceName: "r",
+        deploymentName: "d",
+        apiKey: "k",
+      }),
+    ).toBeUndefined();
+    expect(
+      resolveDefaultAgentOptions({
+        type: "openai-compatible",
+        baseUrl: "https://litellm.example.com/v1",
+        model: "anything",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined when RUSTY_PROMPT_CACHE=false even for requesty/ models", () => {
+    process.env.RUSTY_PROMPT_CACHE = "false";
+    expect(
+      resolveDefaultAgentOptions({
+        type: "router",
+        model: "requesty/anthropic/claude-sonnet-4",
+      }),
+    ).toBeUndefined();
+  });
+});
+
+describe("supportsAnthropicCacheControl", () => {
+  it("returns true for direct anthropic router models", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "router",
+        model: "anthropic/claude-sonnet-4",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for requesty-routed anthropic models", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "router",
+        model: "requesty/anthropic/claude-sonnet-4",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when anthropic appears later in a router model string", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "router",
+        model: "gateway/vendor/anthropic/claude-sonnet-4",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for other requesty-routed providers", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "router",
+        model: "requesty/openai/gpt-5",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-router configs", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "openai-compatible",
+        baseUrl: "https://example.com/v1",
+        model: "anthropic/claude-sonnet-4",
+      }),
+    ).toBe(false);
   });
 });
 

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -14,6 +14,7 @@ vi.mock("../agent/model.js", () => ({
   resolveModel: vi.fn(() => "test-model"),
   getModelDisplayName: vi.fn(() => "test-model"),
   resolveModelSettings: vi.fn(() => ({})),
+  resolveDefaultAgentOptions: vi.fn(() => undefined),
 }));
 
 const { runReview } = await import("../agent/review.js");

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -139,13 +139,13 @@ export async function judgeFindings(
     "running judge pass",
   );
 
-  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
+  const defaultOptions = resolveDefaultAgentOptions(modelConfig);
   const agent = new Agent({
     id: "review-judge",
     name: "Rusty Bot Judge",
     instructions: () => JUDGE_SYSTEM_PROMPT,
     model: () => resolveModel(modelConfig),
-    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
+    ...(defaultOptions && { defaultOptions }),
   });
 
   const userMessage = formatFindingsForJudge(findings, diff);

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -6,6 +6,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  resolveDefaultAgentOptions,
 } from "./model.js";
 import type { Finding, ReviewResult } from "../types.js";
 import { logger } from "../logger.js";
@@ -97,7 +98,10 @@ function resolveJudgeModel(judgeModelOverride?: string) {
   const config = judgeModelOverride
     ? resolveModelConfigWithOverride(judgeModelOverride)
     : resolveModelConfig();
-  return { model: resolveModel(config), displayName: getModelDisplayName(config) };
+  return {
+    displayName: getModelDisplayName(config),
+    config,
+  };
 }
 
 export function resolveJudgeConfig(): JudgeConfig {
@@ -128,18 +132,20 @@ export async function judgeFindings(
     return { accepted: [...findings], rejected: [], evaluations: [], tokenCount: 0 };
   }
 
-  const { model, displayName } = resolveJudgeModel(config.model);
+  const { displayName, config: modelConfig } = resolveJudgeModel(config.model);
 
   log.info(
     { findingCount: findings.length, model: displayName, threshold: config.threshold },
     "running judge pass",
   );
 
+  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
   const agent = new Agent({
     id: "review-judge",
     name: "Rusty Bot Judge",
-    instructions: JUDGE_SYSTEM_PROMPT,
-    model,
+    instructions: () => JUDGE_SYSTEM_PROMPT,
+    model: () => resolveModel(modelConfig),
+    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
   });
 
   const userMessage = formatFindingsForJudge(findings, diff);

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -110,6 +110,20 @@ export function resolveModel(
   }
 }
 
+export function resolveDefaultAgentOptions(
+  config: ModelConfig,
+): { providerOptions: { requesty: { auto_cache: true } } } | undefined {
+  if (process.env.RUSTY_PROMPT_CACHE === "false") return undefined;
+  if (config.type !== "router") return undefined;
+  if (!config.model.startsWith("requesty/")) return undefined;
+  return { providerOptions: { requesty: { auto_cache: true } } };
+}
+
+export function supportsAnthropicCacheControl(config: ModelConfig): boolean {
+  if (config.type !== "router") return false;
+  return config.model.includes("anthropic/");
+}
+
 export interface ModelSettings {
   temperature?: number;
   topP?: number;

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -36,6 +36,35 @@ export function buildSystemPrompt(config: ReviewConfig): string {
     .replace("{{convention_instructions}}", conventionInstructions);
 }
 
+export interface CachedSystemMessage {
+  role: "system";
+  content: string;
+  providerOptions?: {
+    anthropic?: { cacheControl: { type: "ephemeral" } };
+  };
+}
+
+/**
+ * wrap the system prompt in Mastra's array-of-system-messages form, marking the
+ * static block as cacheable for Anthropic when the resolved model supports it.
+ */
+export function buildCachedSystemMessages(
+  systemPrompt: string,
+  options: { anthropicCacheControl: boolean } = { anthropicCacheControl: true },
+): CachedSystemMessage[] {
+  const enabled = process.env.RUSTY_PROMPT_CACHE !== "false" && options.anthropicCacheControl;
+  if (!enabled) {
+    return [{ role: "system", content: systemPrompt }];
+  }
+  return [
+    {
+      role: "system",
+      content: systemPrompt,
+      providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+    },
+  ];
+}
+
 function buildOpenGrepSection(findings: OpenGrepFinding[]): string {
   const parts: string[] = [];
   parts.push("## OpenGrep Pre-scan Findings");

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -1,12 +1,14 @@
 import { Agent } from "@mastra/core/agent";
 import type { ToolsInput } from "@mastra/core/agent";
 import { ReviewOutputSchema, SkimReviewOutputSchema } from "./schema.js";
-import { buildSystemPrompt, buildUserMessage } from "./prompts.js";
+import { buildSystemPrompt, buildUserMessage, buildCachedSystemMessages } from "./prompts.js";
 import {
   resolveModelConfig,
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  resolveDefaultAgentOptions,
+  supportsAnthropicCacheControl,
 } from "./model.js";
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
@@ -130,18 +132,23 @@ export async function runReview(
     options?.chunkFiles,
   );
   const modelConfig = resolveModelConfig();
-  const model = resolveModel(modelConfig);
   const modelName = getModelDisplayName(modelConfig);
 
   const builtInTools = buildTools(options);
   const extraTools = tier === "skim" ? {} : (options?.extraTools ?? {});
 
+  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
+
   const agent = new Agent({
     id: "review-agent",
     name: "Rusty Bot Reviewer",
-    instructions: systemPrompt,
-    model,
+    instructions: () =>
+      buildCachedSystemMessages(systemPrompt, {
+        anthropicCacheControl: supportsAnthropicCacheControl(modelConfig),
+      }),
+    model: () => resolveModel(modelConfig),
     tools: { ...builtInTools, ...extraTools },
+    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
   });
 
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -137,7 +137,7 @@ export async function runReview(
   const builtInTools = buildTools(options);
   const extraTools = tier === "skim" ? {} : (options?.extraTools ?? {});
 
-  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
+  const defaultOptions = resolveDefaultAgentOptions(modelConfig);
 
   const agent = new Agent({
     id: "review-agent",
@@ -148,7 +148,7 @@ export async function runReview(
       }),
     model: () => resolveModel(modelConfig),
     tools: { ...builtInTools, ...extraTools },
-    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
+    ...(defaultOptions && { defaultOptions }),
   });
 
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -99,14 +99,13 @@ export async function generatePRDescription(
   const { compressed } = compressDiff(patches, MAX_DESCRIPTION_TOKENS);
 
   const modelConfig = resolveModelConfig();
-  const model = resolveModel(modelConfig);
   const modelName = getModelDisplayName(modelConfig);
 
   const agent = new Agent({
     id: "description-agent",
     name: "Rusty Bot Description Generator",
-    instructions: buildDescriptionSystemPrompt(),
-    model,
+    instructions: () => buildDescriptionSystemPrompt(),
+    model: () => resolveModel(modelConfig),
   });
 
   const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription);

--- a/packages/core/src/title/generate.ts
+++ b/packages/core/src/title/generate.ts
@@ -27,14 +27,13 @@ export async function generateConventionalTitle(
   const { compressed } = compressDiff(patches, MAX_TITLE_TOKENS);
 
   const modelConfig = resolveModelConfig();
-  const model = resolveModel(modelConfig);
   const modelName = getModelDisplayName(modelConfig);
 
   const agent = new Agent({
     id: "title-agent",
     name: "Rusty Bot Title Generator",
-    instructions: buildTitleSystemPrompt(),
-    model,
+    instructions: () => buildTitleSystemPrompt(),
+    model: () => resolveModel(modelConfig),
   });
 
   const userMessage = buildTitleUserMessage(compressed, prMetadata);

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -111,13 +111,13 @@ export async function runTriage(
     overflowFiles = applyOverflowDefaults(patches, triageablePatches);
   }
 
-  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
+  const defaultOptions = resolveDefaultAgentOptions(modelConfig);
   const agent = new Agent({
     id: "triage-agent",
     name: "Rusty Bot Triage",
     instructions: () => systemPrompt,
     model: () => resolveModel(modelConfig),
-    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
+    ...(defaultOptions && { defaultOptions }),
   });
 
   const triageMessage = buildTriageUserMessage(triageablePatches);

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -8,6 +8,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  resolveDefaultAgentOptions,
 } from "../agent/model.js";
 import { normalizePath } from "../agent/multi-call.js";
 import { countTokens } from "../diff/compress.js";
@@ -80,7 +81,6 @@ export async function runTriage(
     throw new Error("triage model not configured");
   }
 
-  const model = resolveModel(modelConfig);
   const modelName = getModelDisplayName(modelConfig);
   const systemPrompt = buildTriageSystemPrompt();
 
@@ -111,11 +111,13 @@ export async function runTriage(
     overflowFiles = applyOverflowDefaults(patches, triageablePatches);
   }
 
+  const defaultGenerateOptionsLegacy = resolveDefaultAgentOptions(modelConfig);
   const agent = new Agent({
     id: "triage-agent",
     name: "Rusty Bot Triage",
-    instructions: systemPrompt,
-    model,
+    instructions: () => systemPrompt,
+    model: () => resolveModel(modelConfig),
+    ...(defaultGenerateOptionsLegacy && { defaultGenerateOptionsLegacy }),
   });
 
   const triageMessage = buildTriageUserMessage(triageablePatches);


### PR DESCRIPTION
## Summary

- Configure Requesty auto_cache through agent-level provider options only for Requesty router models.
- Pass Mastra agent model and instructions as dynamic functions across the agent call sites.
- Apply Anthropic cache-control metadata only when the resolved router model includes anthropic/.
- Add tests covering Requesty options, Anthropic cache-control gating, and the dynamic agent configuration shape.

## Validation

- pnpm exec prettier --check packages/core/src/agent/review.ts packages/core/src/__tests__/review.test.ts
- pnpm --filter @rusty-bot/core build
- pnpm --filter @rusty-bot/core test -- --runInBand
- pre-commit hook: workspace build and full test suite, 25 files / 670 tests passed