### PR TITLE
feat: auto-fallback to prompt-injected JSON for non-json_schema models

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,8 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_GENERATE_DESCRIPTION` | generate PR description when empty/placeholder | `false` |
 | `RUSTY_RENAME_TITLE_TO_CONVENTIONAL` | rewrite non-conventional PR titles into Conventional Commits format | `false` |
 | `RUSTY_LLM_MAX_RETRIES` | application-level retries on transient LLM errors (max 2) | `2` |
+| `RUSTY_LLM_JSON_PROMPT_INJECTION` | comma-separated model IDs (or `prefix*` wildcards) to force-on prompt-injected JSON output, overriding the auto-detected default | — |
+| `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT` | comma-separated model IDs (or `prefix*` wildcards) to force-on native `json_schema` structured output, overriding the auto-detected default | — |
 | `RUSTY_LLM_TEMPERATURE` | global LLM temperature | provider default |
 | `RUSTY_LLM_TOP_P` | global LLM top-p | provider default |
 | `RUSTY_REVIEW_TEMPERATURE` | temperature override for the review agent | `RUSTY_LLM_TEMPERATURE` |
@@ -354,6 +356,27 @@ RUSTY_DESCRIPTION_TEMPERATURE=0.5
 ```
 
 Some models enforce a fixed temperature (e.g. `moonshot/kimi-k2.5` only accepts `temperature=1`). Use the per-agent override when you run different models per agent.
+
+### Structured Output Compatibility
+
+Mastra asks the model to return findings as a typed JSON object via `response_format: json_schema`. Some providers (notably MiniMax M2.x and DeepSeek V4 in thinking mode) do not implement that protocol, and routers like Requesty only proxy `json_schema` for OpenAI / Anthropic / Google / Moonshot today. When the model can't honour the schema, the response comes back empty and the review pass fails with `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED`.
+
+Rusty Bot detects this automatically and falls back to **prompt-injected JSON** for non-supported model strings (Mastra's `jsonPromptInjection: true`) — the schema is added to the system prompt and Mastra parses the JSON out of the text response. The default rule is:
+
+- Native `json_schema`: any model whose ID starts with `openai/`, `anthropic/`, `google/`, `azure-openai/`, `requesty/openai/`, `requesty/anthropic/`, `requesty/google/`, or `requesty/moonshot/`. Azure (API key or managed identity) and OpenAI-compatible endpoints also default to native.
+- Prompt injection: everything else (e.g. `requesty/minimaxi/...`, `requesty/deepseek/...`, `requesty/qwen/...`).
+
+Override the default per model with two env vars (CSV; trailing-`*` matches a prefix):
+
+```bash
+# force prompt injection (escape hatch when a "supported" model regresses)
+RUSTY_LLM_JSON_PROMPT_INJECTION=requesty/openai/gpt-5-pro,requesty/google/*
+
+# force native json_schema (when a custom proxy translates it correctly)
+RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=requesty/deepseek/deepseek-v4-pro
+```
+
+Force-on takes precedence over force-off when the same model appears in both lists.
 
 ### Per-Repository Configuration
 

--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -112,6 +112,12 @@ Consensus uses `Promise.allSettled` so a single flaky pass does not fail the who
 - If at least `consensusThreshold` passes succeed, consensus is formed from the surviving passes and `consensusMetadata.failedPasses` records how many threw.
 - If fewer than `consensusThreshold` passes succeed, the review throws an `AggregateError` containing every pass failure.
 
+## Structured output compatibility
+
+Some models in the Balanced and Budget stacks above (notably `requesty/minimaxi/MiniMax-M2.7` and `requesty/deepseek/deepseek-v4-pro`) do not support native `response_format: json_schema` — Requesty's `json_schema` only proxies for OpenAI, Anthropic, Google, and Moonshot. Rusty Bot detects this automatically and falls back to Mastra's `jsonPromptInjection: true` (schema injected into the system prompt; JSON parsed from the text response).
+
+Override the default with `RUSTY_LLM_JSON_PROMPT_INJECTION` (force prompt injection) or `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT` (force native `json_schema`). Both accept CSV with trailing-`*` prefix wildcards. See the README's _Structured Output Compatibility_ section for details.
+
 ## Cost
 
 With the default 3 passes, LLM cost per review triples. Combine with [cascading review](/guides/cascading-review/) and/or the [judge pass](/guides/judge-pass/) (using a cheaper model) to offset costs.

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -6,7 +6,9 @@ import {
   resolveReviewPassModelConfigs,
   getModelDisplayName,
   resolveDefaultAgentOptions,
+  resolveJsonPromptInjection,
   supportsAnthropicCacheControl,
+  supportsNativeStructuredOutput,
   applyModelConstraints,
 } from "../agent/model.js";
 
@@ -29,6 +31,8 @@ function clearEnv() {
   delete process.env.RUSTY_LLM_API_KEY;
   delete process.env.REQUESTY_API_KEY;
   delete process.env.RUSTY_PROMPT_CACHE;
+  delete process.env.RUSTY_LLM_JSON_PROMPT_INJECTION;
+  delete process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT;
 }
 
 describe("resolveModelConfig", () => {
@@ -275,6 +279,203 @@ describe("supportsAnthropicCacheControl", () => {
         baseUrl: "https://example.com/v1",
         model: "anthropic/claude-sonnet-4",
       }),
+    ).toBe(false);
+  });
+});
+
+describe("supportsNativeStructuredOutput", () => {
+  it("returns true for direct openai/anthropic/google/azure-openai router prefixes", () => {
+    expect(supportsNativeStructuredOutput({ type: "router", model: "openai/gpt-5-mini" })).toBe(
+      true,
+    );
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "anthropic/claude-sonnet-4-6" }),
+    ).toBe(true);
+    expect(supportsNativeStructuredOutput({ type: "router", model: "google/gemini-3.1-pro" })).toBe(
+      true,
+    );
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "azure-openai/my-deployment" }),
+    ).toBe(true);
+  });
+
+  it("returns true for requesty-routed openai/anthropic/google/moonshot", () => {
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "requesty/openai/gpt-5-mini" }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "router",
+        model: "requesty/anthropic/claude-sonnet-4-6",
+      }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "requesty/google/gemini-3.1-pro" }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "requesty/moonshot/kimi-k2.6" }),
+    ).toBe(true);
+  });
+
+  it("returns false for requesty-routed providers without verified json_schema support", () => {
+    expect(
+      supportsNativeStructuredOutput({
+        type: "router",
+        model: "requesty/minimaxi/MiniMax-M2.7",
+      }),
+    ).toBe(false);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "router",
+        model: "requesty/deepseek/deepseek-v4-pro",
+      }),
+    ).toBe(false);
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "requesty/qwen/qwen3-coder" }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-listed direct router providers", () => {
+    expect(
+      supportsNativeStructuredOutput({ type: "router", model: "deepseek/deepseek-v4-pro" }),
+    ).toBe(false);
+    expect(supportsNativeStructuredOutput({ type: "router", model: "minimaxi/MiniMax-M2.7" })).toBe(
+      false,
+    );
+  });
+
+  it("returns true for azure configs", () => {
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-api-key",
+        resourceName: "r",
+        deploymentName: "d",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-managed-identity",
+        resourceName: "r",
+        deploymentName: "d",
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for openai-compatible configs (assumes proxy translates json_schema)", () => {
+    expect(
+      supportsNativeStructuredOutput({
+        type: "openai-compatible",
+        baseUrl: "https://litellm.example/v1",
+        model: "gpt-4o",
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("resolveJsonPromptInjection", () => {
+  beforeEach(clearEnv);
+
+  it("returns false (use native) for providers in the supported list", () => {
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
+    ).toBe(false);
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/moonshot/kimi-k2.6" }),
+    ).toBe(false);
+  });
+
+  it("returns true (inject prompt) for providers outside the supported list", () => {
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/minimaxi/MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/deepseek/deepseek-v4-pro",
+      }),
+    ).toBe(true);
+  });
+
+  it("force-on env var overrides default for an exact model match", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "requesty/openai/gpt-5-mini";
+
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
+    ).toBe(true);
+    expect(resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-pro" })).toBe(
+      false,
+    );
+  });
+
+  it("force-on env var supports trailing-* prefix wildcards", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "requesty/minimaxi/*,requesty/deepseek/*";
+
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/minimaxi/MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/deepseek/deepseek-v4-pro",
+      }),
+    ).toBe(true);
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
+    ).toBe(false);
+  });
+
+  it("force-off env var overrides the default-injection path", () => {
+    process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT = "requesty/minimaxi/MiniMax-M2.7";
+
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/minimaxi/MiniMax-M2.7",
+      }),
+    ).toBe(false);
+  });
+
+  it("force-on takes precedence over force-off for the same model", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "requesty/openai/gpt-5-mini";
+    process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT = "requesty/openai/gpt-5-mini";
+
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
+    ).toBe(true);
+  });
+
+  it("matches azure configs against azure-openai/<deployment>", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "azure-openai/my-deployment";
+
+    expect(
+      resolveJsonPromptInjection({
+        type: "azure-api-key",
+        resourceName: "r",
+        deploymentName: "my-deployment",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+  });
+
+  it("ignores empty env vars and falls back to default", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "";
+    process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT = "";
+
+    expect(
+      resolveJsonPromptInjection({
+        type: "router",
+        model: "requesty/minimaxi/MiniMax-M2.7",
+      }),
+    ).toBe(true);
+    expect(
+      resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
     ).toBe(false);
   });
 });

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -9,12 +9,15 @@ vi.mock("@mastra/core/agent", () => ({
   }),
 }));
 
+const resolveJsonPromptInjectionMock = vi.fn(() => false);
+
 vi.mock("../agent/model.js", () => ({
   resolveModelConfig: vi.fn(() => ({ type: "router", model: "test-model" })),
   resolveModel: vi.fn(() => "test-model"),
   getModelDisplayName: vi.fn(() => "test-model"),
   resolveModelSettings: vi.fn(() => ({})),
   resolveDefaultAgentOptions: vi.fn(() => undefined),
+  resolveJsonPromptInjection: resolveJsonPromptInjectionMock,
   supportsAnthropicCacheControl: vi.fn(() => false),
   applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
@@ -143,6 +146,33 @@ describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => 
 
     await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("provider timeout");
     expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("runReview jsonPromptInjection forwarding", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+    resolveJsonPromptInjectionMock.mockReset();
+  });
+
+  it("forwards jsonPromptInjection=true into structuredOutput when resolver returns true", async () => {
+    resolveJsonPromptInjectionMock.mockReturnValueOnce(true);
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const callArgs = generateMock.mock.calls[0][1];
+    expect(callArgs.structuredOutput.jsonPromptInjection).toBe(true);
+  });
+
+  it("forwards jsonPromptInjection=false into structuredOutput when resolver returns false", async () => {
+    resolveJsonPromptInjectionMock.mockReturnValueOnce(false);
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const callArgs = generateMock.mock.calls[0][1];
+    expect(callArgs.structuredOutput.jsonPromptInjection).toBe(false);
   });
 });
 

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -124,6 +124,67 @@ export function supportsAnthropicCacheControl(config: ModelConfig): boolean {
   return config.model.includes("anthropic/");
 }
 
+const NATIVE_STRUCTURED_OUTPUT_ROUTER_PREFIXES = [
+  "openai/",
+  "anthropic/",
+  "google/",
+  "azure-openai/",
+  "requesty/openai/",
+  "requesty/anthropic/",
+  "requesty/google/",
+  "requesty/moonshot/",
+];
+
+export function supportsNativeStructuredOutput(config: ModelConfig): boolean {
+  switch (config.type) {
+    case "azure-api-key":
+    case "azure-managed-identity":
+      return true;
+    case "openai-compatible":
+      return true;
+    case "router":
+      return NATIVE_STRUCTURED_OUTPUT_ROUTER_PREFIXES.some((prefix) =>
+        config.model.startsWith(prefix),
+      );
+  }
+}
+
+function modelMatchKey(config: ModelConfig): string {
+  switch (config.type) {
+    case "router":
+      return config.model;
+    case "openai-compatible":
+      return config.model;
+    case "azure-api-key":
+    case "azure-managed-identity":
+      return `azure-openai/${config.deploymentName}`;
+  }
+}
+
+function matchesAny(modelKey: string, patterns: string[]): boolean {
+  for (const pattern of patterns) {
+    if (pattern.endsWith("*")) {
+      const prefix = pattern.slice(0, -1);
+      if (modelKey.startsWith(prefix)) return true;
+    } else if (modelKey === pattern) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export function resolveJsonPromptInjection(config: ModelConfig): boolean {
+  const key = modelMatchKey(config);
+
+  const forceOn = readCsvEnv("RUSTY_LLM_JSON_PROMPT_INJECTION");
+  if (forceOn.length > 0 && matchesAny(key, forceOn)) return true;
+
+  const forceOff = readCsvEnv("RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT");
+  if (forceOff.length > 0 && matchesAny(key, forceOff)) return false;
+
+  return !supportsNativeStructuredOutput(config);
+}
+
 export interface ModelSettings {
   temperature?: number;
   topP?: number;

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -8,6 +8,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
   resolveDefaultAgentOptions,
+  resolveJsonPromptInjection,
   supportsAnthropicCacheControl,
   applyModelConstraints,
 } from "./model.js";
@@ -164,10 +165,11 @@ export async function runReview(
 
   const rawModelSettings = options?.modelSettings ?? resolveModelSettings("review");
   const modelSettings = applyModelConstraints(modelConfig, rawModelSettings);
+  const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
   const response = await generateWithTransientRetry(() =>
     generateWithStructuredOutputRetry(() =>
       agent.generate(userMessage, {
-        structuredOutput: { schema },
+        structuredOutput: { schema, jsonPromptInjection },
         ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
       }),
     ),


### PR DESCRIPTION
## Summary

- Detects models that don't honor `response_format: json_schema` (notably `requesty/minimaxi/*` and `requesty/deepseek/*`) and passes Mastra's `structuredOutput.jsonPromptInjection: true` so the schema is added to the system prompt and JSON is parsed from the text response — no more `STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED` for these providers.
- Native `json_schema` is preserved for `openai/`, `anthropic/`, `google/`, `azure-openai/`, and `requesty/{openai,anthropic,google,moonshot}/*` (the providers Requesty actually proxies `json_schema` for, plus Azure OpenAI direct).
- Adds two env vars to override the auto-detected default per model: `RUSTY_LLM_JSON_PROMPT_INJECTION` (force prompt injection) and `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT` (force native). Both accept CSV with trailing-`*` prefix wildcards. Force-on wins ties.

## Why

Production logs show every consensus pass on `requesty/minimaxi/MiniMax-M2.7` failing with `Invalid input: expected object, received undefined` at root path `[]` — meaning the AI SDK couldn't extract any structured object at all. Root causes:

- [Requesty docs](https://docs.requesty.ai/features/structured-outputs): "JSON schema is available for OpenAI, Anthropic, and Google models" — everything else falls through to plain `json_object` mode at best.
- [MiniMax M2.5 issue #4](https://github.com/MiniMax-AI/MiniMax-M2.5/issues/4): native API does not support `response_format` (neither `json_object` nor `json_schema`).
- [vllm#41132](https://github.com/vllm-project/vllm/issues/41132): DeepSeek V4 emits incorrect structured output when thinking mode is on.

[Mastra's `jsonPromptInjection`](https://mastra.ai/reference/agents/generate) is the documented escape hatch for exactly this case — use the schema as a prompt instruction and parse the text response.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r test` — 786 tests passing across 7 packages
- [x] `pnpm lint` clean
- [x] Unit tests cover each `ModelConfig` variant for `supportsNativeStructuredOutput` and the override-env precedence rules for `resolveJsonPromptInjection` (exact match, `prefix*` wildcard, force-on/off precedence, azure deployment matching, empty-env fallback)
- [x] `runReview` test asserts `jsonPromptInjection` is forwarded into `agent.generate({ structuredOutput: { ... } })`
- [ ] Verify in production by setting `RUSTY_REVIEW_MODELS` to include `requesty/minimaxi/MiniMax-M2.7` and confirming the pass succeeds where it previously threw