### PR TITLE
fix(ci): set kimi-k2.5 review pass temperature to 1

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -34,7 +34,10 @@ jobs:
           RUSTY_LLM_MODEL: requesty/openai/gpt-5-mini
           RUSTY_REVIEW_MODELS: requesty/openai/gpt-5-mini,requesty/moonshot/kimi-k2.5,requesty/minimaxi/MiniMax-M2.7
           RUSTY_REVIEW_TEMPERATURE: "0.2"
-          RUSTY_REVIEW_TEMPERATURES: "0.2,0.2,0.3"
+          # kimi-k2.5 hard-rejects any temperature other than 1; per-pass list
+          # lets the other models stay at low-variance settings while letting
+          # kimi run.
+          RUSTY_REVIEW_TEMPERATURES: "0.2,1,0.3"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_JUDGE_ENABLED: "true"
           RUSTY_JUDGE_MODEL: requesty/anthropic/claude-sonnet-4-6


### PR DESCRIPTION
## Summary

The Rusty Bot CI run on PR #108 ([failed run](https://github.com/jegork/rusty-bot/actions/runs/25259410015)) hit a hard 400 from Requesty:

> `AI_APICallError: invalid temperature: only 1 is allowed for this model` — `model: 'moonshot/kimi-k2.5'`

`kimi-k2.5` rejects any temperature other than 1 (this constraint is already documented in our own README under "Model Inference Settings"). When the multi-model stack landed on PR #111 we set `RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3`, which sends `0.2` to Kimi and breaks pass 2.

This PR uses the per-pass list to give Kimi `1` while keeping the other passes at low-variance settings:

```diff
- RUSTY_REVIEW_TEMPERATURES: "0.2,0.2,0.3"
+ RUSTY_REVIEW_TEMPERATURES: "0.2,1,0.3"
```

## Test plan

- [ ] Next workflow run on this PR completes all 3 review passes without temperature 400s