### PR TITLE
feat: add tiered tree-sitter context expansion

### DIFF
--- a/packages/core/src/__tests__/treesitter.test.ts
+++ b/packages/core/src/__tests__/treesitter.test.ts
@@ -232,7 +232,7 @@ describe("expandToScopeBoundaries", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null when scope exceeds maxScopeLines", async () => {
+  it("uses a medium tier for scopes just over maxScopeLines", async () => {
     const lines = [
       "function huge() {",
       ...Array.from({ length: 300 }, (_, i) => `  const x${i} = ${i};`),
@@ -247,7 +247,29 @@ describe("expandToScopeBoundaries", () => {
       200,
     );
 
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toEqual([{ startLine: 140, endLine: 160 }]);
+    expect(result!.siblingSignatures).toContainEqual({ line: 1, text: "function huge() {" });
+  });
+
+  it("uses a tighter large tier for very large scopes", async () => {
+    const lines = [
+      "function huge() {",
+      ...Array.from({ length: 500 }, (_, i) => `  const x${i} = ${i};`),
+      "}",
+    ];
+    const bigFile = lines.join("\n");
+
+    const result = await expandToScopeBoundaries(
+      bigFile,
+      [{ startLine: 250, endLine: 250 }],
+      "big.js",
+      200,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.scopes).toEqual([{ startLine: 247, endLine: 253 }]);
+    expect(result!.siblingSignatures).toContainEqual({ line: 1, text: "function huge() {" });
   });
 
   it("handles empty file content gracefully", async () => {
@@ -444,6 +466,47 @@ describe("expandContext with tree-sitter", () => {
     // falls back to ±3 fixed lines
     expect(result[0].hunks[0].newStart).toBe(1);
     expect(result[0].hunks[0].content).toContain("export function processData");
+  });
+
+  it("keeps large function context bounded without shifting new-file line numbers", async () => {
+    const lines = [
+      "function huge() {",
+      ...Array.from({ length: 500 }, (_, i) => `  const x${i} = ${i};`),
+      "}",
+    ];
+    const bigFile = lines.join("\n");
+    const patch: FilePatch = {
+      path: "src/big.js",
+      additions: 1,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 250,
+          oldLines: 1,
+          newStart: 250,
+          newLines: 2,
+          content: " const x248 = 248;\n+  const touched = true;",
+        },
+      ],
+    };
+
+    const result = await expandContext([patch], () => Promise.resolve(bigFile), 10);
+    const hunk = result[0].hunks[0];
+
+    expect(hunk.newStart).toBe(248);
+    expect(hunk.content).toContain("~ // ... function huge() {");
+    expect(hunk.content).toContain(" const x246 = 246;");
+    expect(hunk.content).not.toContain(" const x0 = 0;");
+
+    const bodyRowCount = hunk.content.split("\n").filter((l) => !l.startsWith("~")).length;
+    expect(hunk.newLines).toBe(bodyRowCount);
+
+    const { compressDiff } = await import("../diff/compress.js");
+    const { compressed } = compressDiff(result, 10000);
+    const labelled = compressed.split("\n").find((l) => l.startsWith("250 "));
+    expect(labelled).toBeDefined();
+    expect(labelled).toContain("const x248 = 248");
   });
 });
 

--- a/packages/core/src/diff/treesitter.ts
+++ b/packages/core/src/diff/treesitter.ts
@@ -55,6 +55,9 @@ const GRAMMAR_TO_PACKAGE: Record<string, { pkg: string; wasm: string }> = {
 };
 
 const DEFAULT_MAX_SCOPE_LINES = 200;
+const MEDIUM_SCOPE_MULTIPLIER = 2;
+const MEDIUM_SCOPE_CONTEXT_LINES = 10;
+const LARGE_SCOPE_CONTEXT_LINES = 3;
 
 let parserInitialized = false;
 const languageCache = new Map<string, Language>();
@@ -68,7 +71,7 @@ export interface ExpandedScope {
 
 export interface TreeSitterExpansion {
   scopes: ExpandedScope[];
-  /** collapsed signature lines from sibling scopes for orientation */
+  /** collapsed signature lines from sibling scopes or tiered scopes for orientation */
   siblingSignatures: { line: number; text: string }[];
 }
 
@@ -182,10 +185,55 @@ function collectSiblingSignatures(
   return [];
 }
 
+function buildScopeExpansion(
+  scopeNode: Node,
+  range: { startLine: number; endLine: number },
+  fileLines: string[],
+  maxScopeLines: number,
+): { scope: ExpandedScope; signature: { line: number; text: string } | null; dedupeKey: string } {
+  const scopeStartLine = scopeNode.startPosition.row + 1;
+  const scopeEndLine = scopeNode.endPosition.row + 1;
+  const scopeLines = scopeEndLine - scopeStartLine + 1;
+
+  if (scopeLines <= maxScopeLines) {
+    return {
+      scope: {
+        startLine: scopeStartLine,
+        endLine: scopeEndLine,
+      },
+      signature: null,
+      dedupeKey: `${scopeNode.id}:full`,
+    };
+  }
+
+  const contextLines =
+    scopeLines <= maxScopeLines * MEDIUM_SCOPE_MULTIPLIER
+      ? MEDIUM_SCOPE_CONTEXT_LINES
+      : LARGE_SCOPE_CONTEXT_LINES;
+  const startLine = Math.max(scopeStartLine, range.startLine - contextLines);
+  const endLine = Math.min(scopeEndLine, range.endLine + contextLines);
+  const signatureText = getSignatureLine(scopeNode, fileLines);
+
+  return {
+    scope: {
+      startLine,
+      endLine,
+    },
+    signature:
+      signatureText && scopeStartLine < startLine
+        ? {
+            line: scopeStartLine,
+            text: signatureText,
+          }
+        : null,
+    dedupeKey: `${scopeNode.id}:${startLine}:${endLine}`,
+  };
+}
+
 /**
  * Try to expand changed line ranges to enclosing function/class boundaries
  * using tree-sitter. Returns null if tree-sitter can't handle this file
- * (unsupported language, parse failure, scope too large).
+ * (unsupported language, parse failure, no enclosing scope).
  */
 export async function expandToScopeBoundaries(
   fileContent: string,
@@ -212,7 +260,7 @@ export async function expandToScopeBoundaries(
     const fileLines = fileContent.split("\n");
     const scopes: ExpandedScope[] = [];
     const allSiblingSignatures: { line: number; text: string }[] = [];
-    const seenScopeIds = new Set<number>();
+    const seenScopeKeys = new Set<string>();
     const seenSignatureLines = new Set<number>();
 
     for (const range of changedRanges) {
@@ -223,16 +271,17 @@ export async function expandToScopeBoundaries(
 
       if (!scopeNode) return null;
 
-      const scopeLines = scopeNode.endPosition.row - scopeNode.startPosition.row + 1;
-      if (scopeLines > maxScopeLines) return null;
+      const expansion = buildScopeExpansion(scopeNode, range, fileLines, maxScopeLines);
 
-      if (seenScopeIds.has(scopeNode.id)) continue;
-      seenScopeIds.add(scopeNode.id);
+      if (seenScopeKeys.has(expansion.dedupeKey)) continue;
+      seenScopeKeys.add(expansion.dedupeKey);
 
-      scopes.push({
-        startLine: scopeNode.startPosition.row + 1,
-        endLine: scopeNode.endPosition.row + 1,
-      });
+      scopes.push(expansion.scope);
+
+      if (expansion.signature && !seenSignatureLines.has(expansion.signature.line)) {
+        seenSignatureLines.add(expansion.signature.line);
+        allSiblingSignatures.push(expansion.signature);
+      }
 
       for (const sig of collectSiblingSignatures(scopeNode, scopeTypes, fileLines)) {
         if (!seenSignatureLines.has(sig.line)) {


### PR DESCRIPTION
## Summary

- add tiered tree-sitter scope expansion for large enclosing scopes
- keep small scopes on full function/class expansion
- include large-scope signatures as non-counting annotations so inline line numbers stay stable
- cover small, medium, and large expansion behavior in tests

Closes #96.

## Verification

- `pnpm vitest run packages/core/src/__tests__/treesitter.test.ts`
- `pnpm test`
- `pnpm lint`
- `pnpm build`