### PR TITLE
feat: add GitLab + GitLab CI integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,6 +33,16 @@ RUSTY_LINEAR_API_KEY=
 # Azure DevOps (optional, for server mode — pipeline mode uses SYSTEM_ACCESSTOKEN)
 RUSTY_ADO_PAT=
 
+# GitLab (optional — only needed when running the GitLab CI integration)
+# Project access token with the 'api' scope. CI_JOB_TOKEN works for read APIs
+# but cannot post MR notes/discussions on most installs.
+RUSTY_GITLAB_TOKEN=
+# Override the API base URL for self-hosted GitLab (defaults to CI_API_V4_URL).
+# RUSTY_GITLAB_API_URL=https://gitlab.example.com/api/v4
+# Override the project path / MR iid when invoking the CLI outside of CI.
+# RUSTY_GITLAB_PROJECT_PATH=group/sub/project
+# RUSTY_GITLAB_MR_IID=42
+
 # MCP Servers (optional) — path to a JSON config file, defaults to ./mcp-servers.json
 # See mcp-servers.example.json for the expected format.
 # RUSTY_MCP_CONFIG=./mcp-servers.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ COPY packages/core/package.json ./packages/core/
 COPY packages/github/package.json ./packages/github/
 COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/
+COPY packages/gitlab/package.json ./packages/gitlab/
 COPY packages/dashboard/package.json ./packages/dashboard/
 
 RUN pnpm install --frozen-lockfile
@@ -44,6 +45,7 @@ COPY packages/core/package.json ./packages/core/
 COPY packages/github/package.json ./packages/github/
 COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/
+COPY packages/gitlab/package.json ./packages/gitlab/
 COPY packages/dashboard/package.json ./packages/dashboard/
 
 RUN pnpm install --frozen-lockfile --prod --ignore-scripts
@@ -52,6 +54,7 @@ COPY --from=build /app/packages/core/dist ./packages/core/dist
 COPY --from=build /app/packages/github/dist ./packages/github/dist
 COPY --from=build /app/packages/github-action/dist ./packages/github-action/dist
 COPY --from=build /app/packages/azure-devops/dist ./packages/azure-devops/dist
+COPY --from=build /app/packages/gitlab/dist ./packages/gitlab/dist
 COPY --from=build /app/packages/dashboard/dist ./packages/dashboard/dist
 
 # copy prompt files that are bundled alongside dist
@@ -78,6 +81,9 @@ case "$RUSTY_MODE" in
     ;;
   github-action)
     exec node /app/packages/github-action/dist/cli.js
+    ;;
+  gitlab)
+    exec node /app/packages/gitlab/dist/cli.js
     ;;
   *)
     exec node /app/packages/github/dist/server.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,10 @@ COPY --from=build /app/packages/dashboard/dist ./packages/dashboard/dist
 # copy prompt files that are bundled alongside dist
 COPY --from=build /app/packages/core/src/prompts ./packages/core/dist/prompts
 
-RUN mkdir -p /app/data
+RUN mkdir -p /app/data \
+    && groupadd --system --gid 1001 rusty \
+    && useradd --system --uid 1001 --gid rusty --home-dir /app --shell /usr/sbin/nologin rusty \
+    && chown -R rusty:rusty /app
 
 VOLUME /app/data
 
@@ -92,5 +95,7 @@ esac
 EOF
 
 RUN chmod +x /app/entrypoint.sh
+
+USER rusty
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rusty Bot
 
-AI-powered PR review bot with configurable review styles, focus areas, and ticket compliance checking. Works with GitHub and Azure DevOps.
+AI-powered PR review bot with configurable review styles, focus areas, and ticket compliance checking. Works with GitHub, GitLab, and Azure DevOps.
 
 Built on [Mastra](https://mastra.ai/) (TypeScript).
 
@@ -17,7 +17,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
 - **PR description generation** — optionally generate a structured PR description from the diff when the description is empty or a placeholder (off by default)
 - **Incremental review** — on subsequent pushes the bot reviews only the diff since the previously-reviewed state (commit on GitHub, PR iteration on Azure DevOps) instead of the entire PR, cutting tokens on multi-commit PRs (on by default; opt out with `RUSTY_INCREMENTAL_REVIEW=false`)
-- **GitHub + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps, or a drop-in GitHub Action
+- **GitHub + GitLab + Azure DevOps** — webhook server for GitHub, pipeline task for Azure DevOps, GitLab CI job, or a drop-in GitHub Action
 - **Web dashboard** — configure repos, review styles, focus areas, and view history
 
 ## Quick Start
@@ -65,6 +65,7 @@ packages/
 ├── github/         # GitHub App webhook server + config API
 ├── github-action/  # One-shot CLI driven by GitHub Actions env + event payload
 ├── azure-devops/   # Azure DevOps pipeline task (Docker entrypoint)
+├── gitlab/         # GitLab CI task — provider + CLI driven by CI_MERGE_REQUEST_* env
 └── dashboard/      # React SPA for configuration and review history
 ```
 
@@ -176,6 +177,42 @@ Set `RUSTY_LLM_MODEL`, `ANTHROPIC_API_KEY`, and other variables as pipeline vari
 
 The task exits with code 1 when critical issues are found (configurable via `RUSTY_FAIL_ON_CRITICAL`), which can gate PR merges.
 
+## GitLab CI Setup
+
+Rusty Bot ships with a GitLab CI integration that runs as a job inside the published Docker image. The job reads GitLab's predefined `CI_*` variables (`CI_MERGE_REQUEST_IID`, `CI_PROJECT_PATH`, `CI_API_V4_URL`) so there's nothing to configure beyond a token and an LLM key. See [`gitlab-ci-example.yml`](./gitlab-ci-example.yml) for the full snippet.
+
+```yaml
+rusty-bot-review:
+  stage: test
+  image: ghcr.io/jegork/rusty-bot:latest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    RUSTY_MODE: gitlab
+    RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
+    RUSTY_REVIEW_STYLE: balanced
+    RUSTY_FOCUS_AREAS: security,bugs,performance
+    RUSTY_FAIL_ON_CRITICAL: "true"
+  script:
+    - node /app/packages/gitlab/dist/cli.js
+```
+
+**Authentication:** Set `RUSTY_GITLAB_TOKEN` to a [project access token](https://docs.gitlab.com/ee/user/project/settings/project_access_tokens.html) with the `api` scope as a CI/CD variable (Settings → CI/CD → Variables). `CI_JOB_TOKEN` is read-only on most installs and cannot post MR notes or discussions.
+
+**LLM key:** Set the matching key for your chosen provider as a CI/CD variable too (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GOOGLE_GENERATIVE_AI_API_KEY`, etc.).
+
+**Self-hosted GitLab:** No extra config needed — `CI_API_V4_URL` is populated by the runner. Set `RUSTY_GITLAB_API_URL` only when invoking the CLI outside of GitLab CI.
+
+**What the bot does on GitLab:**
+
+- Posts a structured summary as an MR note (severity table, missing tests, ticket compliance)
+- Posts inline review comments on the MR diff via the discussions API
+- Updates the MR title/description when `RUSTY_RENAME_TITLE_TO_CONVENTIONAL=true` or `RUSTY_GENERATE_DESCRIPTION=true`
+- Resolves linked closing issues (`Closes #123`) via the GitLab `closes_issues` endpoint
+- Supports incremental review via head SHA — subsequent pushes only review the delta
+
+The job exits with code 1 when critical issues are found (configurable via `RUSTY_FAIL_ON_CRITICAL`), which can gate MR merges when the job is on the merge train or required.
+
 ## Configuration
 
 ### Environment Variables
@@ -202,6 +239,10 @@ The task exits with code 1 when critical issues are found (configurable via `RUS
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |
 | `RUSTY_LINEAR_API_KEY` | Linear API key | — |
 | `RUSTY_ADO_PAT` | Azure DevOps PAT (server mode) | — |
+| `RUSTY_GITLAB_TOKEN` | GitLab project/personal access token (`api` scope) used by the GitLab CI job | falls back to `CI_JOB_TOKEN` |
+| `RUSTY_GITLAB_API_URL` | GitLab API v4 base URL (override for self-hosted; defaults to `CI_API_V4_URL`) | — |
+| `RUSTY_GITLAB_PROJECT_PATH` | Override `CI_PROJECT_PATH` when invoking the GitLab CLI outside of GitLab CI | — |
+| `RUSTY_GITLAB_MR_IID` | Override `CI_MERGE_REQUEST_IID` when invoking the GitLab CLI outside of GitLab CI | — |
 | `AZURE_OPENAI_API_KEY` | Azure OpenAI API key (or `AZURE_API_KEY`) | — |
 | `AZURE_OPENAI_RESOURCE_NAME` | Azure OpenAI resource name | — |
 | `RUSTY_AZURE_RESOURCE_NAME` | Azure OpenAI resource (managed identity mode) | — |
@@ -542,6 +583,7 @@ Rusty Bot discovers linked tickets through three mechanisms:
 **1. Regex extraction** — scans PR descriptions and branch names for ticket patterns:
 
 - **GitHub Issues**: `#123`, `owner/repo#123`, full URL
+- **GitLab Issues**: `https://gitlab.example.com/group/project/-/issues/123` (in GitLab CI mode, bare `#123` is treated as a GitLab issue)
 - **Jira**: `PROJ-123`, Jira browse URL
 - **Linear**: Linear issue URL
 - **Azure DevOps**: `AB#123`, ADO work item URL
@@ -551,7 +593,9 @@ Rusty Bot discovers linked tickets through three mechanisms:
 
 **3. Azure DevOps linked work items** — calls the PR work items API endpoint to find work items formally linked through the ADO UI, even when they aren't mentioned in the description or branch name.
 
-All three sources are merged and deduplicated before resolution. When tickets are found and the corresponding provider is configured, the review summary includes a compliance assessment.
+**4. GitLab linked closing issues** — calls the MR `closes_issues` API endpoint to find issues closed by the MR via closing keywords (`Closes #123`, `Fixes group/project#456`).
+
+All sources are merged and deduplicated before resolution. When tickets are found and the corresponding provider is configured, the review summary includes a compliance assessment.
 
 ## Development
 

--- a/gitlab-ci-example.yml
+++ b/gitlab-ci-example.yml
@@ -1,0 +1,23 @@
+# Drop this snippet into your existing .gitlab-ci.yml (or use it as the
+# whole file). The job runs only on merge_request_event pipelines, so it
+# fires on every push to an open MR but never on regular branch builds.
+#
+# Required CI/CD variables (Settings → CI/CD → Variables):
+#   RUSTY_GITLAB_TOKEN  — project access token with the 'api' scope.
+#                          CI_JOB_TOKEN works for read APIs but cannot post
+#                          MR notes/discussions on most installs.
+#   ANTHROPIC_API_KEY   — (or the matching key for whichever LLM you pick).
+
+rusty-bot-review:
+  stage: test
+  image: ghcr.io/jegork/rusty-bot:latest
+  rules:
+    - if: $CI_PIPELINE_SOURCE == "merge_request_event"
+  variables:
+    RUSTY_MODE: gitlab
+    RUSTY_LLM_MODEL: anthropic/claude-sonnet-4-20250514
+    RUSTY_REVIEW_STYLE: balanced
+    RUSTY_FOCUS_AREAS: security,bugs,performance
+    RUSTY_FAIL_ON_CRITICAL: "true"
+  script:
+    - node /app/packages/gitlab/dist/cli.js

--- a/packages/core/src/__tests__/tickets.test.ts
+++ b/packages/core/src/__tests__/tickets.test.ts
@@ -108,6 +108,35 @@ describe("extractTicketRefs", () => {
     });
   });
 
+  describe("gitlab refs", () => {
+    it("extracts a standard group/project URL", () => {
+      const refs = extractTicketRefs("see https://gitlab.com/acme/widgets/-/issues/42", "main");
+      expect(refs).toContainEqual(
+        expect.objectContaining({ id: "acme/widgets#42", source: "gitlab" }),
+      );
+    });
+
+    it("extracts a nested subgroup URL", () => {
+      const refs = extractTicketRefs(
+        "https://gitlab.com/group/subgroup/project/-/issues/9",
+        "main",
+      );
+      expect(refs).toContainEqual(
+        expect.objectContaining({ id: "group/subgroup/project#9", source: "gitlab" }),
+      );
+    });
+
+    it("extracts a single-segment (root-level) project URL", () => {
+      const refs = extractTicketRefs("https://gitlab.com/widgets/-/issues/123", "main");
+      expect(refs).toContainEqual(expect.objectContaining({ id: "widgets#123", source: "gitlab" }));
+    });
+
+    it("extracts a self-hosted http URL with a port", () => {
+      const refs = extractTicketRefs("http://gitlab.example.com:8080/team/api/-/issues/7", "main");
+      expect(refs).toContainEqual(expect.objectContaining({ id: "team/api#7", source: "gitlab" }));
+    });
+  });
+
   describe("branch name extraction", () => {
     it("extracts github-style feature/123-desc", () => {
       const refs = extractTicketRefs("", "feature/123-add-login");

--- a/packages/core/src/tickets/extract.ts
+++ b/packages/core/src/tickets/extract.ts
@@ -44,6 +44,12 @@ function extractFromDescription(text: string): TicketRef[] {
     refs.push({ id: m[1], source: "azure-devops" });
   }
 
+  // gitlab issue URL: https://gitlab.com/group/sub/project/-/issues/123 (any host with /-/issues/)
+  // capture project path (any number of slash-separated segments) and issue id
+  for (const m of text.matchAll(/https:\/\/[\w.-]+\/((?:[\w.-]+\/)+[\w.-]+)\/-\/issues\/(\d+)/g)) {
+    refs.push({ id: `${m[1]}#${m[2]}`, source: "gitlab", url: m[0] });
+  }
+
   // owner/repo#123 (github cross-repo ref) - avoid matching URLs already captured
   for (const m of text.matchAll(/(?<![/\w])([\w.-]+)\/([\w.-]+)#(\d+)(?!\d)/g)) {
     // skip if this looks like it's part of a URL we already matched

--- a/packages/core/src/tickets/extract.ts
+++ b/packages/core/src/tickets/extract.ts
@@ -45,8 +45,10 @@ function extractFromDescription(text: string): TicketRef[] {
   }
 
   // gitlab issue URL: https://gitlab.com/group/sub/project/-/issues/123 (any host with /-/issues/)
-  // capture project path (any number of slash-separated segments) and issue id
-  for (const m of text.matchAll(/https:\/\/[\w.-]+\/((?:[\w.-]+\/)+[\w.-]+)\/-\/issues\/(\d+)/g)) {
+  // capture project path (one or more slash-separated segments) and issue id
+  for (const m of text.matchAll(
+    /https?:\/\/[\w.-]+(?::\d+)?\/((?:[\w.-]+\/)*[\w.-]+)\/-\/issues\/(\d+)/g,
+  )) {
     refs.push({ id: `${m[1]}#${m[2]}`, source: "gitlab", url: m[0] });
   }
 

--- a/packages/core/src/tickets/index.ts
+++ b/packages/core/src/tickets/index.ts
@@ -6,3 +6,5 @@ export type { GitHubTicketProviderConfig, IssueFetcher } from "./providers/githu
 export { JiraTicketProvider } from "./providers/jira.js";
 export { LinearTicketProvider } from "./providers/linear.js";
 export { AzureDevOpsTicketProvider } from "./providers/azure-devops.js";
+export { GitLabTicketProvider } from "./providers/gitlab.js";
+export type { GitLabTicketProviderConfig } from "./providers/gitlab.js";

--- a/packages/core/src/tickets/providers/gitlab.ts
+++ b/packages/core/src/tickets/providers/gitlab.ts
@@ -1,0 +1,91 @@
+import type { TicketInfo, TicketProvider } from "../../types.js";
+import { GitLabIssueSchema } from "../schemas.js";
+
+const MAX_DESC_LENGTH = 10_000;
+
+export interface GitLabTicketProviderConfig {
+  /** API base URL, e.g. https://gitlab.com/api/v4 */
+  baseUrl: string;
+  /** Personal access token, project access token, or CI_JOB_TOKEN */
+  token: string;
+  /** Default project path (e.g. "group/sub/project") used when a ref is bare numeric */
+  defaultProjectPath?: string;
+}
+
+/**
+ * Fetches issue details from GitLab. Refs may be:
+ *   "group/sub/project#123"  → fetches from that project
+ *   "123"                    → uses defaultProjectPath
+ */
+export class GitLabTicketProvider implements TicketProvider {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly defaultProjectPath?: string;
+
+  constructor(config: GitLabTicketProviderConfig) {
+    this.baseUrl = config.baseUrl.replace(/\/$/, "");
+    this.token = config.token;
+    if (config.defaultProjectPath) {
+      this.defaultProjectPath = config.defaultProjectPath;
+    }
+  }
+
+  async fetchTicket(ref: string): Promise<TicketInfo | null> {
+    const { projectPath, iid } = parseRef(ref, this.defaultProjectPath);
+    if (!projectPath || !iid) return null;
+
+    const url = `${this.baseUrl}/projects/${encodeURIComponent(projectPath)}/issues/${iid}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url, {
+        headers: {
+          "PRIVATE-TOKEN": this.token,
+          Accept: "application/json",
+        },
+      });
+    } catch {
+      return null;
+    }
+    if (!res.ok) return null;
+
+    let raw: unknown;
+    try {
+      raw = await res.json();
+    } catch {
+      return null;
+    }
+
+    const parsed = GitLabIssueSchema.safeParse(raw);
+    if (!parsed.success) return null;
+
+    const data = parsed.data;
+    return {
+      id: String(data.iid),
+      title: data.title,
+      description: (data.description ?? "").slice(0, MAX_DESC_LENGTH),
+      labels: data.labels ?? [],
+      source: "gitlab",
+    };
+  }
+}
+
+function parseRef(
+  ref: string,
+  defaultProjectPath: string | undefined,
+): { projectPath: string | undefined; iid: number | undefined } {
+  if (ref.includes("#")) {
+    const idx = ref.lastIndexOf("#");
+    const projectPath = ref.slice(0, idx);
+    const iid = Number(ref.slice(idx + 1));
+    return {
+      projectPath,
+      iid: Number.isInteger(iid) && iid > 0 ? iid : undefined,
+    };
+  }
+  const iid = Number(ref);
+  return {
+    projectPath: defaultProjectPath,
+    iid: Number.isInteger(iid) && iid > 0 ? iid : undefined,
+  };
+}

--- a/packages/core/src/tickets/providers/gitlab.ts
+++ b/packages/core/src/tickets/providers/gitlab.ts
@@ -8,6 +8,8 @@ export interface GitLabTicketProviderConfig {
   baseUrl: string;
   /** Personal access token, project access token, or CI_JOB_TOKEN */
   token: string;
+  /** When true, send token via JOB-TOKEN header (CI job token); else PRIVATE-TOKEN */
+  isJobToken?: boolean;
   /** Default project path (e.g. "group/sub/project") used when a ref is bare numeric */
   defaultProjectPath?: string;
 }
@@ -20,11 +22,13 @@ export interface GitLabTicketProviderConfig {
 export class GitLabTicketProvider implements TicketProvider {
   private readonly baseUrl: string;
   private readonly token: string;
+  private readonly tokenHeader: string;
   private readonly defaultProjectPath?: string;
 
   constructor(config: GitLabTicketProviderConfig) {
     this.baseUrl = config.baseUrl.replace(/\/$/, "");
     this.token = config.token;
+    this.tokenHeader = config.isJobToken ? "JOB-TOKEN" : "PRIVATE-TOKEN";
     if (config.defaultProjectPath) {
       this.defaultProjectPath = config.defaultProjectPath;
     }
@@ -40,7 +44,7 @@ export class GitLabTicketProvider implements TicketProvider {
     try {
       res = await fetch(url, {
         headers: {
-          "PRIVATE-TOKEN": this.token,
+          [this.tokenHeader]: this.token,
           Accept: "application/json",
         },
       });

--- a/packages/core/src/tickets/schemas.ts
+++ b/packages/core/src/tickets/schemas.ts
@@ -40,3 +40,10 @@ export const AdoWorkItemSchema = z.object({
   id: z.number().optional(),
   fields: z.record(z.string(), z.unknown()).optional(),
 });
+
+export const GitLabIssueSchema = z.object({
+  iid: z.number(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  labels: z.array(z.string()).optional(),
+});

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -156,7 +156,7 @@ export interface TicketResolutionStatus {
   consideredFetchFailed: number;
 }
 
-export type TicketSource = "github" | "jira" | "linear" | "azure-devops";
+export type TicketSource = "github" | "jira" | "linear" | "azure-devops" | "gitlab";
 
 export interface TicketRef {
   id: string;

--- a/packages/gitlab/package.json
+++ b/packages/gitlab/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@rusty-bot/gitlab",
+  "version": "0.1.0",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/cli.js",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@rusty-bot/core": "workspace:*",
+    "diff": "^9.0.0",
+    "zod": "^4.3.6"
+  }
+}

--- a/packages/gitlab/src/__tests__/provider.test.ts
+++ b/packages/gitlab/src/__tests__/provider.test.ts
@@ -1,0 +1,352 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GitLabProvider } from "../provider.js";
+import type { Finding } from "@rusty-bot/core";
+
+const API_BASE = "https://gitlab.example.com/api/v4";
+const PROJECT = "group/sub/project";
+const MR_IID = 42;
+const TOKEN = "test-token";
+
+const PROJECT_ENC = encodeURIComponent(PROJECT);
+const MR_BASE = `${API_BASE}/projects/${PROJECT_ENC}/merge_requests/${MR_IID}`;
+
+function createProvider(): GitLabProvider {
+  return new GitLabProvider({
+    apiBaseUrl: API_BASE,
+    projectId: PROJECT,
+    mergeRequestIid: MR_IID,
+    token: TOKEN,
+  });
+}
+
+function jsonResponse(body: unknown, ok = true, status = 200): Response {
+  return {
+    ok,
+    status,
+    statusText: ok ? "OK" : "Bad Request",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(JSON.stringify(body)),
+    headers: new Headers(),
+  } as Response;
+}
+
+function textResponse(body: string, ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 404,
+    statusText: ok ? "OK" : "Not Found",
+    json: () => Promise.resolve(body),
+    text: () => Promise.resolve(body),
+    headers: new Headers(),
+  } as Response;
+}
+
+describe("GitLabProvider", () => {
+  let provider: GitLabProvider;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    provider = createProvider();
+    fetchSpy = vi.fn();
+    vi.stubGlobal("fetch", fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getPRMetadata", () => {
+    it("maps the GitLab MR payload to PRMetadata", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          iid: 42,
+          title: "feat: add widget",
+          description: "adds a widget",
+          source_branch: "feature/widget",
+          target_branch: "main",
+          sha: "abc123def456",
+          web_url: "https://gitlab.example.com/group/sub/project/-/merge_requests/42",
+          author: { username: "alice", name: "Alice" },
+          diff_refs: { base_sha: "b", start_sha: "s", head_sha: "h" },
+        }),
+      );
+
+      const md = await provider.getPRMetadata();
+      expect(md).toEqual({
+        id: "42",
+        title: "feat: add widget",
+        description: "adds a widget",
+        author: "alice",
+        sourceBranch: "feature/widget",
+        targetBranch: "main",
+        url: "https://gitlab.example.com/group/sub/project/-/merge_requests/42",
+        headSha: "abc123def456",
+      });
+
+      expect(fetchSpy).toHaveBeenCalledWith(
+        MR_BASE,
+        expect.objectContaining({
+          headers: expect.objectContaining({ "PRIVATE-TOKEN": TOKEN }),
+        }),
+      );
+    });
+
+    it("uses JOB-TOKEN header when isJobToken is set", async () => {
+      const jobProvider = new GitLabProvider({
+        apiBaseUrl: API_BASE,
+        projectId: PROJECT,
+        mergeRequestIid: MR_IID,
+        token: "job-tok",
+        isJobToken: true,
+      });
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          iid: 1,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "t",
+        }),
+      );
+      await jobProvider.getPRMetadata();
+      const call = fetchSpy.mock.calls[0]?.[1] as { headers: Record<string, string> };
+      expect(call.headers).toMatchObject({ "JOB-TOKEN": "job-tok" });
+      expect(call.headers).not.toHaveProperty("PRIVATE-TOKEN");
+    });
+  });
+
+  describe("getDiff", () => {
+    it("parses /changes response into FilePatch[] with hunk content", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          changes: [
+            {
+              old_path: "src/a.ts",
+              new_path: "src/a.ts",
+              diff: "@@ -1,2 +1,3 @@\n line1\n+added\n line2\n",
+            },
+            {
+              old_path: "src/gone.ts",
+              new_path: "src/gone.ts",
+              deleted_file: true,
+              diff: "",
+            },
+          ],
+          diff_refs: { base_sha: "b", start_sha: "s", head_sha: "h" },
+        }),
+      );
+
+      const patches = await provider.getDiff();
+      expect(patches).toHaveLength(1);
+      expect(patches[0]).toMatchObject({
+        path: "src/a.ts",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+      });
+      expect(patches[0].hunks[0].newStart).toBe(1);
+      expect(patches[0].hunks[0].newLines).toBe(3);
+    });
+
+    it("flags binary files instead of trying to parse the diff", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          changes: [
+            {
+              old_path: "image.png",
+              new_path: "image.png",
+              diff: "Binary files a/image.png and b/image.png differ\n",
+            },
+          ],
+        }),
+      );
+      const patches = await provider.getDiff();
+      expect(patches[0]).toMatchObject({ path: "image.png", isBinary: true, hunks: [] });
+    });
+  });
+
+  describe("getLastReviewedSha", () => {
+    it("walks notes newest-first and returns the embedded sha", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 3,
+            body: "<!-- rusty-bot-review -->\n<!-- rusty-bot:last-sha:fee1baadf00d1234567890abcdef1234567890ab -->\nsummary",
+          },
+          {
+            id: 2,
+            body: "<!-- rusty-bot-review -->\n<!-- rusty-bot:last-sha:0123456789abcdef0123456789abcdef01234567 -->\nold summary",
+          },
+          { id: 1, body: "human comment", system: false },
+        ]),
+      );
+
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBe("fee1baadf00d1234567890abcdef1234567890ab");
+    });
+
+    it("ignores system notes and returns null when none have a marker", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          { id: 1, body: "<!-- rusty-bot-review -->\nno sha here" },
+          { id: 2, system: true, body: "<!-- rusty-bot:last-sha:abc1234 -->" },
+        ]),
+      );
+      const sha = await provider.getLastReviewedSha();
+      expect(sha).toBeNull();
+    });
+  });
+
+  describe("postSummaryComment", () => {
+    it("posts a note with the bot marker and last-sha marker", async () => {
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 99 }));
+      await provider.postSummaryComment("hello", { lastReviewedSha: "abc1234" });
+
+      const url = fetchSpy.mock.calls[0]?.[0] as string;
+      const init = fetchSpy.mock.calls[0]?.[1] as { method: string; body: string };
+      expect(url).toBe(`${MR_BASE}/notes`);
+      expect(init.method).toBe("POST");
+      const body = JSON.parse(init.body) as { body: string };
+      expect(body.body).toContain("<!-- rusty-bot-review -->");
+      expect(body.body).toContain("<!-- rusty-bot:last-sha:abc1234 -->");
+      expect(body.body).toContain("hello");
+    });
+  });
+
+  describe("postInlineComments", () => {
+    it("posts a discussion with diff position when refs are cached", async () => {
+      // first call: getPRMetadata to populate diff_refs
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          iid: 42,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "main",
+          diff_refs: { base_sha: "B", start_sha: "S", head_sha: "H" },
+        }),
+      );
+      await provider.getPRMetadata();
+
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: "discussion-1" }));
+
+      const finding: Finding = {
+        file: "src/a.ts",
+        line: 5,
+        endLine: null,
+        severity: "warning",
+        category: "bugs",
+        message: "be careful",
+        suggestedFix: null,
+      };
+      await provider.postInlineComments([finding]);
+
+      const lastCall = fetchSpy.mock.calls[1];
+      expect(lastCall?.[0]).toBe(`${MR_BASE}/discussions`);
+      const body = JSON.parse((lastCall?.[1] as { body: string }).body) as {
+        body: string;
+        position: Record<string, unknown>;
+      };
+      expect(body.position).toMatchObject({
+        position_type: "text",
+        base_sha: "B",
+        start_sha: "S",
+        head_sha: "H",
+        new_path: "src/a.ts",
+        new_line: 5,
+      });
+      expect(body.body).toContain("<!-- rusty-bot-review -->");
+    });
+
+    it("falls back to a top-level note when diff_refs are unavailable", async () => {
+      // metadata fetch (called by ensureDiffRefs) — no diff_refs
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          iid: 42,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "main",
+        }),
+      );
+      // fallback note POST
+      fetchSpy.mockResolvedValueOnce(jsonResponse({ id: 1 }));
+
+      const finding: Finding = {
+        file: "src/a.ts",
+        line: 5,
+        endLine: null,
+        severity: "warning",
+        category: "bugs",
+        message: "be careful",
+        suggestedFix: null,
+      };
+      await provider.postInlineComments([finding]);
+
+      const lastUrl = fetchSpy.mock.calls.at(-1)?.[0] as string;
+      expect(lastUrl).toBe(`${MR_BASE}/notes`);
+    });
+  });
+
+  describe("deleteExistingBotComments", () => {
+    it("deletes bot-authored notes from each discussion", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: "d1",
+            notes: [
+              { id: 10, body: "<!-- rusty-bot-review -->\nsummary" },
+              { id: 11, body: "human reply" },
+            ],
+          },
+          {
+            id: "d2",
+            notes: [{ id: 20, body: "<!-- rusty-bot-review -->\ninline", system: false }],
+          },
+        ]),
+      );
+      // delete responses
+      fetchSpy.mockResolvedValue(jsonResponse({}));
+
+      await provider.deleteExistingBotComments();
+      const deleteCalls = fetchSpy.mock.calls.filter(
+        (c) => (c[1] as { method?: string } | undefined)?.method === "DELETE",
+      );
+      expect(deleteCalls).toHaveLength(2);
+      expect(deleteCalls[0]?.[0]).toBe(`${MR_BASE}/notes/10`);
+      expect(deleteCalls[1]?.[0]).toBe(`${MR_BASE}/notes/20`);
+    });
+  });
+
+  describe("getFileContent", () => {
+    it("fetches raw file content for a ref", async () => {
+      fetchSpy.mockResolvedValueOnce(textResponse("file body"));
+      const content = await provider.getFileContent("src/a.ts", "feature/x");
+      expect(content).toBe("file body");
+      const url = fetchSpy.mock.calls[0]?.[0] as string;
+      expect(url).toContain(`/repository/files/${encodeURIComponent("src/a.ts")}/raw`);
+      expect(url).toContain(`ref=${encodeURIComponent("feature/x")}`);
+    });
+
+    it("returns null on non-200", async () => {
+      fetchSpy.mockResolvedValueOnce(textResponse("nope", false));
+      const content = await provider.getFileContent("missing.ts", "main");
+      expect(content).toBeNull();
+    });
+  });
+
+  describe("getLinkedIssueIids", () => {
+    it("returns full references when present, else iid as string", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([{ iid: 5, references: { full: "group/proj#5" } }, { iid: 6 }]),
+      );
+      const ids = await provider.getLinkedIssueIids();
+      expect(ids).toEqual(["group/proj#5", "6"]);
+    });
+
+    it("returns empty array on error", async () => {
+      fetchSpy.mockRejectedValueOnce(new Error("boom"));
+      expect(await provider.getLinkedIssueIids()).toEqual([]);
+    });
+  });
+});

--- a/packages/gitlab/src/__tests__/provider.test.ts
+++ b/packages/gitlab/src/__tests__/provider.test.ts
@@ -116,22 +116,31 @@ describe("GitLabProvider", () => {
   });
 
   describe("getDiff", () => {
-    it("parses /changes response into FilePatch[] with hunk content", async () => {
+    it("parses paginated /diffs response into FilePatch[] with hunk content", async () => {
+      // page 1 with 2 entries (less than per_page → no follow-up page expected)
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          {
+            old_path: "src/a.ts",
+            new_path: "src/a.ts",
+            diff: "@@ -1,2 +1,3 @@\n line1\n+added\n line2\n",
+          },
+          {
+            old_path: "src/gone.ts",
+            new_path: "src/gone.ts",
+            deleted_file: true,
+            diff: "",
+          },
+        ]),
+      );
+      // diff_refs lookup (ensureDiffRefs) — single MR endpoint
       fetchSpy.mockResolvedValueOnce(
         jsonResponse({
-          changes: [
-            {
-              old_path: "src/a.ts",
-              new_path: "src/a.ts",
-              diff: "@@ -1,2 +1,3 @@\n line1\n+added\n line2\n",
-            },
-            {
-              old_path: "src/gone.ts",
-              new_path: "src/gone.ts",
-              deleted_file: true,
-              diff: "",
-            },
-          ],
+          iid: 42,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "main",
           diff_refs: { base_sha: "b", start_sha: "s", head_sha: "h" },
         }),
       );
@@ -146,22 +155,103 @@ describe("GitLabProvider", () => {
       });
       expect(patches[0].hunks[0].newStart).toBe(1);
       expect(patches[0].hunks[0].newLines).toBe(3);
+
+      const firstUrl = fetchSpy.mock.calls[0]?.[0] as string;
+      expect(firstUrl).toBe(`${MR_BASE}/diffs?per_page=50&page=1&unidiff=true`);
+    });
+
+    it("loops pagination until a short page is returned", async () => {
+      // page 1: full page (per_page=50) → keep going
+      const page1 = Array.from({ length: 50 }, (_, i) => ({
+        old_path: `src/f${i}.ts`,
+        new_path: `src/f${i}.ts`,
+        diff: `@@ -1 +1,2 @@\n line\n+added${i}\n`,
+      }));
+      fetchSpy.mockResolvedValueOnce(jsonResponse(page1));
+      // page 2: short page → stop after this
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          {
+            old_path: "src/last.ts",
+            new_path: "src/last.ts",
+            diff: "@@ -1 +1,2 @@\n x\n+y\n",
+          },
+        ]),
+      );
+      // ensureDiffRefs
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          iid: 42,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "main",
+        }),
+      );
+
+      const patches = await provider.getDiff();
+      expect(patches).toHaveLength(51);
+      const page2Url = fetchSpy.mock.calls[1]?.[0] as string;
+      expect(page2Url).toBe(`${MR_BASE}/diffs?per_page=50&page=2&unidiff=true`);
     });
 
     it("flags binary files instead of trying to parse the diff", async () => {
       fetchSpy.mockResolvedValueOnce(
+        jsonResponse([
+          {
+            old_path: "image.png",
+            new_path: "image.png",
+            diff: "Binary files a/image.png and b/image.png differ\n",
+          },
+        ]),
+      );
+      // ensureDiffRefs
+      fetchSpy.mockResolvedValueOnce(
         jsonResponse({
-          changes: [
-            {
-              old_path: "image.png",
-              new_path: "image.png",
-              diff: "Binary files a/image.png and b/image.png differ\n",
-            },
-          ],
+          iid: 42,
+          title: "t",
+          description: null,
+          source_branch: "s",
+          target_branch: "main",
         }),
       );
       const patches = await provider.getDiff();
       expect(patches[0]).toMatchObject({ path: "image.png", isBinary: true, hunks: [] });
+    });
+  });
+
+  describe("getDiffSinceSha", () => {
+    it("calls /repository/compare with unidiff=true and parses .diffs[]", async () => {
+      fetchSpy.mockResolvedValueOnce(
+        jsonResponse({
+          diffs: [
+            {
+              old_path: "src/a.ts",
+              new_path: "src/a.ts",
+              diff: "@@ -1 +1,2 @@\n line\n+added\n",
+            },
+            {
+              old_path: "src/removed.ts",
+              new_path: "src/removed.ts",
+              deleted_file: true,
+              diff: "",
+            },
+          ],
+        }),
+      );
+
+      const patches = await provider.getDiffSinceSha("aaa1111", "bbb2222");
+      expect(patches).not.toBeNull();
+      expect(patches).toHaveLength(1);
+      expect(patches?.[0].path).toBe("src/a.ts");
+      const url = fetchSpy.mock.calls[0]?.[0] as string;
+      expect(url).toContain("/repository/compare?from=aaa1111&to=bbb2222&unidiff=true");
+    });
+
+    it("returns [] when from === to without making a request", async () => {
+      const patches = await provider.getDiffSinceSha("same", "same");
+      expect(patches).toEqual([]);
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/gitlab/src/cli.ts
+++ b/packages/gitlab/src/cli.ts
@@ -1,0 +1,502 @@
+import type {
+  FilePatch,
+  FocusArea,
+  ReviewConfig,
+  TicketProvider,
+  TicketRef,
+} from "@rusty-bot/core";
+import {
+  ReviewStyleSchema,
+  filterFiles,
+  stripDeletionOnlyHunks,
+  expandContext,
+  summarizeLanguages,
+  extractTicketRefs,
+  resolveTicketsWithStatus,
+  fetchConventionFile,
+  GitLabTicketProvider,
+  JiraTicketProvider,
+  LinearTicketProvider,
+  runMultiCallReview,
+  runCascadeReview,
+  formatSummaryComment,
+  loadMcpServerConfigsFromEnv,
+  logger,
+  flushLogger,
+  isCascadeEnabled,
+  runTriage,
+  splitByClassification,
+  runOpenGrep,
+  extractChangedFilePaths,
+  generatePRDescription,
+  shouldGenerateDescription,
+  generateConventionalTitle,
+  isConventionalTitle,
+  filterAnchorableFindings,
+} from "@rusty-bot/core";
+import { GitLabProvider } from "./provider.js";
+
+const log = logger.child({ package: "gitlab" });
+
+const MAX_TOKENS = 120_000;
+const ALL_FOCUS_AREAS: FocusArea[] = ["security", "performance", "bugs", "style", "tests", "docs"];
+
+export interface GitLabCliConfig {
+  provider: GitLabProvider;
+  review: ReviewConfig;
+  failOnCritical: boolean;
+  incrementalReview: boolean;
+  apiBaseUrl: string;
+  token: string;
+  projectPath: string;
+}
+
+interface ParseEnvOptions {
+  env?: NodeJS.ProcessEnv;
+}
+
+export function parseConfig({ env = process.env }: ParseEnvOptions = {}): GitLabCliConfig {
+  // GitLab CI populates CI_MERGE_REQUEST_IID only on `merge_request_event` pipelines.
+  // Allow explicit overrides for non-CI invocations (e.g. running locally).
+  const mrIidStr = env.RUSTY_GITLAB_MR_IID ?? env.CI_MERGE_REQUEST_IID;
+  const projectPath =
+    env.RUSTY_GITLAB_PROJECT_PATH ?? env.CI_MERGE_REQUEST_PROJECT_PATH ?? env.CI_PROJECT_PATH;
+  // GitLab v4 API base; CI_API_V4_URL is provided automatically inside CI jobs.
+  const apiBaseUrl =
+    env.RUSTY_GITLAB_API_URL ??
+    env.CI_API_V4_URL ??
+    `${(env.CI_SERVER_URL ?? "https://gitlab.com").replace(/\/$/, "")}/api/v4`;
+
+  // Auth precedence: explicit RUSTY_GITLAB_TOKEN (project/personal access token), else CI_JOB_TOKEN.
+  // CI_JOB_TOKEN works for read APIs but cannot post MR notes/discussions on most installs —
+  // surface that in the warning below so operators know to add a project access token.
+  const explicitToken = env.RUSTY_GITLAB_TOKEN ?? env.GITLAB_TOKEN;
+  const jobToken = env.CI_JOB_TOKEN;
+  const token = explicitToken ?? jobToken;
+  const isJobToken = !explicitToken && jobToken !== undefined;
+
+  if (!mrIidStr || !projectPath || !token) {
+    const missing: string[] = [];
+    if (!mrIidStr) missing.push("CI_MERGE_REQUEST_IID (or RUSTY_GITLAB_MR_IID)");
+    if (!projectPath) missing.push("CI_PROJECT_PATH (or RUSTY_GITLAB_PROJECT_PATH)");
+    if (!token) missing.push("RUSTY_GITLAB_TOKEN (or CI_JOB_TOKEN)");
+    throw new Error(`missing required env vars: ${missing.join(", ")}`);
+  }
+
+  const mrIid = parseInt(mrIidStr, 10);
+  if (Number.isNaN(mrIid)) {
+    throw new Error(`invalid CI_MERGE_REQUEST_IID: ${mrIidStr}`);
+  }
+
+  if (isJobToken) {
+    log.warn(
+      "using CI_JOB_TOKEN — posting MR comments may fail. Set RUSTY_GITLAB_TOKEN to a project access token with 'api' scope.",
+    );
+  }
+
+  const reviewStyle = env.RUSTY_REVIEW_STYLE ?? "balanced";
+  const parsedStyle = ReviewStyleSchema.safeParse(reviewStyle);
+  if (!parsedStyle.success) {
+    throw new Error(`invalid review style: ${reviewStyle}`);
+  }
+
+  const rawFocusAreas =
+    env.RUSTY_FOCUS_AREAS?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  const focusAreas = rawFocusAreas.filter((area): area is FocusArea =>
+    (ALL_FOCUS_AREAS as string[]).includes(area),
+  );
+  const invalidFocusAreas = rawFocusAreas.filter((area) => !focusAreas.includes(area as FocusArea));
+  if (invalidFocusAreas.length > 0) {
+    log.warn(
+      { invalid: invalidFocusAreas, allowed: ALL_FOCUS_AREAS },
+      "ignoring unknown RUSTY_FOCUS_AREAS values",
+    );
+  }
+  const ignorePatterns =
+    env.RUSTY_IGNORE_PATTERNS?.split(",")
+      .map((s) => s.trim())
+      .filter(Boolean) ?? [];
+  const failOnCritical = env.RUSTY_FAIL_ON_CRITICAL !== "false";
+  const incrementalReview = env.RUSTY_INCREMENTAL_REVIEW !== "false";
+
+  return {
+    provider: new GitLabProvider({
+      apiBaseUrl,
+      projectId: projectPath,
+      mergeRequestIid: mrIid,
+      token,
+      isJobToken,
+    }),
+    review: {
+      style: parsedStyle.data,
+      focusAreas: focusAreas.length > 0 ? focusAreas : ALL_FOCUS_AREAS,
+      ignorePatterns,
+    },
+    failOnCritical,
+    incrementalReview,
+    apiBaseUrl,
+    token,
+    projectPath,
+  };
+}
+
+function buildTicketProviders(
+  apiBaseUrl: string,
+  token: string,
+  projectPath: string,
+  env: NodeJS.ProcessEnv,
+): Map<string, TicketProvider> {
+  const providers = new Map<string, TicketProvider>();
+
+  providers.set(
+    "gitlab",
+    new GitLabTicketProvider({
+      baseUrl: apiBaseUrl,
+      token,
+      defaultProjectPath: projectPath,
+    }),
+  );
+
+  const jiraUrl = env.RUSTY_JIRA_BASE_URL;
+  const jiraEmail = env.RUSTY_JIRA_EMAIL;
+  const jiraToken = env.RUSTY_JIRA_API_TOKEN;
+  if (jiraUrl && jiraEmail && jiraToken) {
+    providers.set(
+      "jira",
+      new JiraTicketProvider({ baseUrl: jiraUrl, email: jiraEmail, apiToken: jiraToken }),
+    );
+  }
+
+  const linearKey = env.RUSTY_LINEAR_API_KEY;
+  if (linearKey) {
+    providers.set("linear", new LinearTicketProvider({ apiKey: linearKey }));
+  }
+
+  return providers;
+}
+
+/**
+ * In a GitLab context, bare `#123` references mean GitLab issues, not GitHub.
+ * The shared extractor defaults `#N` to source=github (since github is the
+ * common case across providers). Rewrite those bare numeric refs here so the
+ * GitLab ticket provider can resolve them against the current project.
+ */
+function remapBareRefsToGitLab(refs: TicketRef[]): TicketRef[] {
+  return refs.map((ref) => {
+    if (ref.source !== "github") return ref;
+    if (ref.id.includes("/")) return ref; // owner/repo#N — not a bare ref, leave as github
+    if (!/^\d+$/.test(ref.id)) return ref;
+    return { ...ref, source: "gitlab" };
+  });
+}
+
+export async function runReview(config: GitLabCliConfig): Promise<number> {
+  const { provider, review: reviewConfig, failOnCritical, incrementalReview } = config;
+
+  const metadata = await provider.getPRMetadata();
+  log.info(
+    { mrIid: metadata.id, source: metadata.sourceBranch, target: metadata.targetBranch },
+    "reviewing MR",
+  );
+
+  const conventionFile = await fetchConventionFile(
+    (path, ref) => provider.getFileContent(path, ref),
+    metadata.targetBranch,
+  );
+  if (conventionFile) {
+    reviewConfig.conventionFile = conventionFile;
+  }
+
+  // read incremental marker before deleting old bot comments — otherwise we lose the sha
+  let lastReviewedSha: string | null = null;
+  if (incrementalReview && metadata.headSha) {
+    try {
+      lastReviewedSha = await provider.getLastReviewedSha();
+    } catch (err) {
+      log.warn({ err }, "failed to read last-reviewed sha, falling back to full review");
+    }
+  }
+
+  if (lastReviewedSha && metadata.headSha && lastReviewedSha === metadata.headSha) {
+    log.info({ sha: metadata.headSha }, "head sha matches last reviewed sha, skipping review");
+    return 0;
+  }
+
+  await provider.deleteExistingBotComments();
+
+  let rawPatches: FilePatch[] | null = null;
+  let incrementalUsed = false;
+  if (lastReviewedSha && metadata.headSha) {
+    const incremental = await provider.getDiffSinceSha(lastReviewedSha, metadata.headSha);
+    if (incremental) {
+      rawPatches = incremental;
+      incrementalUsed = true;
+      log.info(
+        { lastReviewedSha, headSha: metadata.headSha, files: incremental.length },
+        "running incremental review",
+      );
+    }
+  }
+
+  rawPatches ??= await provider.getDiff();
+
+  const filtered = filterFiles(rawPatches, reviewConfig.ignorePatterns);
+  const reviewable = stripDeletionOnlyHunks(filtered);
+  const skippedCount = rawPatches.length - reviewable.length;
+  log.info(
+    {
+      total: rawPatches.length,
+      reviewed: reviewable.length,
+      skipped: skippedCount,
+      mode: incrementalUsed ? "incremental" : "full",
+    },
+    "files changed",
+  );
+
+  if (incrementalUsed && reviewable.length === 0 && metadata.headSha) {
+    log.info(
+      { lastReviewedSha, headSha: metadata.headSha },
+      "no reviewable changes in incremental delta, skipping LLM review",
+    );
+    await provider.postSummaryComment("No reviewable changes since the last review.", {
+      lastReviewedSha: metadata.headSha,
+    });
+    return 0;
+  }
+
+  if (process.env.RUSTY_RENAME_TITLE_TO_CONVENTIONAL === "true") {
+    try {
+      if (!isConventionalTitle(metadata.title)) {
+        const titleResult = await generateConventionalTitle(reviewable, metadata);
+        await provider.updatePRTitle(titleResult.title);
+        log.info(
+          {
+            originalTitle: metadata.title,
+            newTitle: titleResult.title,
+            model: titleResult.modelUsed,
+            tokens: titleResult.tokenCount,
+          },
+          "renamed MR title to conventional commit format",
+        );
+        metadata.title = titleResult.title;
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to rename MR title, continuing with review");
+    }
+  }
+
+  if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
+    try {
+      if (shouldGenerateDescription(metadata.description)) {
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
+        await provider.updatePRDescription(descResult.markdown);
+        metadata.description = descResult.markdown;
+        log.info(
+          { model: descResult.modelUsed, tokens: descResult.tokenCount },
+          "generated MR description",
+        );
+      }
+    } catch (err) {
+      log.warn({ err }, "failed to generate MR description, continuing with review");
+    }
+  }
+
+  const ticketRefs = remapBareRefsToGitLab(
+    extractTicketRefs(metadata.description, metadata.sourceBranch),
+  );
+
+  let linkedRefs: TicketRef[] = [];
+  try {
+    const linkedIds = await provider.getLinkedIssueIids();
+    const existingIds = new Set(ticketRefs.filter((r) => r.source === "gitlab").map((r) => r.id));
+    linkedRefs = linkedIds
+      .filter((id) => !existingIds.has(id))
+      .map((id) => ({ id, source: "gitlab" as const }));
+  } catch (err) {
+    log.warn({ err }, "failed to fetch linked issues from GitLab, continuing with extracted refs");
+  }
+  const allRefs = [...ticketRefs, ...linkedRefs];
+
+  const ticketProviders = buildTicketProviders(
+    config.apiBaseUrl,
+    config.token,
+    config.projectPath,
+    process.env,
+  );
+
+  const { tickets, status: ticketResolution } = await resolveTicketsWithStatus(
+    allRefs,
+    ticketProviders,
+  );
+
+  const languageSummary = summarizeLanguages(reviewable);
+  const mcpServers = await loadMcpServerConfigsFromEnv();
+
+  const openGrepResult = await runOpenGrep(extractChangedFilePaths(reviewable), {
+    config: process.env.RUSTY_OPENGREP_RULES ?? "auto",
+  });
+  const openGrepFindings = openGrepResult.findings.length > 0 ? openGrepResult.findings : undefined;
+  if (openGrepResult.error) {
+    log.warn(
+      { error: openGrepResult.error },
+      "opengrep pre-scan failed, review will proceed without its findings",
+    );
+  } else if (openGrepResult.available) {
+    log.info({ findingCount: openGrepResult.findings.length }, "opengrep pre-scan complete");
+  }
+
+  let review;
+
+  if (isCascadeEnabled()) {
+    log.info({ fileCount: reviewable.length }, "cascade enabled, running triage");
+
+    let triageResult;
+    try {
+      triageResult = await runTriage(reviewable, openGrepFindings);
+    } catch (err) {
+      log.warn({ err }, "triage failed, falling back to full review");
+    }
+
+    if (triageResult) {
+      const { skip, skim, deepReview } = splitByClassification(reviewable, triageResult.files);
+      log.info(
+        { skipped: skip.length, skimmed: skim.length, deepReview: deepReview.length },
+        "triage classification",
+      );
+
+      const expandedDeep = await expandContext(deepReview, (path) =>
+        provider.getFileContent(path, metadata.sourceBranch),
+      );
+
+      review = await runCascadeReview(
+        skim,
+        expandedDeep,
+        reviewConfig,
+        metadata,
+        tickets.length > 0 ? tickets : undefined,
+        {
+          provider,
+          sourceRef: metadata.sourceBranch,
+          languageSummary,
+          mcpServers,
+          maxTokens: MAX_TOKENS,
+          openGrepFindings,
+        },
+      );
+
+      review.triageStats = {
+        filesSkipped: skip.length,
+        filesSkimmed: skim.length,
+        filesDeepReviewed: deepReview.length,
+        triageModelUsed: triageResult.modelUsed,
+        triageTokenCount: triageResult.tokenCount,
+      };
+    }
+  }
+
+  if (!review) {
+    const expanded = await expandContext(reviewable, (path) =>
+      provider.getFileContent(path, metadata.sourceBranch),
+    );
+
+    review = await runMultiCallReview(
+      expanded,
+      reviewConfig,
+      metadata,
+      tickets.length > 0 ? tickets : undefined,
+      {
+        provider,
+        sourceRef: metadata.sourceBranch,
+        languageSummary,
+        mcpServers,
+        maxTokens: MAX_TOKENS,
+        openGrepFindings,
+      },
+    );
+  }
+
+  review.openGrepStats = {
+    available: openGrepResult.available,
+    findingCount: openGrepResult.rawCount,
+    ...(openGrepResult.error ? { error: openGrepResult.error } : {}),
+  };
+
+  const criticalCount = review.findings.filter((f) => f.severity === "critical").length;
+  const warningCount = review.findings.filter((f) => f.severity === "warning").length;
+  log.info(
+    {
+      findings: review.findings.length,
+      critical: criticalCount,
+      warnings: warningCount,
+      recommendation: review.recommendation,
+    },
+    "review complete",
+  );
+
+  const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
+  await provider.postSummaryComment(
+    summaryMarkdown,
+    metadata.headSha ? { lastReviewedSha: metadata.headSha } : undefined,
+  );
+
+  const inlineCandidates = review.findings.filter((f) => f.line > 0);
+  const { anchored: inlineFindings, dropped } = filterAnchorableFindings(
+    inlineCandidates,
+    reviewable,
+  );
+  if (dropped.length > 0) {
+    log.warn(
+      {
+        droppedCount: dropped.length,
+        samples: dropped.slice(0, 5).map((d) => ({
+          file: d.finding.file,
+          line: d.finding.line,
+          reason: d.reason,
+        })),
+      },
+      "dropped findings that don't anchor to the diff before posting inline comments",
+    );
+  }
+  if (inlineFindings.length > 0) {
+    await provider.postInlineComments(inlineFindings);
+  }
+
+  log.info(
+    { inlineComments: inlineFindings.length, droppedAnchors: dropped.length },
+    "posted summary and inline comments",
+  );
+
+  if (failOnCritical && criticalCount > 0) {
+    log.warn({ criticalCount }, "failing pipeline due to critical issues");
+    return 1;
+  }
+  return 0;
+}
+
+async function main(): Promise<number> {
+  // GitLab CI runs this CLI on every pipeline; only proceed when triggered by an MR event.
+  const eventType = process.env.CI_PIPELINE_SOURCE;
+  if (eventType && eventType !== "merge_request_event" && !process.env.CI_MERGE_REQUEST_IID) {
+    log.info(
+      { eventType },
+      "not a merge_request_event pipeline and CI_MERGE_REQUEST_IID is unset, skipping",
+    );
+    return 0;
+  }
+
+  const config = parseConfig();
+  return await runReview(config);
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === `file://${process.argv[1]}`;
+
+if (isDirectRun) {
+  main()
+    .then((code) => flushLogger(() => process.exit(code)))
+    .catch((err: unknown) => {
+      log.fatal({ err }, "fatal error");
+      flushLogger(() => process.exit(2));
+    });
+}

--- a/packages/gitlab/src/cli.ts
+++ b/packages/gitlab/src/cli.ts
@@ -48,6 +48,7 @@ export interface GitLabCliConfig {
   incrementalReview: boolean;
   apiBaseUrl: string;
   token: string;
+  isJobToken: boolean;
   projectPath: string;
 }
 
@@ -138,6 +139,7 @@ export function parseConfig({ env = process.env }: ParseEnvOptions = {}): GitLab
     incrementalReview,
     apiBaseUrl,
     token,
+    isJobToken,
     projectPath,
   };
 }
@@ -145,6 +147,7 @@ export function parseConfig({ env = process.env }: ParseEnvOptions = {}): GitLab
 function buildTicketProviders(
   apiBaseUrl: string,
   token: string,
+  isJobToken: boolean,
   projectPath: string,
   env: NodeJS.ProcessEnv,
 ): Map<string, TicketProvider> {
@@ -155,6 +158,7 @@ function buildTicketProviders(
     new GitLabTicketProvider({
       baseUrl: apiBaseUrl,
       token,
+      isJobToken,
       defaultProjectPath: projectPath,
     }),
   );
@@ -322,6 +326,7 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
   const ticketProviders = buildTicketProviders(
     config.apiBaseUrl,
     config.token,
+    config.isJobToken,
     config.projectPath,
     process.env,
   );

--- a/packages/gitlab/src/index.ts
+++ b/packages/gitlab/src/index.ts
@@ -1,0 +1,2 @@
+export { GitLabProvider } from "./provider.js";
+export type { GitLabProviderConfig } from "./provider.js";

--- a/packages/gitlab/src/provider.ts
+++ b/packages/gitlab/src/provider.ts
@@ -1,0 +1,417 @@
+import type {
+  GitProvider,
+  FilePatch,
+  PRMetadata,
+  Finding,
+  Hunk,
+  CodeSearchResult,
+  PostSummaryCommentOptions,
+} from "@rusty-bot/core";
+import { formatInlineComment, logger } from "@rusty-bot/core";
+import type { z } from "zod";
+import {
+  GitLabMergeRequestSchema,
+  GitLabMergeRequestChangesSchema,
+  GitLabNotesSchema,
+  GitLabDiscussionsSchema,
+  GitLabClosesIssuesSchema,
+  GitLabSearchResultSchema,
+} from "./schemas.js";
+
+const BOT_MARKER = "<!-- rusty-bot-review -->";
+const LAST_SHA_MARKER_RE = /<!--\s*rusty-bot:last-sha:([0-9a-f]{7,64})\s*-->/i;
+
+const log = logger.child({ package: "gitlab", component: "provider" });
+
+function buildLastShaMarker(sha: string): string {
+  return `<!-- rusty-bot:last-sha:${sha} -->`;
+}
+
+export interface GitLabProviderConfig {
+  /** API root, e.g. https://gitlab.com/api/v4 */
+  apiBaseUrl: string;
+  /** Project id (numeric) or full path (e.g. "group/sub/project") */
+  projectId: string;
+  /** MR internal id (iid) */
+  mergeRequestIid: number;
+  /** Personal access token, project access token, or CI_JOB_TOKEN */
+  token: string;
+  /** When true, send token via JOB-TOKEN header (CI job token); else PRIVATE-TOKEN */
+  isJobToken?: boolean;
+}
+
+interface ParsedHunkHeader {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+}
+
+function parseHunkHeader(line: string): ParsedHunkHeader {
+  const match = /^@@\s+-(\d+)(?:,(\d+))?\s+\+(\d+)(?:,(\d+))?\s+@@/.exec(line);
+  if (!match) {
+    return { oldStart: 0, oldLines: 0, newStart: 0, newLines: 0 };
+  }
+  return {
+    oldStart: parseInt(match[1], 10),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- capture groups can be undefined at runtime
+    oldLines: match[2] != null ? parseInt(match[2], 10) : 1,
+    newStart: parseInt(match[3], 10),
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- capture groups can be undefined at runtime
+    newLines: match[4] != null ? parseInt(match[4], 10) : 1,
+  };
+}
+
+/**
+ * GitLab returns the diff body (without the `diff --git` header) per file in
+ * the changes endpoint. Convert it to our internal Hunk[] representation.
+ */
+function parseGitLabFileDiff(diffBody: string): {
+  hunks: Hunk[];
+  additions: number;
+  deletions: number;
+} {
+  const hunks: Hunk[] = [];
+  let additions = 0;
+  let deletions = 0;
+
+  const lines = diffBody.split("\n");
+  let current: { header: ParsedHunkHeader; lines: string[] } | null = null;
+
+  for (const line of lines) {
+    if (line.startsWith("@@")) {
+      if (current) {
+        hunks.push({ ...current.header, content: current.lines.join("\n") });
+      }
+      current = { header: parseHunkHeader(line), lines: [line] };
+    } else if (current) {
+      current.lines.push(line);
+      if (line.startsWith("+") && !line.startsWith("+++")) additions++;
+      if (line.startsWith("-") && !line.startsWith("---")) deletions++;
+    }
+  }
+
+  if (current) {
+    hunks.push({ ...current.header, content: current.lines.join("\n") });
+  }
+
+  return { hunks, additions, deletions };
+}
+
+export class GitLabProvider implements GitProvider {
+  private readonly apiBaseUrl: string;
+  private readonly projectId: string;
+  private readonly projectIdEncoded: string;
+  private readonly mergeRequestIid: number;
+  private readonly token: string;
+  private readonly tokenHeader: string;
+  /** populated by getDiff/getPRMetadata for use by postInlineComments */
+  private cachedDiffRefs: { base_sha: string; start_sha: string; head_sha: string } | null = null;
+
+  constructor(config: GitLabProviderConfig) {
+    this.apiBaseUrl = config.apiBaseUrl.replace(/\/$/, "");
+    this.projectId = config.projectId;
+    this.projectIdEncoded = encodeURIComponent(config.projectId);
+    this.mergeRequestIid = config.mergeRequestIid;
+    this.token = config.token;
+    this.tokenHeader = config.isJobToken ? "JOB-TOKEN" : "PRIVATE-TOKEN";
+  }
+
+  private get mrBase(): string {
+    return `${this.apiBaseUrl}/projects/${this.projectIdEncoded}/merge_requests/${this.mergeRequestIid}`;
+  }
+
+  private get projectBase(): string {
+    return `${this.apiBaseUrl}/projects/${this.projectIdEncoded}`;
+  }
+
+  private async fetchApi(url: string, options: RequestInit = {}): Promise<Response> {
+    const { headers: extraHeaders, ...rest } = options;
+    const headers: Record<string, string> = {
+      [this.tokenHeader]: this.token,
+      Accept: "application/json",
+    };
+    if (rest.body) {
+      headers["Content-Type"] = "application/json";
+    }
+    if (extraHeaders) {
+      new Headers(extraHeaders).forEach((v, k) => {
+        headers[k] = v;
+      });
+    }
+    const res = await fetch(url, { ...rest, headers });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`GitLab API error ${res.status}: ${res.statusText} - ${body}`);
+    }
+    return res;
+  }
+
+  private async request<T extends z.ZodType>(
+    url: string,
+    schema: T,
+    options?: RequestInit,
+  ): Promise<z.infer<T>> {
+    const res = await this.fetchApi(url, options);
+    const json: unknown = await res.json();
+    return schema.parse(json) as z.infer<T>;
+  }
+
+  async getPRMetadata(): Promise<PRMetadata> {
+    const data = await this.request(this.mrBase, GitLabMergeRequestSchema);
+    if (data.diff_refs?.base_sha && data.diff_refs.start_sha && data.diff_refs.head_sha) {
+      this.cachedDiffRefs = {
+        base_sha: data.diff_refs.base_sha,
+        start_sha: data.diff_refs.start_sha,
+        head_sha: data.diff_refs.head_sha,
+      };
+    }
+    return {
+      id: String(data.iid),
+      title: data.title,
+      description: data.description ?? "",
+      author: data.author?.username ?? data.author?.name ?? "",
+      sourceBranch: data.source_branch,
+      targetBranch: data.target_branch,
+      url: data.web_url ?? "",
+      ...(data.sha ? { headSha: data.sha } : {}),
+    };
+  }
+
+  async getDiff(): Promise<FilePatch[]> {
+    // /changes returns full diff bodies in one request — preferred over paginated /diffs
+    const data = await this.request(`${this.mrBase}/changes`, GitLabMergeRequestChangesSchema);
+
+    if (data.diff_refs?.base_sha && data.diff_refs.start_sha && data.diff_refs.head_sha) {
+      this.cachedDiffRefs = {
+        base_sha: data.diff_refs.base_sha,
+        start_sha: data.diff_refs.start_sha,
+        head_sha: data.diff_refs.head_sha,
+      };
+    }
+
+    const patches: FilePatch[] = [];
+    for (const change of data.changes) {
+      if (change.deleted_file) continue;
+
+      const path = change.new_path;
+      if (change.diff.includes("Binary files") && change.diff.includes("differ")) {
+        patches.push({ path, hunks: [], additions: 0, deletions: 0, isBinary: true });
+        continue;
+      }
+
+      const { hunks, additions, deletions } = parseGitLabFileDiff(change.diff);
+      patches.push({ path, hunks, additions, deletions, isBinary: false });
+    }
+    return patches;
+  }
+
+  async getDiffSinceSha(sinceSha: string, headSha: string): Promise<FilePatch[] | null> {
+    if (sinceSha === headSha) return [];
+    try {
+      const url = `${this.projectBase}/repository/compare?from=${encodeURIComponent(
+        sinceSha,
+      )}&to=${encodeURIComponent(headSha)}&unidiff=true`;
+      const res = await this.fetchApi(url);
+      const raw: unknown = await res.json();
+      const compare = raw as { diffs?: { old_path: string; new_path: string; diff: string }[] };
+      const diffs = compare.diffs ?? [];
+      const patches: FilePatch[] = [];
+      for (const d of diffs) {
+        if (!d.diff) continue;
+        const { hunks, additions, deletions } = parseGitLabFileDiff(d.diff);
+        patches.push({
+          path: d.new_path,
+          hunks,
+          additions,
+          deletions,
+          isBinary: false,
+        });
+      }
+      return patches;
+    } catch (err) {
+      log.warn(
+        { err, sinceSha, headSha },
+        "could not fetch incremental diff (sha unreachable, force-push, or rebase)",
+      );
+      return null;
+    }
+  }
+
+  async getLastReviewedSha(): Promise<string | null> {
+    const notes = await this.request(`${this.mrBase}/notes?per_page=100`, GitLabNotesSchema);
+    // walk newest-first; gitlab returns notes ordered newest-first by default
+    for (const note of notes) {
+      if (note.system) continue;
+      const body = note.body;
+      if (!body?.includes(BOT_MARKER)) continue;
+      const match = LAST_SHA_MARKER_RE.exec(body);
+      if (match) return match[1].toLowerCase();
+    }
+    return null;
+  }
+
+  async getFileContent(path: string, ref: string): Promise<string | null> {
+    try {
+      const url = `${this.projectBase}/repository/files/${encodeURIComponent(
+        path,
+      )}/raw?ref=${encodeURIComponent(ref)}`;
+      const res = await fetch(url, {
+        headers: { [this.tokenHeader]: this.token, Accept: "text/plain" },
+      });
+      if (!res.ok) return null;
+      return await res.text();
+    } catch {
+      return null;
+    }
+  }
+
+  async searchCode(query: string): Promise<CodeSearchResult[]> {
+    try {
+      const url = `${this.projectBase}/search?scope=blobs&search=${encodeURIComponent(query)}&per_page=20`;
+      const res = await this.fetchApi(url);
+      const parsed = GitLabSearchResultSchema.safeParse(await res.json());
+      if (!parsed.success) return [];
+      return parsed.data.map((r) => ({
+        file: r.path ?? r.filename ?? "",
+        line: r.startline ?? 0,
+        content: r.data ?? "",
+      }));
+    } catch {
+      return [];
+    }
+  }
+
+  async postSummaryComment(markdown: string, options?: PostSummaryCommentOptions): Promise<void> {
+    const headerLines = [BOT_MARKER];
+    if (options?.lastReviewedSha) {
+      headerLines.push(buildLastShaMarker(options.lastReviewedSha));
+    }
+    const body = `${headerLines.join("\n")}\n${markdown}`;
+    await this.fetchApi(`${this.mrBase}/notes`, {
+      method: "POST",
+      body: JSON.stringify({ body }),
+    });
+  }
+
+  async postInlineComments(findings: Finding[]): Promise<void> {
+    if (findings.length === 0) return;
+
+    const refs = await this.ensureDiffRefs();
+    if (!refs) {
+      log.warn(
+        "missing diff_refs from GitLab MR — falling back to top-level notes for inline findings",
+      );
+      for (const finding of findings) {
+        const body = `${BOT_MARKER}\n**${finding.file}:${finding.line}**\n\n${formatInlineComment(finding)}`;
+        await this.fetchApi(`${this.mrBase}/notes`, {
+          method: "POST",
+          body: JSON.stringify({ body }),
+        });
+      }
+      return;
+    }
+
+    for (const finding of findings) {
+      const endLine = finding.endLine ?? finding.line;
+      const body = `${BOT_MARKER}\n${formatInlineComment(finding)}`;
+      const position: Record<string, unknown> = {
+        position_type: "text",
+        base_sha: refs.base_sha,
+        start_sha: refs.start_sha,
+        head_sha: refs.head_sha,
+        new_path: finding.file,
+        old_path: finding.file,
+        new_line: endLine,
+      };
+      try {
+        await this.fetchApi(`${this.mrBase}/discussions`, {
+          method: "POST",
+          body: JSON.stringify({ body, position }),
+        });
+      } catch (err) {
+        log.warn(
+          { err, file: finding.file, line: finding.line },
+          "failed to post inline discussion, falling back to top-level note",
+        );
+        const fallback = `${BOT_MARKER}\n**${finding.file}:${finding.line}**\n\n${formatInlineComment(finding)}`;
+        await this.fetchApi(`${this.mrBase}/notes`, {
+          method: "POST",
+          body: JSON.stringify({ body: fallback }),
+        });
+      }
+    }
+  }
+
+  async deleteExistingBotComments(): Promise<void> {
+    // discussions API returns both individual notes and threaded discussions —
+    // walk every note and delete the bot-authored ones individually.
+    const discussions = await this.request(
+      `${this.mrBase}/discussions?per_page=100`,
+      GitLabDiscussionsSchema,
+    );
+    for (const discussion of discussions) {
+      for (const note of discussion.notes) {
+        if (note.system) continue;
+        if (!note.body?.includes(BOT_MARKER)) continue;
+        try {
+          await this.fetchApi(`${this.mrBase}/notes/${note.id}`, { method: "DELETE" });
+        } catch (err) {
+          log.warn(
+            { err, noteId: note.id },
+            "failed to delete bot note (likely a positional note in a resolved discussion)",
+          );
+        }
+      }
+    }
+  }
+
+  async getLinkedIssueIids(): Promise<string[]> {
+    try {
+      const data = await this.request(
+        `${this.mrBase}/closes_issues?per_page=100`,
+        GitLabClosesIssuesSchema,
+      );
+      // references.full is e.g. "group/project#123"; fall back to the raw iid
+      return data.map((issue) => issue.references?.full ?? String(issue.iid));
+    } catch {
+      return [];
+    }
+  }
+
+  async updatePRDescription(description: string): Promise<void> {
+    await this.fetchApi(this.mrBase, {
+      method: "PUT",
+      body: JSON.stringify({ description }),
+    });
+  }
+
+  async updatePRTitle(title: string): Promise<void> {
+    await this.fetchApi(this.mrBase, {
+      method: "PUT",
+      body: JSON.stringify({ title }),
+    });
+  }
+
+  private async ensureDiffRefs(): Promise<{
+    base_sha: string;
+    start_sha: string;
+    head_sha: string;
+  } | null> {
+    if (this.cachedDiffRefs) return this.cachedDiffRefs;
+    try {
+      const data = await this.request(this.mrBase, GitLabMergeRequestSchema);
+      if (data.diff_refs?.base_sha && data.diff_refs.start_sha && data.diff_refs.head_sha) {
+        this.cachedDiffRefs = {
+          base_sha: data.diff_refs.base_sha,
+          start_sha: data.diff_refs.start_sha,
+          head_sha: data.diff_refs.head_sha,
+        };
+        return this.cachedDiffRefs;
+      }
+    } catch {
+      // fall through to null
+    }
+    return null;
+  }
+}

--- a/packages/gitlab/src/provider.ts
+++ b/packages/gitlab/src/provider.ts
@@ -11,7 +11,8 @@ import { formatInlineComment, logger } from "@rusty-bot/core";
 import type { z } from "zod";
 import {
   GitLabMergeRequestSchema,
-  GitLabMergeRequestChangesSchema,
+  GitLabMergeRequestDiffsSchema,
+  GitLabRepositoryCompareSchema,
   GitLabNotesSchema,
   GitLabDiscussionsSchema,
   GitLabClosesIssuesSchema,
@@ -179,30 +180,34 @@ export class GitLabProvider implements GitProvider {
   }
 
   async getDiff(): Promise<FilePatch[]> {
-    // /changes returns full diff bodies in one request — preferred over paginated /diffs
-    const data = await this.request(`${this.mrBase}/changes`, GitLabMergeRequestChangesSchema);
-
-    if (data.diff_refs?.base_sha && data.diff_refs.start_sha && data.diff_refs.head_sha) {
-      this.cachedDiffRefs = {
-        base_sha: data.diff_refs.base_sha,
-        start_sha: data.diff_refs.start_sha,
-        head_sha: data.diff_refs.head_sha,
-      };
-    }
-
+    // /merge_requests/:iid/diffs (paginated, flat array). The deprecated
+    // /changes endpoint is removed in API v5 — use this instead. unidiff=true
+    // forces the portable unified diff format.
+    const PER_PAGE = 50;
     const patches: FilePatch[] = [];
-    for (const change of data.changes) {
-      if (change.deleted_file) continue;
-
-      const path = change.new_path;
-      if (change.diff.includes("Binary files") && change.diff.includes("differ")) {
-        patches.push({ path, hunks: [], additions: 0, deletions: 0, isBinary: true });
-        continue;
+    for (let page = 1; ; page++) {
+      const url = `${this.mrBase}/diffs?per_page=${PER_PAGE}&page=${page}&unidiff=true`;
+      const entries = await this.request(url, GitLabMergeRequestDiffsSchema);
+      if (entries.length === 0) break;
+      for (const entry of entries) {
+        if (entry.deleted_file) continue;
+        const path = entry.new_path;
+        if (entry.diff.includes("Binary files") && entry.diff.includes("differ")) {
+          patches.push({ path, hunks: [], additions: 0, deletions: 0, isBinary: true });
+          continue;
+        }
+        const { hunks, additions, deletions } = parseGitLabFileDiff(entry.diff);
+        patches.push({ path, hunks, additions, deletions, isBinary: false });
       }
-
-      const { hunks, additions, deletions } = parseGitLabFileDiff(change.diff);
-      patches.push({ path, hunks, additions, deletions, isBinary: false });
+      if (entries.length < PER_PAGE) break;
     }
+
+    // /diffs doesn't include diff_refs — fetch them from the MR endpoint so
+    // postInlineComments has them available for positioned discussions.
+    if (!this.cachedDiffRefs) {
+      await this.ensureDiffRefs();
+    }
+
     return patches;
   }
 
@@ -212,21 +217,17 @@ export class GitLabProvider implements GitProvider {
       const url = `${this.projectBase}/repository/compare?from=${encodeURIComponent(
         sinceSha,
       )}&to=${encodeURIComponent(headSha)}&unidiff=true`;
-      const res = await this.fetchApi(url);
-      const raw: unknown = await res.json();
-      const compare = raw as { diffs?: { old_path: string; new_path: string; diff: string }[] };
-      const diffs = compare.diffs ?? [];
+      const compare = await this.request(url, GitLabRepositoryCompareSchema);
       const patches: FilePatch[] = [];
-      for (const d of diffs) {
-        if (!d.diff) continue;
+      for (const d of compare.diffs ?? []) {
+        if (d.deleted_file || !d.diff) continue;
+        const path = d.new_path;
+        if (d.diff.includes("Binary files") && d.diff.includes("differ")) {
+          patches.push({ path, hunks: [], additions: 0, deletions: 0, isBinary: true });
+          continue;
+        }
         const { hunks, additions, deletions } = parseGitLabFileDiff(d.diff);
-        patches.push({
-          path: d.new_path,
-          hunks,
-          additions,
-          deletions,
-          isBinary: false,
-        });
+        patches.push({ path, hunks, additions, deletions, isBinary: false });
       }
       return patches;
     } catch (err) {

--- a/packages/gitlab/src/provider.ts
+++ b/packages/gitlab/src/provider.ts
@@ -257,10 +257,7 @@ export class GitLabProvider implements GitProvider {
       const url = `${this.projectBase}/repository/files/${encodeURIComponent(
         path,
       )}/raw?ref=${encodeURIComponent(ref)}`;
-      const res = await fetch(url, {
-        headers: { [this.tokenHeader]: this.token, Accept: "text/plain" },
-      });
-      if (!res.ok) return null;
+      const res = await this.fetchApi(url, { headers: { Accept: "text/plain" } });
       return await res.text();
     } catch {
       return null;

--- a/packages/gitlab/src/schemas.ts
+++ b/packages/gitlab/src/schemas.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+
+export const GitLabUserSchema = z.object({
+  id: z.number().optional(),
+  username: z.string().optional(),
+  name: z.string().optional(),
+});
+
+export const GitLabDiffRefsSchema = z.object({
+  base_sha: z.string().nullable().optional(),
+  start_sha: z.string().nullable().optional(),
+  head_sha: z.string().nullable().optional(),
+});
+
+export const GitLabMergeRequestSchema = z.object({
+  iid: z.number(),
+  id: z.number().optional(),
+  project_id: z.number().optional(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  state: z.string().optional(),
+  draft: z.boolean().optional(),
+  work_in_progress: z.boolean().optional(),
+  source_branch: z.string(),
+  target_branch: z.string(),
+  sha: z.string().nullable().optional(),
+  web_url: z.string().optional(),
+  author: GitLabUserSchema.nullable().optional(),
+  diff_refs: GitLabDiffRefsSchema.nullable().optional(),
+});
+
+export const GitLabMergeRequestChangeSchema = z.object({
+  old_path: z.string(),
+  new_path: z.string(),
+  a_mode: z.string().optional(),
+  b_mode: z.string().optional(),
+  new_file: z.boolean().optional(),
+  renamed_file: z.boolean().optional(),
+  deleted_file: z.boolean().optional(),
+  diff: z.string(),
+});
+
+export const GitLabMergeRequestChangesSchema = z.object({
+  changes: z.array(GitLabMergeRequestChangeSchema),
+  diff_refs: GitLabDiffRefsSchema.nullable().optional(),
+});
+
+export const GitLabNoteSchema = z.object({
+  id: z.number(),
+  body: z.string().nullable().optional(),
+  system: z.boolean().optional(),
+  author: GitLabUserSchema.nullable().optional(),
+});
+
+export const GitLabNotesSchema = z.array(GitLabNoteSchema);
+
+export const GitLabDiscussionSchema = z.object({
+  id: z.string(),
+  individual_note: z.boolean().optional(),
+  notes: z.array(GitLabNoteSchema),
+});
+
+export const GitLabDiscussionsSchema = z.array(GitLabDiscussionSchema);
+
+export const GitLabIssueRefSchema = z.object({
+  iid: z.number(),
+  project_id: z.number().optional(),
+  references: z
+    .object({
+      full: z.string().optional(),
+    })
+    .optional(),
+});
+
+export const GitLabClosesIssuesSchema = z.array(GitLabIssueRefSchema);
+
+export const GitLabSearchResultSchema = z.array(
+  z.object({
+    path: z.string().optional(),
+    filename: z.string().optional(),
+    startline: z.number().optional(),
+    data: z.string().optional(),
+  }),
+);

--- a/packages/gitlab/src/schemas.ts
+++ b/packages/gitlab/src/schemas.ts
@@ -29,20 +29,26 @@ export const GitLabMergeRequestSchema = z.object({
   diff_refs: GitLabDiffRefsSchema.nullable().optional(),
 });
 
-export const GitLabMergeRequestChangeSchema = z.object({
+export const GitLabDiffEntrySchema = z.object({
   old_path: z.string(),
   new_path: z.string(),
-  a_mode: z.string().optional(),
-  b_mode: z.string().optional(),
+  a_mode: z.string().nullable().optional(),
+  b_mode: z.string().nullable().optional(),
   new_file: z.boolean().optional(),
   renamed_file: z.boolean().optional(),
   deleted_file: z.boolean().optional(),
+  generated_file: z.boolean().optional(),
+  collapsed: z.boolean().optional(),
+  too_large: z.boolean().optional(),
   diff: z.string(),
 });
 
-export const GitLabMergeRequestChangesSchema = z.object({
-  changes: z.array(GitLabMergeRequestChangeSchema),
-  diff_refs: GitLabDiffRefsSchema.nullable().optional(),
+/** Response shape for GET /merge_requests/:iid/diffs — flat paginated array. */
+export const GitLabMergeRequestDiffsSchema = z.array(GitLabDiffEntrySchema);
+
+/** Response shape for GET /repository/compare — diffs are nested under .diffs */
+export const GitLabRepositoryCompareSchema = z.object({
+  diffs: z.array(GitLabDiffEntrySchema).optional(),
 });
 
 export const GitLabNoteSchema = z.object({

--- a/packages/gitlab/tsconfig.json
+++ b/packages/gitlab/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src",
+    "composite": true
+  },
+  "include": ["src"],
+  "references": [{ "path": "../core" }]
+}

--- a/packages/gitlab/vitest.config.ts
+++ b/packages/gitlab/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    exclude: ["dist/**", "node_modules/**"],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,18 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
 
+  packages/gitlab:
+    dependencies:
+      '@rusty-bot/core':
+        specifier: workspace:*
+        version: link:../core
+      diff:
+        specifier: ^9.0.0
+        version: 9.0.0
+      zod:
+        specifier: ^4.3.6
+        version: 4.3.6
+
 packages:
 
   '@a2a-js/sdk@0.2.5':

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    projects: ["packages/core", "packages/github", "packages/azure-devops"],
+    projects: ["packages/core", "packages/github", "packages/azure-devops", "packages/gitlab"],
   },
 });


### PR DESCRIPTION
## Summary

Adds end-to-end GitLab support, mirroring the existing Azure DevOps pattern: a `GitProvider` implementation against GitLab's REST API plus a one-shot CLI driven by GitLab's predefined `CI_MERGE_REQUEST_*` env vars. Drops into any GitLab CI pipeline as a job inside the existing `ghcr.io/jegork/rusty-bot:latest` Docker image (`RUSTY_MODE=gitlab`).

## What's new

**Core (`packages/core`)**
- Add `"gitlab"` to the `TicketSource` union
- Extract GitLab issue URLs (`https://.../-/issues/N`) in the shared ref extractor
- New `GitLabTicketProvider` that resolves issues via `GET /projects/:id/issues/:iid`

**New package `packages/gitlab` (provider + CLI)**
- `GitLabProvider` implementing the full `GitProvider` interface
- One-shot CLI that reads `CI_MERGE_REQUEST_IID`, `CI_PROJECT_PATH`, `CI_API_V4_URL`, etc. — supports both project access tokens (`RUSTY_GITLAB_TOKEN` via `PRIVATE-TOKEN` header) and the read-only `CI_JOB_TOKEN` fallback (via `JOB-TOKEN` header), with a warning when only the job token is available
- Posts MR summary as a top-level note and inline findings as positioned discussions (correct semantics for added lines: `new_line` only, no `old_line`)
- Falls back to top-level notes when `diff_refs` are unavailable
- Incremental review via head-SHA marker embedded in the summary note
- Resolves linked closing issues via `GET /merge_requests/:iid/closes_issues`
- In a GitLab context, bare `#123` refs are remapped from the extractor's default `source: "github"` to `source: "gitlab"` so the GitLab ticket provider resolves them against the current project

**Repo-level**
- New [`gitlab-ci-example.yml`](./gitlab-ci-example.yml) snippet
- Dockerfile updated with the `gitlab` package and a new `RUSTY_MODE=gitlab` entrypoint case
- `.env.example`: `RUSTY_GITLAB_TOKEN`, `RUSTY_GITLAB_API_URL`, `RUSTY_GITLAB_PROJECT_PATH`, `RUSTY_GITLAB_MR_IID`
- README: new "GitLab CI Setup" section, env-var table entries, project-structure update, GitLab issue extraction docs

## API schema verification

Before pushing, I cross-checked every GitLab REST API request and response shape against the [official GitLab docs](https://docs.gitlab.com/api/merge_requests/) (fetched live from the `gitlabhq/gitlabhq` repo). That review caught two real issues, fixed in the second commit (`9b7d9f4`):

1. **`/merge_requests/:iid/changes` is deprecated since GitLab 15.7** and slated for removal in API v5. The provider now uses `/merge_requests/:iid/diffs?per_page=50&unidiff=true` with page-loop pagination, as the docs direct.
2. **`/diffs` doesn't return a `diff_refs` wrapper** (flat array). The provider explicitly fetches `diff_refs` from the MR endpoint via `ensureDiffRefs()` so positioned inline discussions still work.

Verified to match the docs: discussion `position` object (`text` type, added-line anchoring), `/repository/compare` response, `/search?scope=blobs` shape, `PUT /merge_requests/:iid` for title/description, `closes_issues`, project issues, and the `PRIVATE-TOKEN` / `JOB-TOKEN` headers.

## Tests

17 unit tests in `packages/gitlab/src/__tests__/provider.test.ts` covering every method on `GitLabProvider`:

- `getPRMetadata` — payload mapping; `JOB-TOKEN` vs `PRIVATE-TOKEN` header selection
- `getDiff` — paginated `/diffs`, page-loop pagination, binary file detection
- `getDiffSinceSha` — compare endpoint with `unidiff=true`; same-SHA shortcut
- `getLastReviewedSha` — newest-first walk, embedded SHA marker; ignores system notes
- `postSummaryComment` — bot marker + `last-sha` marker
- `postInlineComments` — positioned discussion with `diff_refs`; fallback to top-level note when refs unavailable
- `deleteExistingBotComments` — walks discussions, deletes only bot-authored notes
- `getFileContent` — raw file fetch; null on non-200
- `getLinkedIssueIids` — `references.full` if present, else iid; empty on error

Also registered `packages/gitlab` in the root `vitest.config.ts` so the workspace test runner picks them up.

**Result:** `pnpm test` — 27 test files, **725 tests passing** (up from 708). `pnpm lint` and `pnpm format:check` clean.

## Test plan

- [ ] Build the Docker image (`docker build -t rusty-bot-gitlab .`) and verify the `gitlab` entrypoint case starts the right CLI
- [ ] Drop the `gitlab-ci-example.yml` snippet into a real GitLab project; open a test MR and confirm:
  - [ ] Summary note posts with the bot marker and `last-sha` marker
  - [ ] Inline findings post as positioned discussions on the correct diff lines
  - [ ] Convention file (`.rusty-bot.md`) is fetched from the target branch
  - [ ] `closes_issues`-style refs (`Closes #123`) get resolved via `GitLabTicketProvider`
  - [ ] Subsequent push triggers an incremental review (only the delta since the last reviewed SHA)
  - [ ] `RUSTY_FAIL_ON_CRITICAL=true` exits the job with code 1 when a critical finding is posted
- [ ] Verify on a self-hosted GitLab instance (uses `CI_API_V4_URL` automatically; no extra config needed)
- [ ] Confirm `CI_JOB_TOKEN`-only flow logs the warning and either succeeds (read-only operations) or fails cleanly when posting

## Out of scope

- No GitLab webhook server (parallel to the GitHub App). The CI-job pattern matches how GitLab integrations are typically deployed; a webhook server can be added in a follow-up if needed.
- The dashboard isn't aware of GitLab repos yet (it's GitHub-only today; same as Azure DevOps).
- `scope=blobs` search requires GitLab Premium/Ultimate — `searchCode()` degrades gracefully to `[]` on free-tier projects.

https://claude.ai/code/session_01TBi7hUmbNGHQJayS2nzNA4

---
_Generated by [Claude Code](https://claude.ai/code/session_01TBi7hUmbNGHQJayS2nzNA4)_