### PR TITLE
chore(deps): bump @hono/node-server to v2 and drop unused @mastra/hono

### DIFF
--- a/packages/github/package.json
+++ b/packages/github/package.json
@@ -18,8 +18,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@hono/node-server": "^1.19.14",
-    "@mastra/hono": "^1.4.13",
+    "@hono/node-server": "^2.0.1",
     "@octokit/app": "^16.1.2",
     "@rusty-bot/core": "workspace:*",
     "hono": "^4.12.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,11 +155,8 @@ importers:
   packages/github:
     dependencies:
       '@hono/node-server':
-        specifier: ^1.19.14
-        version: 1.19.14(hono@4.12.17)
-      '@mastra/hono':
-        specifier: ^1.4.13
-        version: 1.4.13(@hono/node-server@1.19.14(hono@4.12.17))(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(hono@4.12.17)(zod@4.4.3)
+        specifier: ^2.0.1
+        version: 2.0.1(hono@4.12.17)
       '@octokit/app':
         specifier: ^16.1.2
         version: 16.1.2
@@ -364,12 +361,11 @@ packages:
     peerDependencies:
       hono: ^4
 
-  '@hono/node-ws@1.3.1':
-    resolution: {integrity: sha512-vo/MwCnpJAVHBkGzWjCJ28wF45fYHAfbPZcH2rodZODHtch2GHA94KtMfusmVycTUtsLAsaNsHhtY6P8X3RQsA==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.1':
+    resolution: {integrity: sha512-jI9yMDyFpqBeSighf/zlXnQG/nl9AyBc6aAgy4XtxJMyt/CNyJpvPfzDD+bCc2zAOmhhqtF6TnmIaY+xV4mIrw==}
+    engines: {node: '>=20'}
     peerDependencies:
-      '@hono/node-server': ^1.19.11
-      hono: ^4.6.0
+      hono: ^4
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -486,12 +482,6 @@ packages:
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@mastra/hono@1.4.13':
-    resolution: {integrity: sha512-8hQn5tCZLi5U/pwS0yCsrjTELOn6nKOC8gC0R0Yz77ARwbFDVk9A4ROS+jGHJntfCirJtqI6AiqEGqgQwQw1Sg==}
-    engines: {node: '>=22.13.0'}
-    peerDependencies:
-      '@mastra/core': '>=1.0.0-0 <2.0.0-0'
-
   '@mastra/libsql@1.10.0':
     resolution: {integrity: sha512-yf2JD0821i/Mu7gsS5mP04NZIYWm0IRrHJMGaUVTYVjPtZCRTWAKNBn1f4JIPN+G0zGTNsuYJYboxz9E/PDU2Q==}
     engines: {node: '>=22.13.0'}
@@ -509,13 +499,6 @@ packages:
     resolution: {integrity: sha512-1/RgazXqi1Wdyx8aR81CVS+sRyzlTGUL1YhhHkSULoEY8aXs58bvWkH/6iixlYsY0xGvn+0OPLCeSRkBCtDx4Q==}
     engines: {node: '>=22.13.0'}
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-
-  '@mastra/server@1.32.1':
-    resolution: {integrity: sha512-CybYeWN2Ga+MRx2+PouMQ5ne0B9M63YtiY3XOs5RnYYifkq6k3Wv9uaDvHoLbW4wWllCUwRMeV3WEOQLGPW13g==}
-    engines: {node: '>=22.13.0'}
-    peerDependencies:
-      '@mastra/core': '>=1.13.2-0 <2.0.0-0'
       zod: ^3.25.0 || ^4.0.0
 
   '@modelcontextprotocol/ext-apps@1.7.1':
@@ -1534,9 +1517,6 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
-
-  fetch-to-node@2.1.0:
-    resolution: {integrity: sha512-Wq05j6LE1GrWpT2t1YbCkyFY6xKRJq3hx/oRJdWEJpZlik3g25MmdJS6RFm49iiMJw6zpZuBOrgihOgy2jGyAA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -3069,14 +3049,9 @@ snapshots:
     dependencies:
       hono: 4.12.17
 
-  '@hono/node-ws@1.3.1(@hono/node-server@1.19.14(hono@4.12.17))(hono@4.12.17)':
+  '@hono/node-server@2.0.1(hono@4.12.17)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.17)
       hono: 4.12.17
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -3231,20 +3206,6 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@mastra/hono@1.4.13(@hono/node-server@1.19.14(hono@4.12.17))(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(hono@4.12.17)(zod@4.4.3)':
-    dependencies:
-      '@hono/node-ws': 1.3.1(@hono/node-server@1.19.14(hono@4.12.17))(hono@4.12.17)
-      '@mastra/core': 1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3)
-      '@mastra/server': 1.32.1(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)
-      fetch-to-node: 2.1.0
-      ws: 8.20.0
-    transitivePeerDependencies:
-      - '@hono/node-server'
-      - bufferutil
-      - hono
-      - utf-8-validate
-      - zod
-
   '@mastra/libsql@1.10.0(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))':
     dependencies:
       '@libsql/client': 0.15.15
@@ -3274,12 +3235,6 @@ snapshots:
       zod-from-json-schema: 0.5.2
       zod-from-json-schema-v3: zod-from-json-schema@0.0.5
       zod-to-json-schema: 3.25.2(zod@4.4.3)
-
-  '@mastra/server@1.32.1(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(zod@4.4.3)':
-    dependencies:
-      '@mastra/core': 1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3)
-      hono: 4.12.17
-      zod: 4.4.3
 
   '@modelcontextprotocol/ext-apps@1.7.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)':
     dependencies:
@@ -4265,8 +4220,6 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
-
-  fetch-to-node@2.1.0: {}
 
   figures@6.1.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Bump `@hono/node-server` 1.19.14 → 2.0.1 (the major bump deferred from [#141](https://github.com/jegork/rusty-bot/pull/141))
- Drop `@mastra/hono` from [packages/github/package.json](packages/github/package.json) — declared but never imported

## Why the major bump is safe

[v2 release notes](https://github.com/honojs/node-server/releases) document only two breaking changes:

1. **Node.js v18 dropped, v20+ required.** Our [`engines.node`](package.json:25) is already `>=22.0.0`. ✓
2. **`@hono/node-server/vercel` adapter removed.** We don't import it — only [`{ serve }`](packages/github/src/server.ts:3). ✓

The release notes explicitly state "the public API stays the same — the headline of this release is the large performance improvement". Our single call site at [`packages/github/src/server.ts:222`](packages/github/src/server.ts:222) (`serve({ fetch: app.fetch, port })`) doesn't capture the return value and doesn't touch the Vercel adapter, so nothing in our code needs to change.

## Why drop @mastra/hono

Was declared as a dependency in `packages/github/package.json` but never imported anywhere in the codebase (verified by grepping for both `@mastra/hono` and `@hono/node-ws` imports across all packages — zero hits). Its transitive `@hono/node-ws@1.3.1` was emitting a peer warning under the v2 bump (`@hono/node-server@^1.19.11` declared peer). Removing the unused root dep both kills the warning and trims the dep tree.

## Test plan

- [x] `pnpm -r build` clean
- [x] `pnpm -r test` — 828/828 passing
- [x] `pnpm lint` clean
- [x] **Smoke test:** booted the webhook server locally on v2, `/health` returned 200, structured log line `"server listening"` confirms `serve()` start path is unchanged
- [ ] After merge + image rebuild: confirm the GitHub App webhook server actually accepts a real webhook in deployed mode (only relevant if anyone runs the long-lived deployment — the per-PR CI action paths don't touch this code)