### PR TITLE
feat: support per-pass models and adaptive consensus passes

### DIFF
--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -9,10 +9,27 @@ By default, each review runs 3 independent passes with shuffled diff ordering (f
 
 Configure via per-repo config in the dashboard or API:
 
-| Setting | Description | Default |
-| --- | --- | --- |
-| `consensusPasses` | Number of independent review passes (set to `1` to disable) | `3` |
-| `consensusThreshold` | Minimum votes to keep a finding | `ceil(passes/2)` |
+| Setting              | Description                                                 | Default                               |
+| -------------------- | ----------------------------------------------------------- | ------------------------------------- |
+| `consensusPasses`    | Number of independent review passes (set to `1` to disable) | `3`                                   |
+| `consensusThreshold` | Minimum votes to keep a finding                             | strict majority (`floor(passes/2)+1`) |
+
+You can also set per-pass review models with `RUSTY_REVIEW_MODELS`, for example:
+
+```bash
+RUSTY_REVIEW_MODELS=anthropic/claude-sonnet-4-20250514,openai/gpt-5-mini,google/gemini-3.1-pro
+RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
+```
+
+When fewer models are provided than passes, missing entries fall back to `RUSTY_LLM_MODEL`.
+
+Adaptive pass planning is opt-in:
+
+```bash
+RUSTY_REVIEW_ADAPTIVE_PASSES=true
+```
+
+With adaptive planning enabled, ordinary deep-review chunks use 2 passes, while large or security-sensitive chunks keep up to 3 passes. Explicit `consensusPasses` still caps the maximum number of passes.
 
 ## How it works
 

--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -23,6 +23,19 @@ RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
 
 When fewer models are provided than passes, missing entries fall back to `RUSTY_LLM_MODEL`.
 
+Example balanced multi-model setup:
+
+```bash
+RUSTY_LLM_TRIAGE_MODEL=requesty/google/gemini-3.1-flash-lite-preview
+RUSTY_REVIEW_MODELS=requesty/anthropic/claude-sonnet-4-6,requesty/openai/gpt-5-mini,requesty/google/gemini-3.1-pro
+RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
+RUSTY_JUDGE_MODEL=requesty/anthropic/claude-sonnet-4-6
+RUSTY_JUDGE_TEMPERATURE=0
+RUSTY_REVIEW_ADAPTIVE_PASSES=true
+```
+
+Treat model IDs as provider-specific configuration. If your router uses different current aliases, keep the same role split: cheap structured model for triage, diverse review models for consensus, and a well-calibrated model for the judge.
+
 Adaptive pass planning is opt-in:
 
 ```bash

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -58,6 +58,10 @@ The managed identity vars (`RUSTY_AZURE_*`) take priority over the API-key vars 
 | `RUSTY_LLM_TEMPERATURE` | provider default | Global temperature for all agents |
 | `RUSTY_LLM_TOP_P` | provider default | Global top-p for all agents |
 | `RUSTY_REVIEW_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the review agent |
+| `RUSTY_REVIEW_MODELS` | `RUSTY_LLM_MODEL` | Comma-separated per-pass review models for consensus, e.g. `anthropic/claude-sonnet,openai/gpt-5-mini` |
+| `RUSTY_REVIEW_TEMPERATURES` | `RUSTY_REVIEW_TEMPERATURE` | Comma-separated per-pass review temperatures |
+| `RUSTY_REVIEW_TOP_PS` | `RUSTY_REVIEW_TOP_P` | Comma-separated per-pass review top-p values |
+| `RUSTY_REVIEW_ADAPTIVE_PASSES` | `false` | When `true`, ordinary deep-review chunks use fewer consensus passes while large or security-sensitive chunks keep up to 3 |
 | `RUSTY_TRIAGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the triage agent |
 | `RUSTY_JUDGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the judge agent |
 | `RUSTY_DESCRIPTION_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the description agent |

--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -80,6 +80,11 @@ describe("runConsensusReview", () => {
   beforeEach(() => {
     callCount = 0;
     mockBehavior = "default";
+    delete process.env.RUSTY_REVIEW_MODELS;
+    delete process.env.RUSTY_REVIEW_TEMPERATURES;
+    delete process.env.RUSTY_REVIEW_TOP_PS;
+    delete process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
+    delete process.env.RUSTY_LLM_MODEL;
     vi.clearAllMocks();
   });
 
@@ -137,6 +142,76 @@ describe("runConsensusReview", () => {
     const { runReview } = await import("../agent/review.js");
     expect(runReview).toHaveBeenCalledTimes(3);
     expect(result.consensusMetadata?.passes).toBe(3);
+  });
+
+  it("passes per-pass model configs and settings to each review pass", async () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/default";
+    process.env.RUSTY_REVIEW_MODELS = "anthropic/pass-1,openai/pass-2";
+    process.env.RUSTY_REVIEW_TEMPERATURES = "0.1,0.2";
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+    const { runReview } = await import("../agent/review.js");
+    const calls = (runReview as ReturnType<typeof vi.fn>).mock.calls;
+
+    expect(calls[0][4]?.modelConfig).toEqual({ type: "router", model: "anthropic/pass-1" });
+    expect(calls[0][4]?.modelSettings).toEqual({ temperature: 0.1 });
+    expect(calls[1][4]?.modelConfig).toEqual({ type: "router", model: "openai/pass-2" });
+    expect(calls[1][4]?.modelSettings).toEqual({ temperature: 0.2 });
+    expect(calls[2][4]?.modelConfig).toEqual({ type: "router", model: "anthropic/default" });
+    expect(result.consensusMetadata?.passModels).toEqual([
+      "anthropic/pass-1",
+      "openai/pass-2",
+      "anthropic/default",
+    ]);
+  });
+
+  it("reduces ordinary deep-review chunks to two passes when adaptive pass planning is enabled", async () => {
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "true";
+
+    const patches = [
+      {
+        path: "src/service.ts",
+        additions: 20,
+        deletions: 5,
+        isBinary: false,
+        hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, content: "+x" }],
+      },
+    ];
+    const result = await runConsensusReview(patches, config, prMetadata, "diff content");
+    const { runReview } = await import("../agent/review.js");
+
+    expect(runReview).toHaveBeenCalledTimes(2);
+    expect(result.consensusMetadata?.passes).toBe(2);
+    expect(result.consensusMetadata?.threshold).toBe(2);
+    expect(result.consensusMetadata?.passPlanReason).toBe("ordinary deep-review chunk");
+  });
+
+  it("uses strict majority as the default threshold for two-pass consensus", async () => {
+    const consensusConfig = { ...config, consensusPasses: 2 };
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.consensusMetadata?.threshold).toBe(2);
+  });
+
+  it("keeps three adaptive passes for security-sensitive chunks", async () => {
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "true";
+
+    const patches = [
+      {
+        path: "src/auth/session.ts",
+        additions: 20,
+        deletions: 5,
+        isBinary: false,
+        hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, content: "+x" }],
+      },
+    ];
+    const result = await runConsensusReview(patches, config, prMetadata, "diff content");
+    const { runReview } = await import("../agent/review.js");
+
+    expect(runReview).toHaveBeenCalledTimes(3);
+    expect(result.consensusMetadata?.passes).toBe(3);
+    expect(result.consensusMetadata?.passPlanReason).toBe("security-sensitive file");
   });
 
   it("populates droppedFindings for clusters below threshold", async () => {

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -3,6 +3,7 @@ import {
   resolveModelConfig,
   resolveTriageModelConfig,
   resolveModelConfigWithOverride,
+  resolveReviewPassModelConfigs,
   getModelDisplayName,
   resolveDefaultAgentOptions,
   supportsAnthropicCacheControl,
@@ -11,6 +12,13 @@ import {
 function clearEnv() {
   delete process.env.RUSTY_LLM_MODEL;
   delete process.env.RUSTY_LLM_TRIAGE_MODEL;
+  delete process.env.RUSTY_REVIEW_MODELS;
+  delete process.env.RUSTY_REVIEW_TEMPERATURES;
+  delete process.env.RUSTY_REVIEW_TOP_PS;
+  delete process.env.RUSTY_REVIEW_TEMPERATURE;
+  delete process.env.RUSTY_REVIEW_TOP_P;
+  delete process.env.RUSTY_LLM_TEMPERATURE;
+  delete process.env.RUSTY_LLM_TOP_P;
   delete process.env.AZURE_API_KEY;
   delete process.env.AZURE_OPENAI_API_KEY;
   delete process.env.AZURE_OPENAI_RESOURCE_NAME;
@@ -79,6 +87,50 @@ describe("resolveModelConfig", () => {
 
     const config = resolveModelConfig();
     expect(config).toEqual({ type: "router", model: "requesty/anthropic/claude-sonnet-4" });
+  });
+});
+
+describe("resolveReviewPassModelConfigs", () => {
+  beforeEach(clearEnv);
+
+  it("uses the default review model for every pass when no per-pass models are set", () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/claude-sonnet";
+
+    const configs = resolveReviewPassModelConfigs(3);
+
+    expect(configs.map((c) => c.displayName)).toEqual([
+      "anthropic/claude-sonnet",
+      "anthropic/claude-sonnet",
+      "anthropic/claude-sonnet",
+    ]);
+  });
+
+  it("resolves per-pass models and falls back to RUSTY_LLM_MODEL for missing entries", () => {
+    process.env.RUSTY_LLM_MODEL = "anthropic/default";
+    process.env.RUSTY_REVIEW_MODELS = "anthropic/pass-1, openai/pass-2";
+
+    const configs = resolveReviewPassModelConfigs(3);
+
+    expect(configs.map((c) => c.displayName)).toEqual([
+      "anthropic/pass-1",
+      "openai/pass-2",
+      "anthropic/default",
+    ]);
+  });
+
+  it("applies per-pass temperature and top-p overrides", () => {
+    process.env.RUSTY_REVIEW_TEMPERATURE = "0.5";
+    process.env.RUSTY_REVIEW_TOP_P = "0.8";
+    process.env.RUSTY_REVIEW_TEMPERATURES = "0.1,0.2";
+    process.env.RUSTY_REVIEW_TOP_PS = "0.9";
+
+    const configs = resolveReviewPassModelConfigs(3);
+
+    expect(configs.map((c) => c.settings)).toEqual([
+      { temperature: 0.1, topP: 0.9 },
+      { temperature: 0.2, topP: 0.8 },
+      { temperature: 0.5, topP: 0.8 },
+    ]);
   });
 });
 

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -14,9 +14,12 @@ import { shufflePatches } from "../diff/shuffle.js";
 import { clusterFindings, clusterObservations } from "./cluster.js";
 import { runReview, type RunReviewOptions } from "./review.js";
 import { mergeMissingTests } from "./multi-call.js";
+import { resolveReviewPassModelConfigs } from "./model.js";
 import { logger } from "../logger.js";
 
 const DEFAULT_CONSENSUS_PASSES = 3;
+const LARGE_REVIEW_LINE_THRESHOLD = 300;
+const SECURITY_SENSITIVE_PATH = /\b(auth|crypto|payment|permission|token|session|policy|secret)\b/i;
 
 const RECOMMENDATION_SEVERITY: Record<Recommendation, number> = {
   looks_good: 0,
@@ -56,6 +59,44 @@ function deriveRecommendation(
   return "looks_good";
 }
 
+function isAdaptivePassPlanningEnabled(): boolean {
+  const raw = process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
+  return raw === "true" || raw === "1";
+}
+
+function isSecuritySensitivePatch(patch: FilePatch): boolean {
+  return SECURITY_SENSITIVE_PATH.test(patch.path);
+}
+
+function planConsensusPasses(
+  patches: FilePatch[],
+  configuredPasses: number,
+): { passes: number; reason?: string } {
+  if (!isAdaptivePassPlanningEnabled() || configuredPasses <= 1) {
+    return { passes: configuredPasses };
+  }
+
+  const hasSecuritySensitiveFile = patches.some(isSecuritySensitivePatch);
+  if (hasSecuritySensitiveFile) {
+    return { passes: Math.min(configuredPasses, 3), reason: "security-sensitive file" };
+  }
+
+  const changedLines = patches.reduce((sum, patch) => sum + patch.additions + patch.deletions, 0);
+  const hasLargeFile = patches.some(
+    (patch) => patch.additions + patch.deletions >= LARGE_REVIEW_LINE_THRESHOLD,
+  );
+
+  if (changedLines >= LARGE_REVIEW_LINE_THRESHOLD || hasLargeFile) {
+    return { passes: Math.min(configuredPasses, 3), reason: "large deep-review chunk" };
+  }
+
+  return { passes: Math.min(configuredPasses, 2), reason: "ordinary deep-review chunk" };
+}
+
+function deriveConsensusThreshold(configuredThreshold: number | null | undefined, passes: number) {
+  return Math.min(configuredThreshold ?? Math.floor(passes / 2) + 1, passes);
+}
+
 export async function runConsensusReview(
   patches: FilePatch[],
   config: ReviewConfig,
@@ -64,22 +105,39 @@ export async function runConsensusReview(
   ticketContext?: TicketInfo[],
   options?: RunReviewOptions,
 ): Promise<ReviewResult> {
-  const passes = config.consensusPasses ?? DEFAULT_CONSENSUS_PASSES;
+  const configuredPasses = config.consensusPasses ?? DEFAULT_CONSENSUS_PASSES;
+  const passPlan = planConsensusPasses(patches, configuredPasses);
+  const passes = passPlan.passes;
 
   if (passes <= 1) {
     return runReview(config, diff, prMetadata, ticketContext, options);
   }
 
-  const threshold = config.consensusThreshold ?? Math.ceil(passes / 2);
+  const threshold = deriveConsensusThreshold(config.consensusThreshold, passes);
   const baseSeed = deriveBaseSeed(prMetadata);
+  const passModelConfigs = resolveReviewPassModelConfigs(passes);
 
-  logger.info({ passes, threshold, prId: prMetadata.id }, "starting consensus review");
+  logger.info(
+    {
+      passes,
+      threshold,
+      prId: prMetadata.id,
+      passPlanReason: passPlan.reason,
+      passModels: passModelConfigs.map((m) => m.displayName),
+    },
+    "starting consensus review",
+  );
 
   const passPromises = Array.from({ length: passes }, (_, i) => {
     const shuffled = shufflePatches(patches, baseSeed + i);
     const { compressed } = compressDiff(shuffled, Infinity);
     const tickets = i === 0 ? ticketContext : undefined;
-    return runReview(config, compressed, prMetadata, tickets, options);
+    const passModel = passModelConfigs[i];
+    return runReview(config, compressed, prMetadata, tickets, {
+      ...options,
+      modelConfig: passModel.config,
+      modelSettings: passModel.settings,
+    });
   });
 
   const settled = await Promise.allSettled(passPromises);
@@ -183,6 +241,8 @@ export async function runConsensusReview(
       agreementRate,
       recommendationElevated,
       passRecommendations,
+      passModels: passModelConfigs.map((m) => m.displayName),
+      ...(passPlan.reason ? { passPlanReason: passPlan.reason } : {}),
       failedPasses,
     },
     droppedFindings: droppedFindings.length > 0 ? droppedFindings : undefined,

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -163,6 +163,53 @@ export function resolveModelSettings(agentKind: AgentKind = "review"): ModelSett
   return settings;
 }
 
+function readCsvEnv(key: string): string[] {
+  return (
+    process.env[key]
+      ?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? []
+  );
+}
+
+function readNumericCsvEnv(key: string): number[] {
+  return readCsvEnv(key)
+    .map((value) => Number(value))
+    .filter((value) => Number.isFinite(value));
+}
+
+export interface ReviewPassModelConfig {
+  config: ModelConfig;
+  settings: ModelSettings;
+  displayName: string;
+}
+
+export function resolveReviewPassModelConfigs(passCount: number): ReviewPassModelConfig[] {
+  const reviewModels = readCsvEnv("RUSTY_REVIEW_MODELS");
+  const reviewTemperatures = readNumericCsvEnv("RUSTY_REVIEW_TEMPERATURES");
+  const reviewTopPs = readNumericCsvEnv("RUSTY_REVIEW_TOP_PS");
+  const defaultSettings = resolveModelSettings("review");
+
+  return Array.from({ length: passCount }, (_, index) => {
+    const model = reviewModels[index];
+    const config = model ? resolveModelConfigWithOverride(model) : resolveModelConfig();
+    const settings: ModelSettings = { ...defaultSettings };
+
+    if (index < reviewTemperatures.length) {
+      settings.temperature = reviewTemperatures[index];
+    }
+    if (index < reviewTopPs.length) {
+      settings.topP = reviewTopPs[index];
+    }
+
+    return {
+      config,
+      settings,
+      displayName: getModelDisplayName(config),
+    };
+  });
+}
+
 export function getModelDisplayName(config: ModelConfig): string {
   switch (config.type) {
     case "router":

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -10,6 +10,7 @@ import {
   resolveDefaultAgentOptions,
   supportsAnthropicCacheControl,
 } from "./model.js";
+import type { ModelConfig, ModelSettings } from "./model.js";
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 import { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
@@ -98,6 +99,10 @@ export interface RunReviewOptions {
   chunkFiles?: string[];
   /** OpenGrep findings to feed to the LLM for triage. */
   openGrepFindings?: OpenGrepFinding[];
+  /** override used by consensus pass planning; defaults to RUSTY_LLM_MODEL. */
+  modelConfig?: ModelConfig;
+  /** override used by consensus pass planning; defaults to review env settings. */
+  modelSettings?: ModelSettings;
 }
 
 function buildTools(options?: RunReviewOptions): ToolsInput {
@@ -131,7 +136,7 @@ export async function runReview(
     options?.openGrepFindings,
     options?.chunkFiles,
   );
-  const modelConfig = resolveModelConfig();
+  const modelConfig = options?.modelConfig ?? resolveModelConfig();
   const modelName = getModelDisplayName(modelConfig);
 
   const builtInTools = buildTools(options);
@@ -153,7 +158,7 @@ export async function runReview(
 
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;
 
-  const modelSettings = resolveModelSettings("review");
+  const modelSettings = options?.modelSettings ?? resolveModelSettings("review");
   const response = await generateWithTransientRetry(() =>
     generateWithStructuredOutputRetry(() =>
       agent.generate(userMessage, {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -35,6 +35,8 @@ export interface ConsensusMetadata {
   agreementRate: number;
   recommendationElevated: boolean;
   passRecommendations: Recommendation[];
+  passModels?: string[];
+  passPlanReason?: string;
   /** number of consensus passes that threw before producing a result */
   failedPasses: number;
 }


### PR DESCRIPTION
## Summary

- Add `RUSTY_REVIEW_MODELS`, `RUSTY_REVIEW_TEMPERATURES`, `RUSTY_REVIEW_TOP_PS` env vars to assign different models/temperature/top-p per consensus pass, falling back to `RUSTY_LLM_MODEL` for unspecified entries
- Add `RUSTY_REVIEW_ADAPTIVE_PASSES` opt-in to automatically reduce ordinary deep-review chunks to 2 passes while keeping 3 for security-sensitive or large chunks
- Fix consensus threshold to use strict majority (`floor(passes/2)+1`) instead of `ceil(passes/2)`
- Extend `ConsensusMetadata` with `passModels` and `passPlanReason` for observability
- Add corresponding tests and docs

Closes #100