### PR TITLE
feat: forward jsonPromptInjection through judge/triage/description/title agents

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -9,6 +9,8 @@ vi.mock("@mastra/core/agent", () => ({
   }),
 }));
 
+const resolveJsonPromptInjectionMock = vi.fn(() => false);
+
 vi.mock("../agent/model.js", () => ({
   resolveModelConfig: vi.fn(() => ({ type: "router", model: "test-model" })),
   resolveModelConfigWithOverride: vi.fn((model: string) => ({ type: "router", model })),
@@ -20,6 +22,7 @@ vi.mock("../agent/model.js", () => ({
   ),
   resolveModelSettings: vi.fn(() => ({})),
   resolveDefaultAgentOptions: vi.fn(() => undefined),
+  resolveJsonPromptInjection: resolveJsonPromptInjectionMock,
   applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
 
@@ -495,5 +498,38 @@ describe("judgeReviewResult", () => {
 
     const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
     expect(result.droppedFindings).toEqual(review.droppedFindings);
+  });
+});
+
+describe("judgeFindings jsonPromptInjection forwarding", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+    resolveJsonPromptInjectionMock.mockReset();
+  });
+
+  it("forwards jsonPromptInjection=true into structuredOutput when resolver returns true", async () => {
+    resolveJsonPromptInjectionMock.mockReturnValueOnce(true);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const callArgs = generateMock.mock.calls[0][1];
+    expect(callArgs.structuredOutput.jsonPromptInjection).toBe(true);
+  });
+
+  it("forwards jsonPromptInjection=false into structuredOutput when resolver returns false", async () => {
+    resolveJsonPromptInjectionMock.mockReturnValueOnce(false);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const callArgs = generateMock.mock.calls[0][1];
+    expect(callArgs.structuredOutput.jsonPromptInjection).toBe(false);
   });
 });

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -7,6 +7,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
   resolveDefaultAgentOptions,
+  resolveJsonPromptInjection,
   applyModelConstraints,
 } from "./model.js";
 import type { Finding, ReviewResult } from "../types.js";
@@ -161,8 +162,9 @@ export async function judgeFindings(
   let tokenCount = 0;
   try {
     const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("judge"));
+    const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
     const response = await agent.generate(userMessage, {
-      structuredOutput: { schema: JudgeOutputSchema },
+      structuredOutput: { schema: JudgeOutputSchema, jsonPromptInjection },
       ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
     });
     evaluations = response.object.evaluations;

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -5,6 +5,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  resolveJsonPromptInjection,
   applyModelConstraints,
 } from "../agent/model.js";
 import { PRDescriptionOutputSchema, type PRDescriptionOutput } from "./schema.js";
@@ -112,8 +113,9 @@ export async function generatePRDescription(
   const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription);
 
   const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("description"));
+  const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
   const response = await agent.generate(userMessage, {
-    structuredOutput: { schema: PRDescriptionOutputSchema },
+    structuredOutput: { schema: PRDescriptionOutputSchema, jsonPromptInjection },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
   });
 

--- a/packages/core/src/title/generate.ts
+++ b/packages/core/src/title/generate.ts
@@ -5,6 +5,7 @@ import {
   resolveModel,
   getModelDisplayName,
   resolveModelSettings,
+  resolveJsonPromptInjection,
   applyModelConstraints,
 } from "../agent/model.js";
 import { ConventionalTitleOutputSchema, type ConventionalTitleOutput } from "./schema.js";
@@ -40,8 +41,9 @@ export async function generateConventionalTitle(
   const userMessage = buildTitleUserMessage(compressed, prMetadata);
 
   const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("title"));
+  const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
   const response = await agent.generate(userMessage, {
-    structuredOutput: { schema: ConventionalTitleOutputSchema },
+    structuredOutput: { schema: ConventionalTitleOutputSchema, jsonPromptInjection },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
   });
 

--- a/packages/core/src/triage/triage.ts
+++ b/packages/core/src/triage/triage.ts
@@ -9,6 +9,7 @@ import {
   getModelDisplayName,
   resolveModelSettings,
   resolveDefaultAgentOptions,
+  resolveJsonPromptInjection,
   applyModelConstraints,
 } from "../agent/model.js";
 import { normalizePath } from "../agent/multi-call.js";
@@ -123,8 +124,9 @@ export async function runTriage(
 
   const triageMessage = buildTriageUserMessage(triageablePatches);
   const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("triage"));
+  const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
   const response = await agent.generate(triageMessage, {
-    structuredOutput: { schema: TriageOutputSchema },
+    structuredOutput: { schema: TriageOutputSchema, jsonPromptInjection },
     ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
   });
 


### PR DESCRIPTION
## Summary

Wire `resolveJsonPromptInjection(modelConfig)` into the four remaining agents that use structured output:

- [`packages/core/src/agent/judge.ts`](packages/core/src/agent/judge.ts)
- [`packages/core/src/triage/triage.ts`](packages/core/src/triage/triage.ts)
- [`packages/core/src/description/generate.ts`](packages/core/src/description/generate.ts)
- [`packages/core/src/title/generate.ts`](packages/core/src/title/generate.ts)

Same shape as [#133](https://github.com/jegork/rusty-bot/pull/133)'s `runReview` change: 6 lines per file (one import + one `jsonPromptInjection` resolution + forwarding into `structuredOutput`).

## Why

#133 only wired the resolver into `runReview`. The other four agents kept calling `agent.generate({ structuredOutput: { schema } })` without specifying `jsonPromptInjection`, so Mastra picked the default itself.

In production, the judge agent on `requesty/anthropic/claude-sonnet-4-6` failed with:

```
APICallError: This model does not support assistant message prefill.
The conversation must end with a user message.
```

The captured request showed Mastra had layered `jsonPromptInjection`'s assistant-message prefill *on top of* `response_format: json_schema`:

```json
"messages": [
  { "role": "system", "content": "You are a skeptical code review quality judge..." },
  { "role": "user", "content": "## Diff under review..." },
  { "role": "assistant", "content": "{\"evaluations\":[...]}" }    ← prefill
]
```

Anthropic via Requesty requires conversations to end on a user turn. With this PR, anthropic/* models flow through `resolveJsonPromptInjection` → returns `false` → Mastra sends only `response_format: json_schema`, no prefill, judge succeeds.

The same fix preserves prompt-injection for non-supported models (minimaxi/*, deepseek/*, qwen/*) when used as triage/description/title models, matching the review path's behavior.

## Test plan

- [x] `pnpm --filter @rusty-bot/core test` — 630 tests passing (2 new judge forwarding tests)
- [x] `pnpm -r test` — 786 across 7 packages
- [x] `pnpm -r build` clean
- [ ] After merge + image rebuild: confirm judge runs on `requesty/anthropic/claude-sonnet-4-6` no longer 400, summary footer shows `judge` token count instead of "judge pass failed, keeping all findings"

## Notes

Forwarding tests are added only for the judge agent — its test file already had agent-mock infrastructure from prior work. The triage/description/title test files don't currently exercise the agent-generate path at all (they test schemas/prompts/parsers in isolation), and adding mock infra for a one-line wiring change would expand scope substantially. The resolver itself has comprehensive unit tests in [`model.test.ts`](packages/core/src/__tests__/model.test.ts), and the wiring is mechanically identical across all four agents.