### PR TITLE
fix(formatter): show all reviewer models in summary footer

### DIFF
--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -126,10 +126,43 @@ describe("formatSummaryComment", () => {
       },
     });
 
+    const footerLine = formatSummaryComment(review)
+      .split("\n")
+      .find((l) => l.startsWith("Reviewed by "));
+    expect(footerLine).toBeDefined();
+    const occurrences = footerLine!.match(/anthropic\/claude-sonnet-4-6/g) ?? [];
+    expect(occurrences).toHaveLength(1);
+  });
+
+  it("falls back to modelUsed in the footer when consensusMetadata is absent", () => {
+    const review = makeReview({
+      modelUsed: "openai/gpt-5-mini",
+      tokenCount: 12345,
+    });
+
     const result = formatSummaryComment(review);
 
-    expect(result).toContain("Reviewed by anthropic/claude-sonnet-4-6 ·");
-    expect(result).not.toContain("anthropic/claude-sonnet-4-6, anthropic/claude-sonnet-4-6");
+    expect(result).toContain("Reviewed by openai/gpt-5-mini · 12345 tokens");
+  });
+
+  it("falls back to modelUsed when passModels is an empty array", () => {
+    const review = makeReview({
+      modelUsed: "openai/gpt-5-mini",
+      tokenCount: 12345,
+      consensusMetadata: {
+        passes: 1,
+        threshold: 1,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good"],
+        passModels: [],
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("Reviewed by openai/gpt-5-mini · 12345 tokens");
   });
 
   it("renders a clean review with zero findings", () => {

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -86,6 +86,52 @@ describe("formatSummaryComment", () => {
     expect(result).toContain("Reviewed by claude-opus-4-20250514 · 50000 tokens");
   });
 
+  it("renders all distinct pass models in the footer when consensus ran multiple models", () => {
+    const review = makeReview({
+      modelUsed: "openai/gpt-5-mini",
+      tokenCount: 30000,
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 0.6,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "address_before_merge"],
+        passModels: ["openai/gpt-5-mini", "moonshot/kimi-k2.5", "minimaxi/MiniMax-M2.7"],
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain(
+      "Reviewed by openai/gpt-5-mini, moonshot/kimi-k2.5, minimaxi/MiniMax-M2.7 · 30000 tokens",
+    );
+  });
+
+  it("dedupes pass models when the same model ran multiple passes", () => {
+    const review = makeReview({
+      modelUsed: "anthropic/claude-sonnet-4-6",
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good", "looks_good"],
+        passModels: [
+          "anthropic/claude-sonnet-4-6",
+          "anthropic/claude-sonnet-4-6",
+          "anthropic/claude-sonnet-4-6",
+        ],
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("Reviewed by anthropic/claude-sonnet-4-6 ·");
+    expect(result).not.toContain("anthropic/claude-sonnet-4-6, anthropic/claude-sonnet-4-6");
+  });
+
   it("renders a clean review with zero findings", () => {
     const review = makeReview({
       recommendation: "looks_good",

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -333,7 +333,12 @@ export function formatSummaryComment(
   lines.push("");
   lines.push("---");
   lines.push("");
-  const parts = [`Reviewed by ${review.modelUsed} · ${review.tokenCount} tokens (review)`];
+  const passModels = review.consensusMetadata?.passModels;
+  const reviewerLabel =
+    passModels && passModels.length > 0
+      ? Array.from(new Set(passModels)).join(", ")
+      : review.modelUsed;
+  const parts = [`Reviewed by ${reviewerLabel} · ${review.tokenCount} tokens (review)`];
   if (review.judgeTokenCount !== undefined) {
     parts.push(`${review.judgeTokenCount} tokens (judge)`);
   }


### PR DESCRIPTION
## Summary

After enabling multi-model consensus voting in PR #111, the rusty-bot's own review comments still attributed the work to a single model:

> Reviewed by `requesty/openai/gpt-5-mini` · 6124 tokens (review) · 0 tokens (judge) · 0 low-confidence findings filtered

…even though three different models actually ran (gpt-5-mini, kimi-k2.5, MiniMax-M2.7). The footer was reading `review.modelUsed`, which is just the first pass's model.

This PR uses `consensusMetadata.passModels` (already populated by `runConsensus`) and joins the deduped list:

> Reviewed by `openai/gpt-5-mini, moonshot/kimi-k2.5, minimaxi/MiniMax-M2.7` · 30000 tokens (review) · …

When `passModels` is unset (single-model run, no consensus, or older results) it falls back to `modelUsed` — backward-compatible with every existing caller and test.

## Test plan

- [x] `pnpm --filter @rusty-bot/core test` — 599 tests pass, including 2 new ones:
  - renders all distinct pass models in the footer when consensus ran multiple models
  - dedupes pass models when the same model ran multiple passes
- [ ] Verify on a real PR run that the comment footer lists all three review models