### PR TITLE
fix: apply per-model temperature constraints across all agent paths

### DIFF
--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -96,6 +96,23 @@ describe("runConsensusReview", () => {
     expect(result.consensusMetadata).toBeUndefined();
   });
 
+  it("uses RUSTY_REVIEW_MODELS[0] / RUSTY_REVIEW_TEMPERATURES[0] on the single-pass path", async () => {
+    process.env.RUSTY_REVIEW_MODELS = "anthropic/single-pass-model,requesty/moonshot/kimi-k2.5";
+    process.env.RUSTY_REVIEW_TEMPERATURES = "0.2,1";
+    process.env.RUSTY_LLM_MODEL = "requesty/moonshot/kimi-k2.5";
+
+    const singlePassConfig = { ...config, consensusPasses: 1 };
+    await runConsensusReview([], singlePassConfig, prMetadata, "diff content");
+    const { runReview } = await import("../agent/review.js");
+    const calls = (runReview as ReturnType<typeof vi.fn>).mock.calls;
+
+    expect(calls[0][4]?.modelConfig).toEqual({
+      type: "router",
+      model: "anthropic/single-pass-model",
+    });
+    expect(calls[0][4]?.modelSettings).toEqual({ temperature: 0.2 });
+  });
+
   it("runs N passes and filters by majority vote", async () => {
     const consensusConfig = { ...config, consensusPasses: 3 };
     const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -20,6 +20,7 @@ vi.mock("../agent/model.js", () => ({
   ),
   resolveModelSettings: vi.fn(() => ({})),
   resolveDefaultAgentOptions: vi.fn(() => undefined),
+  applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
 
 const { judgeFindings, judgeReviewResult, resolveJudgeConfig } = await import("../agent/judge.js");

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -7,6 +7,7 @@ import {
   getModelDisplayName,
   resolveDefaultAgentOptions,
   supportsAnthropicCacheControl,
+  applyModelConstraints,
 } from "../agent/model.js";
 
 function clearEnv() {
@@ -131,6 +132,54 @@ describe("resolveReviewPassModelConfigs", () => {
       { temperature: 0.2, topP: 0.8 },
       { temperature: 0.5, topP: 0.8 },
     ]);
+  });
+
+  it("forces temperature=1 for kimi-k2.5 even when the per-pass list says otherwise", () => {
+    process.env.RUSTY_REVIEW_MODELS = "anthropic/claude-sonnet,requesty/moonshot/kimi-k2.5";
+    process.env.RUSTY_REVIEW_TEMPERATURES = "0.2,0.2";
+
+    const configs = resolveReviewPassModelConfigs(2);
+
+    expect(configs[0].settings.temperature).toBe(0.2);
+    expect(configs[1].settings.temperature).toBe(1);
+  });
+});
+
+describe("applyModelConstraints", () => {
+  beforeEach(clearEnv);
+
+  it("forces temperature=1 for moonshot/kimi-k2.5 router models", () => {
+    const settings = applyModelConstraints(
+      { type: "router", model: "requesty/moonshot/kimi-k2.5" },
+      { temperature: 0.2, topP: 0.9 },
+    );
+    expect(settings).toEqual({ temperature: 1, topP: 0.9 });
+  });
+
+  it("matches kimi-k2.5 even without a routing prefix", () => {
+    const settings = applyModelConstraints(
+      { type: "router", model: "moonshot/kimi-k2.5" },
+      { temperature: 0.4 },
+    );
+    expect(settings.temperature).toBe(1);
+  });
+
+  it("leaves settings unchanged when temperature is already at the locked value", () => {
+    const original = { temperature: 1, topP: 0.5 };
+    const settings = applyModelConstraints(
+      { type: "router", model: "requesty/moonshot/kimi-k2.5" },
+      original,
+    );
+    expect(settings).toBe(original);
+  });
+
+  it("returns settings unchanged for unaffected models", () => {
+    const original = { temperature: 0.2 };
+    const settings = applyModelConstraints(
+      { type: "router", model: "anthropic/claude-sonnet-4-6" },
+      original,
+    );
+    expect(settings).toBe(original);
   });
 });
 

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -809,4 +809,32 @@ describe("runCascadeReview", () => {
       expect(call[4]?.openGrepFindings).toBeUndefined();
     }
   });
+
+  it("routes the skim tier through RUSTY_REVIEW_MODELS[0] / RUSTY_REVIEW_TEMPERATURES[0]", async () => {
+    process.env.RUSTY_REVIEW_MODELS = "anthropic/skim-model,requesty/moonshot/kimi-k2.5";
+    process.env.RUSTY_REVIEW_TEMPERATURES = "0.2,1";
+    process.env.RUSTY_LLM_MODEL = "requesty/moonshot/kimi-k2.5";
+    process.env.RUSTY_REVIEW_TEMPERATURE = "0.2";
+
+    try {
+      await runCascadeReview(
+        [makePatch("tests/test_auth.py", 20)],
+        [],
+        config,
+        prMetadata,
+        undefined,
+      );
+
+      const skimCalls = runReviewMock.mock.calls.filter((call) => call[4]?.tier === "skim");
+      expect(skimCalls.length).toBeGreaterThanOrEqual(1);
+      const skimOpts = skimCalls[0][4];
+      expect(skimOpts?.modelConfig).toEqual({ type: "router", model: "anthropic/skim-model" });
+      expect(skimOpts?.modelSettings).toEqual({ temperature: 0.2 });
+    } finally {
+      delete process.env.RUSTY_REVIEW_MODELS;
+      delete process.env.RUSTY_REVIEW_TEMPERATURES;
+      delete process.env.RUSTY_LLM_MODEL;
+      delete process.env.RUSTY_REVIEW_TEMPERATURE;
+    }
+  });
 });

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -15,6 +15,8 @@ vi.mock("../agent/model.js", () => ({
   getModelDisplayName: vi.fn(() => "test-model"),
   resolveModelSettings: vi.fn(() => ({})),
   resolveDefaultAgentOptions: vi.fn(() => undefined),
+  supportsAnthropicCacheControl: vi.fn(() => false),
+  applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
 
 const { runReview } = await import("../agent/review.js");

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -110,7 +110,12 @@ export async function runConsensusReview(
   const passes = passPlan.passes;
 
   if (passes <= 1) {
-    return runReview(config, diff, prMetadata, ticketContext, options);
+    const [singlePassModel] = resolveReviewPassModelConfigs(1);
+    return runReview(config, diff, prMetadata, ticketContext, {
+      ...options,
+      modelConfig: options?.modelConfig ?? singlePassModel.config,
+      modelSettings: options?.modelSettings ?? singlePassModel.settings,
+    });
   }
 
   const threshold = deriveConsensusThreshold(config.consensusThreshold, passes);

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -7,6 +7,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
   resolveDefaultAgentOptions,
+  applyModelConstraints,
 } from "./model.js";
 import type { Finding, ReviewResult } from "../types.js";
 import { logger } from "../logger.js";
@@ -159,7 +160,7 @@ export async function judgeFindings(
   let evaluations: JudgeEvaluation[];
   let tokenCount = 0;
   try {
-    const modelSettings = resolveModelSettings("judge");
+    const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("judge"));
     const response = await agent.generate(userMessage, {
       structuredOutput: { schema: JudgeOutputSchema },
       ...(Object.keys(modelSettings).length > 0 && { modelSettings }),

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -204,10 +204,30 @@ export function resolveReviewPassModelConfigs(passCount: number): ReviewPassMode
 
     return {
       config,
-      settings,
+      settings: applyModelConstraints(config, settings),
       displayName: getModelDisplayName(config),
     };
   });
+}
+
+interface HardTemperatureLock {
+  pattern: RegExp;
+  temperature: number;
+}
+
+const HARD_TEMPERATURE_LOCKS: HardTemperatureLock[] = [
+  { pattern: /moonshot\/kimi-k2\.5/i, temperature: 1 },
+];
+
+function findHardTemperatureLock(displayName: string): HardTemperatureLock | undefined {
+  return HARD_TEMPERATURE_LOCKS.find((entry) => entry.pattern.test(displayName));
+}
+
+export function applyModelConstraints(config: ModelConfig, settings: ModelSettings): ModelSettings {
+  const lock = findHardTemperatureLock(getModelDisplayName(config));
+  if (!lock) return settings;
+  if (settings.temperature === lock.temperature) return settings;
+  return { ...settings, temperature: lock.temperature };
 }
 
 export function getModelDisplayName(config: ModelConfig): string {

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -21,6 +21,7 @@ import type { OpenGrepFinding } from "../opengrep/types.js";
 import { runReview, type RunReviewOptions, type ReviewTier } from "./review.js";
 import { runConsensusReview } from "./consensus.js";
 import { judgeReviewResult, resolveJudgeConfig } from "./judge.js";
+import { resolveReviewPassModelConfigs } from "./model.js";
 import type { McpServerConfig } from "../mcp/types.js";
 import { connectMcpServers } from "../mcp/client.js";
 import { logger } from "../logger.js";
@@ -307,10 +308,16 @@ async function runTieredReview(
   };
 
   if (tier === "skim") {
+    const [skimPassModel] = resolveReviewPassModelConfigs(1);
+    const skimOptions: RunReviewOptions = {
+      ...tierOptions,
+      modelConfig: tierOptions.modelConfig ?? skimPassModel.config,
+      modelSettings: tierOptions.modelSettings ?? skimPassModel.settings,
+    };
     const { compressed, skippedFiles } = compressDiff(patches, maxTokens);
     if (skippedFiles.length === 0) {
       const result = await runReview(config, compressed, prMetadata, ticketContext, {
-        ...tierOptions,
+        ...skimOptions,
         chunkFiles: patches.map((p) => p.path),
       });
       return [result];
@@ -323,7 +330,7 @@ async function runTieredReview(
       const { compressed: groupDiff } = compressDiff(groups[i], maxTokens);
       const groupTickets = i === 0 ? ticketContext : undefined;
       const result = await runReview(config, groupDiff, prMetadata, groupTickets, {
-        ...tierOptions,
+        ...skimOptions,
         openGrepFindings: groupOpenGrep,
         chunkFiles: [...groupPaths],
       });

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -9,6 +9,7 @@ import {
   resolveModelSettings,
   resolveDefaultAgentOptions,
   supportsAnthropicCacheControl,
+  applyModelConstraints,
 } from "./model.js";
 import type { ModelConfig, ModelSettings } from "./model.js";
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
@@ -161,7 +162,8 @@ export async function runReview(
 
   const schema = tier === "skim" ? SkimReviewOutputSchema : ReviewOutputSchema;
 
-  const modelSettings = options?.modelSettings ?? resolveModelSettings("review");
+  const rawModelSettings = options?.modelSettings ?? resolveModelSettings("review");
+  const modelSettings = applyModelConstraints(modelConfig, rawModelSettings);
   const response = await generateWithTransientRetry(() =>
     generateWithStructuredOutputRetry(() =>
       agent.generate(userMessage, {

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -5,6 +5,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  applyModelConstraints,
 } from "../agent/model.js";
 import { PRDescriptionOutputSchema, type PRDescriptionOutput } from "./schema.js";
 import { buildDescriptionSystemPrompt, buildDescriptionUserMessage } from "./prompt.js";
@@ -110,7 +111,7 @@ export async function generatePRDescription(
 
   const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription);
 
-  const modelSettings = resolveModelSettings("description");
+  const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("description"));
   const response = await agent.generate(userMessage, {
     structuredOutput: { schema: PRDescriptionOutputSchema },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),

--- a/packages/core/src/title/generate.ts
+++ b/packages/core/src/title/generate.ts
@@ -5,6 +5,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  applyModelConstraints,
 } from "../agent/model.js";
 import { ConventionalTitleOutputSchema, type ConventionalTitleOutput } from "./schema.js";
 import { buildTitleSystemPrompt, buildTitleUserMessage } from "./prompt.js";
@@ -38,7 +39,7 @@ export async function generateConventionalTitle(
 
   const userMessage = buildTitleUserMessage(compressed, prMetadata);
 
-  const modelSettings = resolveModelSettings("title");
+  const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("title"));
   const response = await agent.generate(userMessage, {
     structuredOutput: { schema: ConventionalTitleOutputSchema },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -9,6 +9,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
   resolveDefaultAgentOptions,
+  applyModelConstraints,
 } from "../agent/model.js";
 import { normalizePath } from "../agent/multi-call.js";
 import { countTokens } from "../diff/compress.js";
@@ -121,7 +122,7 @@ export async function runTriage(
   });
 
   const triageMessage = buildTriageUserMessage(triageablePatches);
-  const modelSettings = resolveModelSettings("triage");
+  const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("triage"));
   const response = await agent.generate(triageMessage, {
     structuredOutput: { schema: TriageOutputSchema },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),


### PR DESCRIPTION
## Summary

- Wire `RUSTY_REVIEW_MODELS[0]` / `RUSTY_REVIEW_TEMPERATURES[0]` into the **skim tier** and the **consensus single-pass path** so per-pass settings are honored regardless of pass count. Previously these paths fell back to the singleton `RUSTY_LLM_MODEL` + `RUSTY_REVIEW_TEMPERATURE` and ignored the per-pass list entirely.
- Introduce `applyModelConstraints(config, settings)` with a `HARD_TEMPERATURE_LOCKS` table that force-coerces `moonshot/kimi-k2.5` to `temperature: 1` at every `agent.generate` call site (review, triage, judge, title, description). kimi-k2.5 hard-rejects any other temperature with HTTP 400; this guard makes that failure structurally impossible regardless of which env var or code path resolves the model.

## Why

When `RUSTY_LLM_MODEL=requesty/moonshot/kimi-k2.5` and `RUSTY_REVIEW_TEMPERATURE=0.2`, the skim tier in cascade mode (and the single-pass deep-review fallback) called kimi at temp 0.2 and got `400 invalid temperature: only 1 is allowed for this model` from the provider. The per-pass `RUSTY_REVIEW_TEMPERATURES="0.2,1,0.3"` mapping was only consulted from `runConsensusReview` → `resolveReviewPassModelConfigs`, not from these other paths.

## Test plan

- [x] `pnpm --filter @rusty-bot/core test` — 612/612 pass (5 new assertions covering the kimi temperature lock + the skim/single-pass routing)
- [x] `pnpm tsc` — clean across all packages