### PR TITLE
fix(docker): include packages/cli/package.json in workspace install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/
+COPY packages/cli/package.json ./packages/cli/
 COPY packages/github/package.json ./packages/github/
 COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/
@@ -42,6 +43,7 @@ RUN corepack enable
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY packages/core/package.json ./packages/core/
+COPY packages/cli/package.json ./packages/cli/
 COPY packages/github/package.json ./packages/github/
 COPY packages/github-action/package.json ./packages/github-action/
 COPY packages/azure-devops/package.json ./packages/azure-devops/


### PR DESCRIPTION
## Summary

The `packages/cli` workspace (added in [2177a01](https://github.com/jegork/rusty-bot/commit/2177a01)) was never added to the [Dockerfile](Dockerfile) — its `package.json` is not copied before `pnpm install`, so the workspace install skips `cli` entirely. Once `COPY . .` brings in cli's source, `pnpm -r build` tries to compile cli with no resolved deps:

```
packages/cli build: src/cli.ts(195,25): error TS2591: Cannot find name 'process'. Do you need to install type definitions for node?
packages/cli build: src/local-provider.ts(12,8): error TS2307: Cannot find module '@rusty-bot/core'
```

**Every** push to `main` since 2177a01 has failed `Publish Docker Image`. `ghcr.io/jegork/rusty-bot:latest` (what `uses: jegork/rusty-bot` pulls) has been frozen since then. That means [#128](https://github.com/jegork/rusty-bot/pull/128) (multi-model footer), [#131](https://github.com/jegork/rusty-bot/pull/131) (per-model temperature constraints), and the json-prompt-injection PR (once merged) have not reached production action users — explaining why PR comments still say "Reviewed by openai/gpt-5-mini" instead of listing all consensus models.

## Fix

Add `COPY packages/cli/package.json ./packages/cli/` to both the build stage and runtime stage `COPY` blocks. With cli registered as a workspace member, `pnpm install` properly hoists `@types/node` from transitive deps and creates the `@rusty-bot/core` workspace symlink, so `tsc` in `packages/cli` can resolve everything.

## Test plan

- [x] `pnpm -r build` clean locally
- [x] `pnpm -r test` — 768 tests passing across 7 packages
- [ ] After merge, watch the next `Publish Docker Image` run and confirm a fresh `ghcr.io/jegork/rusty-bot:latest` is pushed
- [ ] Re-trigger `Rusty Bot Review` on a PR and confirm the footer renders all 3 (or adaptive 2) consensus models, not just the first

## Notes

The runtime stage doesn't strictly need cli's `dist` for the published action paths (action invokes `github-action`/`azure-devops`/`gitlab`/`github` entrypoints), but adding cli's `package.json` to the runtime stage too keeps the workspace shape consistent and unblocks future `rusty-bot` CLI distribution from this image.