### PR TITLE
fix(docker): default container to root so CI handlers can provision their agent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,6 +98,9 @@ EOF
 
 RUN chmod +x /app/entrypoint.sh
 
-USER rusty
-
+# Default to root so CI container handlers (GitHub Actions, Azure Pipelines)
+# can run their in-container agent setup (groupadd, sudo provisioning) on
+# `docker exec`. Long-lived webhook deployments should drop privileges by
+# passing `--user rusty` (or `user: rusty` in compose) — the rusty user
+# is already created above with /app chowned to it.
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ cp .env.example .env
 podman compose up --build
 ```
 
+The image defaults to `root` so CI container handlers (GitHub Actions, Azure Pipelines, GitLab CI) can perform their in-container agent setup. The included `compose.yaml` drops privileges via `user: rusty` for the long-running webhook server. If you run the image standalone outside of CI and want non-root, pass `--user rusty` to `docker run` / `podman run`.
+
 ## Project Structure
 
 ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,7 @@
 services:
   rusty-bot:
     build: .
+    user: rusty
     ports:
       - "3000:3000"
     env_file: .env


### PR DESCRIPTION
## Summary

- Drop `USER rusty` from the runtime stage of the [Dockerfile](Dockerfile) so the container defaults to root
- Add `user: rusty` to [compose.yaml](compose.yaml) so the long-running webhook deployment still drops privileges
- Document the convention in the README's Podman quickstart

## Why

Azure Pipelines (and GitHub Actions per [their docs](https://docs.github.com/en/actions/sharing-automations/creating-actions/dockerfile-support-for-github-actions#user)) require root inside the container so the agent can perform its in-container setup (`groupadd azure_pipelines_sudo`, sudo provisioning) when attaching via `docker exec`. With `USER rusty` baked into the image, ADO fails the container init step with:

```
groupadd: Permission denied
groupadd: cannot lock /etc/group; try again later
##[error]Docker-exec executed: `groupadd azure_pipelines_sudo`; ... exit code: `10`
```

GHA happens to be more lenient about who runs the entrypoint so it had been working there, but it's also officially against GHA's published guidance. Defaulting to root unblocks ADO and aligns with both providers' documented expectations.

The `rusty` user and `/app` chown stay in the image, so anyone running the container outside CI (long-lived webhook server, custom orchestration) can still drop privileges with `--user rusty`. The bundled `compose.yaml` does this automatically for the webhook deployment path.

## Test plan

- [x] `docker build` succeeds locally (no behavioral change to build stage)
- [ ] After merge, watch the next ADO pipeline run and confirm the container init phase succeeds (`groupadd azure_pipelines_sudo` returns 0)
- [ ] Confirm GHA still works as before — should be unchanged since GHA was already running as root effectively
- [ ] Confirm `podman compose up` still launches the webhook server as the `rusty` user, not root, thanks to the new `user:` directive