### PR TITLE
feat: treat requesty/fireworks/* as native json_schema and switch CI to fireworks v4-pro

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -32,12 +32,12 @@ jobs:
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
           RUSTY_LLM_MODEL: requesty/openai/gpt-5-mini
-          RUSTY_REVIEW_MODELS: requesty/openai/gpt-5-mini,requesty/moonshot/kimi-k2.5,requesty/minimaxi/MiniMax-M2.7
+          RUSTY_REVIEW_MODELS: requesty/moonshot/kimi-k2.5,requesty/fireworks/deepseek-v4-pro,requesty/minimaxi/MiniMax-M2.7
           RUSTY_REVIEW_TEMPERATURE: "0.2"
           # kimi-k2.5 hard-rejects any temperature other than 1; per-pass list
           # lets the other models stay at low-variance settings while letting
           # kimi run.
-          RUSTY_REVIEW_TEMPERATURES: "0.2,1,0.3"
+          RUSTY_REVIEW_TEMPERATURES: "1,0.2,0.3"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_JUDGE_ENABLED: "true"
           RUSTY_JUDGE_MODEL: requesty/anthropic/claude-sonnet-4-6

--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ Mastra asks the model to return findings as a typed JSON object via `response_fo
 
 Rusty Bot detects this automatically and falls back to **prompt-injected JSON** for non-supported model strings (Mastra's `jsonPromptInjection: true`) — the schema is added to the system prompt and Mastra parses the JSON out of the text response. The default rule is:
 
-- Native `json_schema`: any model whose ID starts with `openai/`, `anthropic/`, `google/`, `azure-openai/`, `requesty/openai/`, `requesty/anthropic/`, `requesty/google/`, or `requesty/moonshot/`. Azure (API key or managed identity) and OpenAI-compatible endpoints also default to native.
+- Native `json_schema`: any model whose ID starts with `openai/`, `anthropic/`, `google/`, `azure-openai/`, `requesty/openai/`, `requesty/anthropic/`, `requesty/google/`, `requesty/moonshot/`, or `requesty/fireworks/`. Azure (API key or managed identity) and OpenAI-compatible endpoints also default to native.
 - Prompt injection: everything else (e.g. `requesty/minimaxi/...`, `requesty/deepseek/...`, `requesty/qwen/...`).
 
 Override the default per model with two env vars (CSV; trailing-`*` matches a prefix):

--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -59,12 +59,14 @@ Generation runs on cheap open-weight models (3 different vendors for diversity);
 
 ```bash
 RUSTY_LLM_TRIAGE_MODEL=requesty/google/gemini-3.1-flash-lite-preview
-RUSTY_REVIEW_MODELS=requesty/deepseek/deepseek-v4-pro,requesty/moonshot/kimi-k2.6,requesty/minimaxi/MiniMax-M2.7
-RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
+RUSTY_REVIEW_MODELS=requesty/fireworks/deepseek-v4-pro,requesty/moonshot/kimi-k2.6,requesty/minimaxi/MiniMax-M2.7
+RUSTY_REVIEW_TEMPERATURES=0.2,1,0.3
 RUSTY_JUDGE_MODEL=requesty/anthropic/claude-sonnet-4-6
 RUSTY_JUDGE_TEMPERATURE=0
 RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
+
+> Use the `requesty/fireworks/` route for DeepSeek V4 Pro. Fireworks proxies `json_schema` natively and exposes the model's reasoning in a separate `reasoning_content` field, so structured output stays intact while thinking still happens. The direct `requesty/deepseek/` route currently corrupts JSON when thinking mode is on ([vllm-project/vllm#41132](https://github.com/vllm-project/vllm/issues/41132)).
 
 ### 💰 Budget — fully open-weight (~$0.05–$0.20/PR)
 
@@ -72,9 +74,9 @@ No proprietary spend. Judge moves to DeepSeek V4 Pro — the strongest open-weig
 
 ```bash
 RUSTY_LLM_TRIAGE_MODEL=requesty/google/gemini-3.1-flash-lite-preview
-RUSTY_REVIEW_MODELS=requesty/deepseek/deepseek-v4-pro,requesty/moonshot/kimi-k2.6,requesty/minimaxi/MiniMax-M2.7
-RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
-RUSTY_JUDGE_MODEL=requesty/deepseek/deepseek-v4-pro
+RUSTY_REVIEW_MODELS=requesty/fireworks/deepseek-v4-pro,requesty/moonshot/kimi-k2.6,requesty/minimaxi/MiniMax-M2.7
+RUSTY_REVIEW_TEMPERATURES=0.2,1,0.3
+RUSTY_JUDGE_MODEL=requesty/fireworks/deepseek-v4-pro
 RUSTY_JUDGE_TEMPERATURE=0
 RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
@@ -114,7 +116,7 @@ Consensus uses `Promise.allSettled` so a single flaky pass does not fail the who
 
 ## Structured output compatibility
 
-Some models in the Balanced and Budget stacks above (notably `requesty/minimaxi/MiniMax-M2.7` and `requesty/deepseek/deepseek-v4-pro`) do not support native `response_format: json_schema` — Requesty's `json_schema` only proxies for OpenAI, Anthropic, Google, and Moonshot. Rusty Bot detects this automatically and falls back to Mastra's `jsonPromptInjection: true` (schema injected into the system prompt; JSON parsed from the text response).
+Some models in the Balanced and Budget stacks above (notably `requesty/minimaxi/MiniMax-M2.7`) do not support native `response_format: json_schema` — Requesty's `json_schema` only proxies for OpenAI, Anthropic, Google, Moonshot, and Fireworks. Rusty Bot detects this automatically and falls back to Mastra's `jsonPromptInjection: true` (schema injected into the system prompt; JSON parsed from the text response).
 
 Override the default with `RUSTY_LLM_JSON_PROMPT_INJECTION` (force prompt injection) or `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT` (force native `json_schema`). Both accept CSV with trailing-`*` prefix wildcards. See the README's _Structured Output Compatibility_ section for details.
 

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -299,7 +299,7 @@ describe("supportsNativeStructuredOutput", () => {
     ).toBe(true);
   });
 
-  it("returns true for requesty-routed openai/anthropic/google/moonshot", () => {
+  it("returns true for requesty-routed openai/anthropic/google/moonshot/fireworks", () => {
     expect(
       supportsNativeStructuredOutput({ type: "router", model: "requesty/openai/gpt-5-mini" }),
     ).toBe(true);
@@ -314,6 +314,12 @@ describe("supportsNativeStructuredOutput", () => {
     ).toBe(true);
     expect(
       supportsNativeStructuredOutput({ type: "router", model: "requesty/moonshot/kimi-k2.6" }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "router",
+        model: "requesty/fireworks/deepseek-v4-pro",
+      }),
     ).toBe(true);
   });
 

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -133,6 +133,7 @@ const NATIVE_STRUCTURED_OUTPUT_ROUTER_PREFIXES = [
   "requesty/anthropic/",
   "requesty/google/",
   "requesty/moonshot/",
+  "requesty/fireworks/",
 ];
 
 export function supportsNativeStructuredOutput(config: ModelConfig): boolean {


### PR DESCRIPTION
## Summary

- Add \`requesty/fireworks/\` to the [`NATIVE_STRUCTURED_OUTPUT_ROUTER_PREFIXES`](packages/core/src/agent/model.ts) list. Fireworks via Requesty proxies \`response_format: json_schema\` cleanly and exposes the model's chain-of-thought in a separate \`reasoning_content\` field, so structured output and reasoning coexist — verified with a live request against Requesty.
- Switch our own CI's \`RUSTY_REVIEW_MODELS\` to use \`requesty/fireworks/deepseek-v4-pro\` instead of \`requesty/openai/gpt-5-mini\` for the second pass, and update the Balanced/Budget stack recipes in [consensus-voting.md](docs/src/content/docs/guides/consensus-voting.md) to recommend the same route.

## Why

Production runs on \`requesty/fireworks/deepseek-v4-pro\` were failing with \`STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED — root: Invalid input: expected object, received undefined\`. The model wasn't actually broken — \`requesty/fireworks/\` just wasn't in our native-supported prefix list, so [#133](https://github.com/jegork/rusty-bot/pull/133)'s \`resolveJsonPromptInjection\` returned \`true\` for it. Mastra then sent all three of \`response_format: json_schema\` + schema-in-system-prompt + assistant-message prefill at once, which V4-Pro doesn't tolerate, and \`response.object\` came back undefined.

A live curl against Requesty with only \`response_format: json_schema\` (no prompt-injection layering) returns:

\`\`\`json
{
  "finish_reason": "stop",
  "message": {
    "content": "{\\"findings\\": [...], \\"recommendation\\": \\"looks_good\\", \\"summary\\": \\"...\\"}",
    "reasoning_content": "We are asked to review..."
  }
}
\`\`\`

— clean structured JSON, reasoning preserved separately. So the Fireworks-docs caveat ("Using \`response_format\` with \`json_schema\` disables reasoning output") doesn't apply through Requesty's translation. Adding the prefix flips the model to the native path Mastra knows how to call, and the failure goes away.

The direct \`requesty/deepseek/\` route is still left out of the native list because of [vllm-project/vllm#41132](https://github.com/vllm-project/vllm/issues/41132) — V4-Pro corrupts JSON when its own thinking mode is on, and DeepSeek's native API doesn't have the same Requesty-side translation Fireworks does. Use the Fireworks route for V4-Pro.

## Test plan

- [x] Live curl to \`https://router.requesty.ai/v1/chat/completions\` with model \`fireworks/deepseek-v4-pro\` and \`response_format: json_schema\` — returns 200, valid JSON in \`content\`, reasoning preserved in \`reasoning_content\`
- [x] \`pnpm --filter @rusty-bot/core test\` — 628/628 passing (1 new assertion in \`supportsNativeStructuredOutput\` test)
- [x] \`pnpm -r build\` clean
- [ ] After merge, watch the next \`Rusty Bot Review\` run on a follow-up PR and confirm the second pass on \`requesty/fireworks/deepseek-v4-pro\` succeeds (no \`STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED\`) and the footer lists all three models