### PR TITLE
fix(docker): create /home/rusty so ADO container handler can chdir there

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,10 +62,10 @@ COPY --from=build /app/packages/dashboard/dist ./packages/dashboard/dist
 # copy prompt files that are bundled alongside dist
 COPY --from=build /app/packages/core/src/prompts ./packages/core/dist/prompts
 
-RUN mkdir -p /app/data \
+RUN mkdir -p /app/data /home/rusty \
     && groupadd --system --gid 1001 rusty \
-    && useradd --system --uid 1001 --gid rusty --home-dir /app --shell /usr/sbin/nologin rusty \
-    && chown -R rusty:rusty /app
+    && useradd --system --uid 1001 --gid rusty --home-dir /home/rusty --shell /usr/sbin/nologin rusty \
+    && chown -R rusty:rusty /app /home/rusty
 
 VOLUME /app/data
 


### PR DESCRIPTION
## Summary

- Azure Pipelines runs steps via `docker exec -i -u 1001 -w /home/rusty …`. The host agent runs as UID 1001 and auto-maps to the matching `rusty` user inside the container, then hardcodes `/home/<username>` as the cwd.
- The runtime image previously created the `rusty` user with `--home-dir /app` and never created `/home/rusty`, so the `chdir` failed:
  ```
  OCI runtime exec failed: chdir to cwd ("/home/rusty") set in config.json failed: no such file or directory
  ##[error]Exit code 127
  ```
- Switch the user's home dir to `/home/rusty`, create the directory, and chown it. `WORKDIR /app` is unchanged, so compose deployments and the entrypoint still run from `/app`. No code in the repo reads `$HOME` / `os.homedir()`, so runtime behavior is unaffected.

## Test plan

- [ ] Build image locally and verify `getent passwd 1001` returns `/home/rusty`
- [ ] Run the example Azure pipeline against the rebuilt image and confirm the `Rusty Bot PR Review` step no longer exits 127
- [ ] Verify the long-running compose service (`user: rusty`, `WORKDIR /app`) still starts and writes to `/app/data`