### PR TITLE
feat: add graph-ranked review context

### DIFF
--- a/docs/src/content/docs/guides/graph-ranked-context.md
+++ b/docs/src/content/docs/guides/graph-ranked-context.md
@@ -1,0 +1,24 @@
+---
+title: Graph-ranked context
+description: Add a small GraphSift-inspired dependency context package to deep reviews.
+---
+
+Graph-ranked context is an opt-in context selector inspired by [GraphSift](https://github.com/maheshmakvana/graphsift). Rusty Bot does not depend on the Python package. Instead, it builds a small TypeScript-native context package from directly resolvable JavaScript and TypeScript relative imports around deep-review files.
+
+When enabled, Rusty Bot:
+
+1. Reads deep-review files only
+2. Resolves directly imported relative JS/TS modules
+3. Scores candidates by graph proximity, path overlap, keyword overlap, and symbol overlap
+4. Greedily selects context under a hard token budget
+5. Injects the selected context before the diff with instructions to keep findings anchored to changed code
+
+```bash
+RUSTY_GRAPH_CONTEXT=true
+RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET=2000
+RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES=8
+```
+
+High-scoring files may be included as fuller context. Lower-scoring or large files are rendered as signatures/API surface only. If nothing fits the budget, no context section is added.
+
+This first version is intentionally narrow: no Python runtime, no embeddings, no vector database, no 14-language parity, and no repo-wide importer discovery. It is meant to reduce wasted context for deep reviews while keeping the behavior easy to measure and disable.

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -88,6 +88,16 @@ See [Judge / filter pass](/guides/judge-pass/).
 
 See [Cascading review](/guides/cascading-review/).
 
+## Graph-ranked context
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `RUSTY_GRAPH_CONTEXT` | `false` | Enable GraphSift-style ranked context selection for deep-review prompts |
+| `RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET` | `2000` | Hard token budget for selected dependency context |
+| `RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES` | `8` | Maximum directly related files to consider after ranking |
+
+See [Graph-ranked context](/guides/graph-ranked-context/).
+
 ## OpenGrep
 
 | Variable | Default | Description |

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -315,6 +315,24 @@ describe("buildUserMessage", () => {
     expect(chunkIdx).toBeGreaterThan(-1);
     expect(chunkIdx).toBeLessThan(diffIdx);
   });
+
+  it("includes ranked context before the diff when provided", () => {
+    const msg = buildUserMessage(
+      "diff content here",
+      prMetadata,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ["src/foo.ts"],
+      "## Graph-ranked Context\n### src/bar.ts",
+    );
+
+    const contextIdx = msg.indexOf("## Graph-ranked Context");
+    const diffIdx = msg.indexOf("## Diff");
+    expect(contextIdx).toBeGreaterThan(-1);
+    expect(contextIdx).toBeLessThan(diffIdx);
+  });
 });
 
 describe("ReviewOutputSchema", () => {

--- a/packages/core/src/__tests__/graph-context.test.ts
+++ b/packages/core/src/__tests__/graph-context.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, afterEach } from "vitest";
+import { buildGraphRankedContext, resolveGraphContextConfig } from "../diff/graph-context.js";
+import type { FilePatch, PRMetadata } from "../types.js";
+
+const metadata: PRMetadata = {
+  id: "1",
+  title: "Refactor auth token validation",
+  description: "Tightens login session handling",
+  author: "dev",
+  sourceBranch: "feature/auth",
+  targetBranch: "main",
+  url: "https://example.com/pr/1",
+};
+
+function patch(path: string, content: string): FilePatch {
+  return {
+    path,
+    additions: 1,
+    deletions: 0,
+    isBinary: false,
+    hunks: [{ oldStart: 1, oldLines: 1, newStart: 1, newLines: 1, content }],
+  };
+}
+
+describe("resolveGraphContextConfig", () => {
+  afterEach(() => {
+    delete process.env.RUSTY_GRAPH_CONTEXT;
+    delete process.env.RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET;
+    delete process.env.RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES;
+  });
+
+  it("defaults to disabled", () => {
+    expect(resolveGraphContextConfig()).toEqual({
+      enabled: false,
+      tokenBudget: 2000,
+      maxCandidates: 8,
+    });
+  });
+
+  it("parses opt-in settings", () => {
+    process.env.RUSTY_GRAPH_CONTEXT = "true";
+    process.env.RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET = "120";
+    process.env.RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES = "2";
+
+    expect(resolveGraphContextConfig()).toEqual({
+      enabled: true,
+      tokenBudget: 120,
+      maxCandidates: 2,
+    });
+  });
+});
+
+describe("buildGraphRankedContext", () => {
+  it("selects directly imported relative context under budget", async () => {
+    const files = new Map([
+      [
+        "src/auth/login.ts",
+        [
+          'import { validateToken } from "./token";',
+          'import { auditLogin } from "../audit";',
+          "",
+          "export function login(token: string) {",
+          "  return validateToken(token);",
+          "}",
+        ].join("\n"),
+      ],
+      [
+        "src/auth/token.ts",
+        [
+          "export interface TokenPayload { userId: string }",
+          "export function validateToken(token: string): TokenPayload {",
+          "  return { userId: token };",
+          "}",
+        ].join("\n"),
+      ],
+      [
+        "src/audit.ts",
+        ["export function auditLogin(userId: string) {", "  return userId;", "}"].join("\n"),
+      ],
+    ]);
+
+    const result = await buildGraphRankedContext(
+      [patch("src/auth/login.ts", "+  return validateToken(token);")],
+      async (filePath) => files.get(filePath) ?? null,
+      metadata,
+      { enabled: true, tokenBudget: 500, maxCandidates: 8 },
+    );
+
+    expect(result.selections.map((s) => s.path)).toEqual(["src/auth/token.ts", "src/audit.ts"]);
+    expect(result.tokenCount).toBeLessThanOrEqual(500);
+    expect(result.renderedContext).toContain("## Graph-ranked Context");
+    expect(result.renderedContext).toContain("validateToken");
+  });
+
+  it("falls back from full content to signatures when the budget is tight", async () => {
+    const files = new Map([
+      ["src/service.ts", 'import { expensiveHelper } from "./helper";\nexport const value = 1;'],
+      [
+        "src/helper.ts",
+        [
+          "export function expensiveHelper() {",
+          ...Array.from({ length: 200 }, (_, i) => `  const value${i} = ${i};`),
+          "  return true;",
+          "}",
+        ].join("\n"),
+      ],
+    ]);
+
+    const result = await buildGraphRankedContext(
+      [patch("src/service.ts", "+export const value = expensiveHelper();")],
+      async (filePath) => files.get(filePath) ?? null,
+      metadata,
+      { enabled: true, tokenBudget: 600, maxCandidates: 8 },
+    );
+
+    expect(result.selections).toHaveLength(1);
+    expect(result.selections[0].mode).toBe("signatures");
+    expect(result.renderedContext).toContain("export function expensiveHelper()");
+    expect(result.renderedContext).not.toContain("const value199");
+  });
+
+  it("returns no context when disabled", async () => {
+    const result = await buildGraphRankedContext(
+      [patch("src/service.ts", '+import "./helper";')],
+      async () => "export const helper = true;",
+      metadata,
+      { enabled: false, tokenBudget: 500, maxCandidates: 8 },
+    );
+
+    expect(result).toEqual({ renderedContext: "", selections: [], tokenCount: 0 });
+  });
+});

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { countTokens } from "../diff/compress.js";
-import type { FilePatch, ReviewConfig, ReviewResult, TicketInfo, Observation } from "../types.js";
+import type {
+  FilePatch,
+  ReviewConfig,
+  ReviewResult,
+  TicketInfo,
+  Observation,
+  GitProvider,
+} from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 
 function makeMockReview(diff: string): ReviewResult {
@@ -87,6 +94,7 @@ describe("runMultiCallReview", () => {
   beforeEach(() => {
     runReviewMock.mockReset();
     runReviewMock.mockImplementation(async (_config, diff) => makeMockReview(diff));
+    delete process.env.RUSTY_GRAPH_CONTEXT;
   });
 
   it("uses single call when diff fits in budget", async () => {
@@ -698,6 +706,29 @@ describe("runCascadeReview", () => {
 
     const deepOpts = deepCalls[0][4];
     expect(deepOpts?.otherPrFiles).toBeUndefined();
+  });
+
+  it("injects graph-ranked context into deep-review tier when enabled", async () => {
+    process.env.RUSTY_GRAPH_CONTEXT = "true";
+    const files = new Map([
+      [
+        "src/auth.ts",
+        'import { validateToken } from "./token";\nexport function auth() { return validateToken("x"); }',
+      ],
+      ["src/token.ts", "export function validateToken(token: string) { return token.length > 0; }"],
+    ]);
+    const provider = {
+      getFileContent: async (path: string) => files.get(path) ?? null,
+    } as unknown as GitProvider;
+
+    await runCascadeReview([], [makePatch("src/auth.ts", 20)], config, prMetadata, undefined, {
+      provider,
+      sourceRef: "feature/auth",
+    });
+
+    const deepCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier !== "skim");
+    expect(deepCalls[0][4]?.rankedContext).toContain("## Graph-ranked Context");
+    expect(deepCalls[0][4]?.rankedContext).toContain("src/token.ts");
   });
 
   function makeFinding(file: string): OpenGrepFinding {

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -144,6 +144,43 @@ describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => 
   });
 });
 
+describe("runReview ranked context", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+  });
+
+  it("includes ranked context for deep-review calls", async () => {
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata, undefined, {
+      tier: "deep-review",
+      rankedContext: "## Graph-ranked Context\n### src/helper.ts",
+    });
+
+    expect(generateMock.mock.calls[0][0]).toContain("## Graph-ranked Context");
+  });
+
+  it("omits ranked context for skim calls", async () => {
+    generateMock.mockResolvedValueOnce({
+      object: {
+        summary: "looks fine",
+        recommendation: "looks_good",
+        findings: [],
+        observations: [],
+        filesReviewed: ["a.ts"],
+      },
+      usage: { totalTokens: 100 },
+    });
+
+    await runReview(config, "diff", prMetadata, undefined, {
+      tier: "skim",
+      rankedContext: "## Graph-ranked Context\n### src/helper.ts",
+    });
+
+    expect(generateMock.mock.calls[0][0]).not.toContain("## Graph-ranked Context");
+  });
+});
+
 class FakeApiCallError extends Error {
   isRetryable: boolean;
   constructor(message: string, isRetryable: boolean) {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -1,4 +1,9 @@
 import { compressDiff, countTokens } from "../diff/compress.js";
+import {
+  buildGraphRankedContext,
+  resolveGraphContextConfig,
+  type GraphContextConfig,
+} from "../diff/graph-context.js";
 import type {
   FilePatch,
   ReviewConfig,
@@ -75,6 +80,45 @@ function estimateTicketContextTokens(ticketContext?: TicketInfo[]): number {
     .join("\n\n");
 
   return countTokens(serialized);
+}
+
+async function buildRankedContextForPatches(
+  patches: FilePatch[],
+  prMetadata: PRMetadata,
+  options: RunReviewOptions,
+  config: GraphContextConfig,
+): Promise<string | undefined> {
+  if (!config.enabled || patches.length === 0 || !options.provider || !options.sourceRef) {
+    return undefined;
+  }
+
+  const provider = options.provider;
+  const sourceRef = options.sourceRef;
+  const result = await buildGraphRankedContext(
+    patches,
+    (path) => provider.getFileContent(path, sourceRef),
+    prMetadata,
+    config,
+  );
+
+  if (!result.renderedContext) return undefined;
+
+  logger.info(
+    {
+      selected: result.selections.map((s) => ({
+        path: s.path,
+        score: s.score,
+        mode: s.mode,
+        tokens: s.tokens,
+        reasons: s.reasons,
+      })),
+      tokenCount: result.tokenCount,
+      tokenBudget: config.tokenBudget,
+    },
+    "selected graph-ranked context",
+  );
+
+  return result.renderedContext;
 }
 
 export function normalizePath(file: string): string {
@@ -250,6 +294,7 @@ async function runTieredReview(
   resolvedOptions: RunReviewOptions,
   maxTokens: number,
   tier: ReviewTier,
+  graphContextConfig: GraphContextConfig,
 ): Promise<ReviewResult[]> {
   if (patches.length === 0) return [];
 
@@ -288,6 +333,12 @@ async function runTieredReview(
   }
 
   // deep-review: consensus + ticket compliance
+  const rankedContext = await buildRankedContextForPatches(
+    patches,
+    prMetadata,
+    resolvedOptions,
+    graphContextConfig,
+  );
   const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
   if (skippedFiles.length === 0) {
     const result = await runConsensusReview(
@@ -296,7 +347,7 @@ async function runTieredReview(
       prMetadata,
       compressed,
       ticketContext,
-      { ...tierOptions, chunkFiles: patches.map((p) => p.path) },
+      { ...tierOptions, rankedContext, chunkFiles: patches.map((p) => p.path) },
     );
     return [result];
   }
@@ -306,6 +357,12 @@ async function runTieredReview(
   for (const group of groups) {
     const groupPaths = new Set(group.map((p) => p.path));
     const groupOpenGrep = filterOpenGrepForFiles(resolvedOptions.openGrepFindings, groupPaths);
+    const groupRankedContext = await buildRankedContextForPatches(
+      group,
+      prMetadata,
+      resolvedOptions,
+      graphContextConfig,
+    );
     const groupCompressed = compressDiff(group, maxTokens).compressed;
     const groupResult = await runConsensusReview(
       group,
@@ -313,7 +370,12 @@ async function runTieredReview(
       prMetadata,
       groupCompressed,
       ticketContext,
-      { ...tierOptions, openGrepFindings: groupOpenGrep, chunkFiles: [...groupPaths] },
+      {
+        ...tierOptions,
+        openGrepFindings: groupOpenGrep,
+        rankedContext: groupRankedContext,
+        chunkFiles: [...groupPaths],
+      },
     );
     results.push(groupResult);
   }
@@ -329,6 +391,7 @@ export async function runMultiCallReview(
 ): Promise<ReviewResult> {
   const { mcpServers, maxTokens: maxTokensOpt, ...reviewOptions } = options ?? {};
   const maxTokens = maxTokensOpt ?? DEFAULT_MAX_TOKENS;
+  const graphContextConfig = resolveGraphContextConfig();
 
   let mcpDisconnect: (() => Promise<void>) | undefined;
   let resolvedOptions: RunReviewOptions = reviewOptions;
@@ -348,12 +411,19 @@ export async function runMultiCallReview(
 
   try {
     const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
+    const rankedContext = await buildRankedContextForPatches(
+      patches,
+      prMetadata,
+      resolvedOptions,
+      graphContextConfig,
+    );
 
     let result: ReviewResult;
 
     if (skippedFiles.length === 0) {
       result = await runConsensusReview(patches, config, prMetadata, compressed, ticketContext, {
         ...resolvedOptions,
+        rankedContext,
         chunkFiles: patches.map((p) => p.path),
       });
     } else {
@@ -378,6 +448,12 @@ export async function runMultiCallReview(
         const groupPaths = new Set(group.map((p) => p.path));
         const otherPrFiles = allPaths.filter((f) => !groupPaths.has(f));
         const groupOpenGrep = filterOpenGrepForFiles(resolvedOptions.openGrepFindings, groupPaths);
+        const groupRankedContext = await buildRankedContextForPatches(
+          group,
+          prMetadata,
+          resolvedOptions,
+          graphContextConfig,
+        );
         const groupCompressed = compressDiff(group, maxTokens).compressed;
         const groupResult = await runConsensusReview(
           group,
@@ -389,6 +465,7 @@ export async function runMultiCallReview(
             ...resolvedOptions,
             otherPrFiles,
             openGrepFindings: groupOpenGrep,
+            rankedContext: groupRankedContext,
             chunkFiles: [...groupPaths],
           },
         );
@@ -434,6 +511,7 @@ export async function runCascadeReview(
 ): Promise<ReviewResult> {
   const { mcpServers, maxTokens: maxTokensOpt, ...reviewOptions } = options ?? {};
   const maxTokens = maxTokensOpt ?? DEFAULT_MAX_TOKENS;
+  const graphContextConfig = resolveGraphContextConfig();
 
   let mcpDisconnect: (() => Promise<void>) | undefined;
   let resolvedOptions: RunReviewOptions = reviewOptions;
@@ -468,6 +546,7 @@ export async function runCascadeReview(
       resolvedOptions,
       maxTokens,
       "skim",
+      graphContextConfig,
     );
     allResults.push(...skimResults);
 
@@ -491,6 +570,7 @@ export async function runCascadeReview(
       deepOptionsWithSkimContext,
       maxTokens,
       "deep-review",
+      graphContextConfig,
     );
     allResults.push(...deepResults);
 

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -99,6 +99,7 @@ export function buildUserMessage(
   otherPrFiles?: string[],
   openGrepFindings?: OpenGrepFinding[],
   chunkFiles?: string[],
+  rankedContext?: string,
 ): string {
   const parts: string[] = [];
 
@@ -167,6 +168,11 @@ export function buildUserMessage(
   if (openGrepFindings && openGrepFindings.length > 0) {
     parts.push("");
     parts.push(buildOpenGrepSection(openGrepFindings));
+  }
+
+  if (rankedContext) {
+    parts.push("");
+    parts.push(rankedContext);
   }
 
   parts.push("\n## Diff\n");

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -99,6 +99,8 @@ export interface RunReviewOptions {
   chunkFiles?: string[];
   /** OpenGrep findings to feed to the LLM for triage. */
   openGrepFindings?: OpenGrepFinding[];
+  /** Ranked dependency context selected under a token budget for deep review. */
+  rankedContext?: string;
   /** override used by consensus pass planning; defaults to RUSTY_LLM_MODEL. */
   modelConfig?: ModelConfig;
   /** override used by consensus pass planning; defaults to review env settings. */
@@ -135,6 +137,7 @@ export async function runReview(
     options?.otherPrFiles,
     options?.openGrepFindings,
     options?.chunkFiles,
+    tier === "deep-review" ? options?.rankedContext : undefined,
   );
   const modelConfig = options?.modelConfig ?? resolveModelConfig();
   const modelName = getModelDisplayName(modelConfig);

--- a/packages/core/src/diff/graph-context.ts
+++ b/packages/core/src/diff/graph-context.ts
@@ -1,0 +1,371 @@
+import path from "node:path";
+import type { FilePatch, PRMetadata } from "../types.js";
+import { countTokens } from "./compress.js";
+import type { FileContentFetcher } from "./context.js";
+
+const DEFAULT_TOKEN_BUDGET = 2_000;
+const DEFAULT_MAX_CANDIDATES = 8;
+const JS_TS_EXTENSIONS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".cjs"];
+const STOP_WORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "with",
+  "from",
+  "this",
+  "that",
+  "into",
+  "src",
+  "test",
+  "tests",
+  "true",
+  "false",
+  "null",
+  "undefined",
+  "return",
+  "import",
+  "export",
+  "const",
+  "let",
+  "var",
+  "function",
+  "class",
+  "interface",
+  "type",
+]);
+
+export interface GraphContextConfig {
+  enabled: boolean;
+  tokenBudget: number;
+  maxCandidates: number;
+}
+
+interface Candidate {
+  path: string;
+  content: string;
+  importedBy: Set<string>;
+  keywords: Set<string>;
+  symbols: Set<string>;
+  score: number;
+  reasons: string[];
+}
+
+export interface GraphContextSelection {
+  path: string;
+  score: number;
+  tokens: number;
+  mode: "full" | "signatures";
+  reasons: string[];
+}
+
+export interface GraphRankedContextResult {
+  renderedContext: string;
+  selections: GraphContextSelection[];
+  tokenCount: number;
+}
+
+export function resolveGraphContextConfig(): GraphContextConfig {
+  const enabled =
+    process.env.RUSTY_GRAPH_CONTEXT === "true" || process.env.RUSTY_GRAPH_CONTEXT === "1";
+  const tokenBudget = readPositiveInt(
+    process.env.RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET,
+    DEFAULT_TOKEN_BUDGET,
+  );
+  const maxCandidates = readPositiveInt(
+    process.env.RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES,
+    DEFAULT_MAX_CANDIDATES,
+  );
+
+  return { enabled, tokenBudget, maxCandidates };
+}
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function isJsTsPath(filePath: string): boolean {
+  return JS_TS_EXTENSIONS.some((ext) => filePath.endsWith(ext));
+}
+
+function tokenize(text: string): Set<string> {
+  const tokens = new Set<string>();
+  for (const raw of text.match(/[A-Za-z_][A-Za-z0-9_]*/g) ?? []) {
+    const token = raw.toLowerCase();
+    if (token.length < 3 || STOP_WORDS.has(token)) continue;
+    tokens.add(token);
+  }
+  return tokens;
+}
+
+function extractSymbols(content: string): Set<string> {
+  const symbols = new Set<string>();
+  const patterns = [
+    /\bexport\s+(?:async\s+)?function\s+([A-Za-z_$][\w$]*)/g,
+    /\bexport\s+class\s+([A-Za-z_$][\w$]*)/g,
+    /\bexport\s+interface\s+([A-Za-z_$][\w$]*)/g,
+    /\bexport\s+type\s+([A-Za-z_$][\w$]*)/g,
+    /\bexport\s+(?:const|let|var)\s+([A-Za-z_$][\w$]*)/g,
+    /\bfunction\s+([A-Za-z_$][\w$]*)/g,
+    /\bclass\s+([A-Za-z_$][\w$]*)/g,
+    /\binterface\s+([A-Za-z_$][\w$]*)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      symbols.add(match[1].toLowerCase());
+    }
+  }
+  return symbols;
+}
+
+function extractImportSpecifiers(content: string): string[] {
+  const specs: string[] = [];
+  const patterns = [
+    /\bimport\s+(?:type\s+)?(?:[^'"]+?\s+from\s+)?["']([^"']+)["']/g,
+    /\bexport\s+(?:type\s+)?[^'"]+?\s+from\s+["']([^"']+)["']/g,
+    /\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    /\brequire\s*\(\s*["']([^"']+)["']\s*\)/g,
+  ];
+
+  for (const pattern of patterns) {
+    for (const match of content.matchAll(pattern)) {
+      specs.push(match[1]);
+    }
+  }
+  return specs;
+}
+
+function diffTextForPatch(patch: FilePatch): string {
+  return patch.hunks.map((h) => h.content).join("\n");
+}
+
+function changedKeywordSet(patches: FilePatch[], prMetadata: PRMetadata): Set<string> {
+  return tokenize(
+    [
+      prMetadata.title,
+      prMetadata.description,
+      ...patches.flatMap((patch) => [patch.path, diffTextForPatch(patch)]),
+    ].join("\n"),
+  );
+}
+
+function changedSymbolsSet(contents: string[]): Set<string> {
+  const symbols = new Set<string>();
+  for (const content of contents) {
+    for (const symbol of extractSymbols(content)) {
+      symbols.add(symbol);
+    }
+  }
+  return symbols;
+}
+
+function overlapRatio(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 || b.size === 0) return 0;
+  let overlap = 0;
+  for (const value of a) {
+    if (b.has(value)) overlap++;
+  }
+  return overlap / Math.min(a.size, b.size);
+}
+
+function pathOverlapScore(candidatePath: string, changedPaths: string[]): number {
+  const candidateParts = candidatePath.split("/");
+  let best = 0;
+
+  for (const changedPath of changedPaths) {
+    const changedParts = changedPath.split("/");
+    const shared = candidateParts.filter((part) => changedParts.includes(part)).length;
+    best = Math.max(best, shared / Math.max(candidateParts.length, changedParts.length));
+  }
+
+  return best;
+}
+
+function normalizeRepoPath(filePath: string): string {
+  return path.posix.normalize(filePath).replace(/^\.\//, "");
+}
+
+function importCandidates(fromPath: string, specifier: string): string[] {
+  if (!specifier.startsWith(".")) return [];
+
+  const dir = path.posix.dirname(fromPath);
+  const base = normalizeRepoPath(path.posix.join(dir, specifier));
+  const ext = path.posix.extname(base);
+  if (ext) return [base];
+
+  return [
+    ...JS_TS_EXTENSIONS.map((candidateExt) => `${base}${candidateExt}`),
+    ...JS_TS_EXTENSIONS.map((candidateExt) => `${base}/index${candidateExt}`),
+  ];
+}
+
+async function resolveImportPath(
+  fromPath: string,
+  specifier: string,
+  fetchContent: FileContentFetcher,
+): Promise<{ path: string; content: string } | null> {
+  for (const candidate of importCandidates(fromPath, specifier)) {
+    const content = await fetchContent(candidate);
+    if (content !== null) {
+      return { path: candidate, content };
+    }
+  }
+  return null;
+}
+
+function renderSignatures(content: string): string {
+  const lines = content.split("\n");
+  const signatures = lines
+    .map((line) => line.trimEnd())
+    .filter((line) =>
+      /^(import\s|export\s|(?:export\s+)?(?:async\s+)?function\s|(?:export\s+)?class\s|(?:export\s+)?interface\s|(?:export\s+)?type\s|(?:export\s+)?const\s)/.test(
+        line.trimStart(),
+      ),
+    );
+
+  return signatures.slice(0, 80).join("\n");
+}
+
+function renderCandidate(candidate: Candidate, mode: "full" | "signatures"): string {
+  const body =
+    mode === "full" ? candidate.content.trim() : renderSignatures(candidate.content).trim();
+  if (!body) return "";
+
+  return [
+    `### ${candidate.path}`,
+    `Score: ${candidate.score.toFixed(2)} | Mode: ${mode} | Reasons: ${candidate.reasons.join(", ")}`,
+    "```ts",
+    body,
+    "```",
+  ].join("\n");
+}
+
+function scoreCandidate(
+  candidate: Candidate,
+  changedPaths: string[],
+  changedKeywords: Set<string>,
+  changedSymbols: Set<string>,
+): void {
+  const graphScore = Math.min(1, candidate.importedBy.size) * 0.55;
+  const pathScore = pathOverlapScore(candidate.path, changedPaths) * 0.15;
+  const keywordScore = overlapRatio(candidate.keywords, changedKeywords) * 0.15;
+  const symbolScore = overlapRatio(candidate.symbols, changedSymbols) * 0.15;
+  candidate.score = Math.min(1, graphScore + pathScore + keywordScore + symbolScore);
+
+  candidate.reasons = [
+    `imported by ${candidate.importedBy.size} changed file${candidate.importedBy.size === 1 ? "" : "s"}`,
+  ];
+  if (pathScore > 0) candidate.reasons.push("path overlap");
+  if (keywordScore > 0) candidate.reasons.push("keyword overlap");
+  if (symbolScore > 0) candidate.reasons.push("symbol overlap");
+}
+
+export async function buildGraphRankedContext(
+  patches: FilePatch[],
+  fetchContent: FileContentFetcher,
+  prMetadata: PRMetadata,
+  config: GraphContextConfig = resolveGraphContextConfig(),
+): Promise<GraphRankedContextResult> {
+  if (!config.enabled || config.tokenBudget <= 0 || patches.length === 0) {
+    return { renderedContext: "", selections: [], tokenCount: 0 };
+  }
+
+  const changedPaths = patches.map((p) => p.path).filter(isJsTsPath);
+  if (changedPaths.length === 0) {
+    return { renderedContext: "", selections: [], tokenCount: 0 };
+  }
+
+  const changedPathSet = new Set(changedPaths);
+  const changedContents: string[] = [];
+  const candidates = new Map<string, Candidate>();
+
+  for (const changedPath of changedPaths) {
+    const content = await fetchContent(changedPath);
+    if (!content) continue;
+    changedContents.push(content);
+
+    for (const specifier of extractImportSpecifiers(content)) {
+      const resolved = await resolveImportPath(changedPath, specifier, fetchContent);
+      if (!resolved || changedPathSet.has(resolved.path) || !isJsTsPath(resolved.path)) continue;
+
+      const existing = candidates.get(resolved.path);
+      if (existing) {
+        existing.importedBy.add(changedPath);
+        continue;
+      }
+
+      candidates.set(resolved.path, {
+        path: resolved.path,
+        content: resolved.content,
+        importedBy: new Set([changedPath]),
+        keywords: tokenize(`${resolved.path}\n${resolved.content}`),
+        symbols: extractSymbols(resolved.content),
+        score: 0,
+        reasons: [],
+      });
+    }
+  }
+
+  const changedKeywords = changedKeywordSet(patches, prMetadata);
+  const changedSymbols = changedSymbolsSet(changedContents);
+  for (const candidate of candidates.values()) {
+    scoreCandidate(candidate, changedPaths, changedKeywords, changedSymbols);
+  }
+
+  const header = [
+    "## Graph-ranked Context",
+    "The following related files were selected under a token budget for orientation. Use them to understand dependencies and API contracts, but anchor findings to the reviewed diff unless the changed code creates the risk.",
+  ].join("\n");
+  const headerTokens = countTokens(header);
+  if (headerTokens >= config.tokenBudget) {
+    return { renderedContext: "", selections: [], tokenCount: 0 };
+  }
+
+  const selected: string[] = [];
+  const selections: GraphContextSelection[] = [];
+  let remaining = config.tokenBudget - headerTokens;
+
+  const ranked = [...candidates.values()]
+    .sort((a, b) => b.score - a.score || a.path.localeCompare(b.path))
+    .slice(0, config.maxCandidates);
+
+  for (const candidate of ranked) {
+    const preferredMode = candidate.score >= 0.75 ? "full" : "signatures";
+    const modes: ("full" | "signatures")[] =
+      preferredMode === "full" ? ["full", "signatures"] : ["signatures"];
+
+    for (const mode of modes) {
+      const rendered = renderCandidate(candidate, mode);
+      if (!rendered) continue;
+
+      const tokens = countTokens(rendered);
+      if (tokens > remaining) continue;
+
+      selected.push(rendered);
+      selections.push({
+        path: candidate.path,
+        score: Number(candidate.score.toFixed(3)),
+        tokens,
+        mode,
+        reasons: candidate.reasons,
+      });
+      remaining -= tokens;
+      break;
+    }
+  }
+
+  if (selected.length === 0) {
+    return { renderedContext: "", selections: [], tokenCount: 0 };
+  }
+
+  const renderedContext = [header, ...selected].join("\n\n");
+
+  return {
+    renderedContext,
+    selections,
+    tokenCount: countTokens(renderedContext),
+  };
+}

--- a/packages/core/src/diff/index.ts
+++ b/packages/core/src/diff/index.ts
@@ -3,6 +3,12 @@ export { filterFiles, stripDeletionOnlyHunks } from "./filter.js";
 export { compressDiff, countTokens } from "./compress.js";
 export { expandContext } from "./context.js";
 export type { FileContentFetcher } from "./context.js";
+export { buildGraphRankedContext, resolveGraphContextConfig } from "./graph-context.js";
+export type {
+  GraphContextConfig,
+  GraphContextSelection,
+  GraphRankedContextResult,
+} from "./graph-context.js";
 export { detectLanguage, summarizeLanguages } from "./language.js";
 export { shufflePatches } from "./shuffle.js";
 export { filterAnchorableFindings } from "./anchor.js";


### PR DESCRIPTION
## Summary
- add an opt-in GraphSift-inspired context selector for deep-review prompts
- rank directly related JS/TS relative imports by graph proximity, path overlap, keyword overlap, and symbol overlap
- render selected context under a hard token budget with full/signature modes
- document the new env vars and usage guide

Closes #97

## Verification
- pnpm --filter @rusty-bot/core test -- graph-context agent review multi-call
- pnpm --filter @rusty-bot/core build
- pnpm exec eslint packages/core/src/diff/graph-context.ts packages/core/src/agent/prompts.ts packages/core/src/agent/review.ts packages/core/src/agent/multi-call.ts packages/core/src/__tests__/graph-context.test.ts packages/core/src/__tests__/agent.test.ts packages/core/src/__tests__/review.test.ts packages/core/src/__tests__/multi-call.test.ts
- git diff --check
- commit hook: workspace build + full test suite (26 files, 708 tests)