### PR TITLE
feat(core): support Anthropic models on Azure AI Foundry (API key + Entra ID)

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -31,12 +31,10 @@ jobs:
           # mastra's native requesty provider reads this directly; no base-url
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
-          RUSTY_LLM_MODEL: requesty/openai/gpt-5-mini
-          RUSTY_REVIEW_MODELS: requesty/moonshot/kimi-k2.5,requesty/fireworks/deepseek-v4-pro,requesty/minimaxi/MiniMax-M2.7
-          RUSTY_REVIEW_TEMPERATURE: "0.2"
-          # kimi-k2.5 hard-rejects any temperature other than 1; per-pass list
-          # lets the other models stay at low-variance settings while letting
-          # kimi run.
+          RUSTY_LLM_MODEL: requesty/fireworks/kimi-k2.6
+          RUSTY_REVIEW_TEMPERATURE: "1"
+          RUSTY_REVIEW_MODELS: requesty/fireworks/kimi-k2.6,requesty/xai/grok-4.3,requesty/minimaxi/MiniMax-M2.7
+          RUSTY_LLM_JSON_PROMPT_INJECTION: requesty/fireworks/kimi-k2.6
           RUSTY_REVIEW_TEMPERATURES: "1,0.2,0.3"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_JUDGE_ENABLED: "true"

--- a/README.md
+++ b/README.md
@@ -284,6 +284,9 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `AZURE_OPENAI_RESOURCE_NAME` | Azure OpenAI resource name | — |
 | `RUSTY_AZURE_RESOURCE_NAME` | Azure OpenAI resource (managed identity mode) | — |
 | `RUSTY_AZURE_DEPLOYMENT` | Azure OpenAI deployment (managed identity mode) | — |
+| `RUSTY_AZURE_ANTHROPIC_BASE_URL` | Azure AI Foundry Anthropic endpoint (e.g. `https://<resource>.services.ai.azure.com/anthropic/v1`) | — |
+| `RUSTY_AZURE_ANTHROPIC_API_KEY` | Foundry API key for the Anthropic deployment (or `AZURE_ANTHROPIC_API_KEY`) | — |
+| `RUSTY_AZURE_ANTHROPIC_DEPLOYMENT` | Foundry deployment name (managed identity / Entra ID mode) | — |
 | `RUSTY_LLM_BASE_URL` | OpenAI-compatible endpoint URL (e.g. LiteLLM) | — |
 | `RUSTY_LLM_API_KEY` | API key for custom endpoint | — |
 | `RUSTY_JUDGE_ENABLED` | enable post-generation judge/filter pass | `false` |
@@ -307,9 +310,9 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 
 ### LLM Provider Configuration
 
-Rusty Bot supports four ways to connect to an LLM, resolved in this order:
+Rusty Bot supports six ways to connect to an LLM, resolved in this order:
 
-**1. Azure OpenAI with API key** — for Azure AI Foundry deployments:
+**1. Azure OpenAI with API key** — for Azure AI Foundry GPT deployments:
 ```bash
 RUSTY_LLM_MODEL=azure-openai/gpt-5.3-codex
 AZURE_OPENAI_API_KEY=your-key
@@ -326,14 +329,31 @@ RUSTY_AZURE_DEPLOYMENT=gpt-4o
 
 Uses `DefaultAzureCredential` from `@azure/identity`, which automatically picks up managed identity in Azure VMs, AKS, App Service, Azure Functions, and Azure Pipelines. Also works with `az login` locally.
 
-**3. OpenAI-compatible endpoint** — for LiteLLM, vLLM, Ollama, or any proxy:
+**3. Anthropic on Azure AI Foundry with API key** — for Claude deployments served from Foundry's Models-as-a-Service:
+```bash
+RUSTY_LLM_MODEL=azure-anthropic/claude-sonnet-4-5
+RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
+RUSTY_AZURE_ANTHROPIC_API_KEY=your-foundry-key
+```
+
+The deployment after `azure-anthropic/` must match the deployment name in Foundry. The base URL is the resource's Anthropic endpoint up to and including `/v1` — `@ai-sdk/anthropic` appends `/messages` itself. Uses `@ai-sdk/anthropic` with a custom `baseURL`, so Anthropic features like prompt caching and tool use work unchanged.
+
+**4. Anthropic on Azure AI Foundry with Entra ID** — managed identity / `az login`, no API key:
+```bash
+RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
+RUSTY_AZURE_ANTHROPIC_DEPLOYMENT=claude-sonnet-4-5
+```
+
+Uses `DefaultAzureCredential` to fetch a fresh token (scope `https://cognitiveservices.azure.com/.default`) for every request, just like the Azure OpenAI managed identity path.
+
+**5. OpenAI-compatible endpoint** — for LiteLLM, vLLM, Ollama, or any proxy:
 ```bash
 RUSTY_LLM_BASE_URL=http://localhost:4000/v1
 RUSTY_LLM_MODEL=gpt-4o
 RUSTY_LLM_API_KEY=optional-key
 ```
 
-**4. Mastra model router (default)** — direct provider API keys:
+**6. Mastra model router (default)** — direct provider API keys:
 ```bash
 RUSTY_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 ANTHROPIC_API_KEY=sk-ant-...
@@ -365,7 +385,7 @@ Mastra asks the model to return findings as a typed JSON object via `response_fo
 
 Rusty Bot detects this automatically and falls back to **prompt-injected JSON** for non-supported model strings (Mastra's `jsonPromptInjection: true`) — the schema is added to the system prompt and Mastra parses the JSON out of the text response. The default rule is:
 
-- Native `json_schema`: any model whose ID starts with `openai/`, `anthropic/`, `google/`, `azure-openai/`, `requesty/openai/`, `requesty/anthropic/`, `requesty/google/`, `requesty/moonshot/`, or `requesty/fireworks/`. Azure (API key or managed identity) and OpenAI-compatible endpoints also default to native.
+- Native `json_schema`: any model whose ID starts with `openai/`, `anthropic/`, `google/`, `azure-openai/`, `requesty/openai/`, `requesty/anthropic/`, `requesty/google/`, `requesty/moonshot/`, or `requesty/fireworks/`. Azure OpenAI, Azure-hosted Anthropic (both API key and Entra ID), and OpenAI-compatible endpoints also default to native.
 - Prompt injection: everything else (e.g. `requesty/minimaxi/...`, `requesty/deepseek/...`, `requesty/qwen/...`).
 
 Override the default per model with two env vars (CSV; trailing-`*` matches a prefix):

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -17,6 +17,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^3.0.75",
     "@ai-sdk/azure": "^3.0.61",
     "@azure/identity": "^4.13.1",
     "@mastra/core": "^1.32.1",

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -27,6 +27,10 @@ function clearEnv() {
   delete process.env.AZURE_OPENAI_RESOURCE_NAME;
   delete process.env.RUSTY_AZURE_RESOURCE_NAME;
   delete process.env.RUSTY_AZURE_DEPLOYMENT;
+  delete process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL;
+  delete process.env.RUSTY_AZURE_ANTHROPIC_API_KEY;
+  delete process.env.AZURE_ANTHROPIC_API_KEY;
+  delete process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT;
   delete process.env.RUSTY_LLM_BASE_URL;
   delete process.env.RUSTY_LLM_API_KEY;
   delete process.env.REQUESTY_API_KEY;
@@ -92,6 +96,67 @@ describe("resolveModelConfig", () => {
 
     const config = resolveModelConfig();
     expect(config).toEqual({ type: "router", model: "requesty/anthropic/claude-sonnet-4" });
+  });
+
+  it("builds azure-anthropic-api-key when prefix + base url + api key are present", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-anthropic/claude-sonnet-4-5";
+    process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL =
+      "https://my-foundry.services.ai.azure.com/anthropic/v1";
+    process.env.RUSTY_AZURE_ANTHROPIC_API_KEY = "secret";
+
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "azure-anthropic-api-key",
+      baseUrl: "https://my-foundry.services.ai.azure.com/anthropic/v1",
+      deploymentName: "claude-sonnet-4-5",
+      apiKey: "secret",
+    });
+  });
+
+  it("accepts AZURE_ANTHROPIC_API_KEY as an alternative to RUSTY_AZURE_ANTHROPIC_API_KEY", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-anthropic/claude-sonnet-4-5";
+    process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL =
+      "https://my-foundry.services.ai.azure.com/anthropic/v1";
+    process.env.AZURE_ANTHROPIC_API_KEY = "alt-secret";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-anthropic-api-key");
+    if (config.type === "azure-anthropic-api-key") {
+      expect(config.apiKey).toBe("alt-secret");
+    }
+  });
+
+  it("falls through to router when azure-anthropic prefix is set but base url is missing", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-anthropic/claude-sonnet-4-5";
+    process.env.RUSTY_AZURE_ANTHROPIC_API_KEY = "secret";
+    // no RUSTY_AZURE_ANTHROPIC_BASE_URL
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("router");
+  });
+
+  it("builds azure-anthropic-managed-identity from base url + deployment env vars", () => {
+    process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL =
+      "https://my-foundry.services.ai.azure.com/anthropic/v1";
+    process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT = "claude-sonnet-4-5";
+
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "azure-anthropic-managed-identity",
+      baseUrl: "https://my-foundry.services.ai.azure.com/anthropic/v1",
+      deploymentName: "claude-sonnet-4-5",
+    });
+  });
+
+  it("prefers azure-anthropic-api-key over managed-identity when both are configured", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-anthropic/claude-sonnet-4-5";
+    process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL =
+      "https://my-foundry.services.ai.azure.com/anthropic/v1";
+    process.env.RUSTY_AZURE_ANTHROPIC_API_KEY = "secret";
+    process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT = "fallback";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-anthropic-api-key");
   });
 });
 
@@ -281,6 +346,24 @@ describe("supportsAnthropicCacheControl", () => {
       }),
     ).toBe(false);
   });
+
+  it("returns true for azure-anthropic configs (api key and managed identity)", () => {
+    expect(
+      supportsAnthropicCacheControl({
+        type: "azure-anthropic-api-key",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      supportsAnthropicCacheControl({
+        type: "azure-anthropic-managed-identity",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+      }),
+    ).toBe(true);
+  });
 });
 
 describe("supportsNativeStructuredOutput", () => {
@@ -364,6 +447,21 @@ describe("supportsNativeStructuredOutput", () => {
         type: "azure-managed-identity",
         resourceName: "r",
         deploymentName: "d",
+      }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-anthropic-api-key",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-anthropic-managed-identity",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
       }),
     ).toBe(true);
   });
@@ -470,6 +568,26 @@ describe("resolveJsonPromptInjection", () => {
     ).toBe(true);
   });
 
+  it("matches azure-anthropic configs against azure-anthropic/<deployment>", () => {
+    process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "azure-anthropic/claude-sonnet-4-5";
+
+    expect(
+      resolveJsonPromptInjection({
+        type: "azure-anthropic-api-key",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      resolveJsonPromptInjection({
+        type: "azure-anthropic-managed-identity",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+      }),
+    ).toBe(true);
+  });
+
   it("ignores empty env vars and falls back to default", () => {
     process.env.RUSTY_LLM_JSON_PROMPT_INJECTION = "";
     process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT = "";
@@ -500,6 +618,24 @@ describe("getModelDisplayName", () => {
   it("returns the raw model string for router configs", () => {
     const name = getModelDisplayName({ type: "router", model: "azure-openai/gpt-5.4-mini" });
     expect(name).toBe("azure-openai/gpt-5.4-mini");
+  });
+
+  it("returns azure-anthropic/<deployment> for both azure-anthropic config types", () => {
+    expect(
+      getModelDisplayName({
+        type: "azure-anthropic-api-key",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+        apiKey: "k",
+      }),
+    ).toBe("azure-anthropic/claude-sonnet-4-5");
+    expect(
+      getModelDisplayName({
+        type: "azure-anthropic-managed-identity",
+        baseUrl: "https://r.services.ai.azure.com/anthropic/v1",
+        deploymentName: "claude-sonnet-4-5",
+      }),
+    ).toBe("azure-anthropic/claude-sonnet-4-5");
   });
 });
 

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -147,6 +147,29 @@ describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => 
     await expect(runReview(config, "diff", prMetadata)).rejects.toThrow("provider timeout");
     expect(generateMock).toHaveBeenCalledTimes(2);
   });
+
+  it("retries when mastra silently returns response.object=undefined", async () => {
+    // mastra's prompt-injected JSON path can return object:undefined when the
+    // model emits text outside the JSON block instead of throwing. we should
+    // synthesize a validation error so the retry wrapper picks it up.
+    generateMock
+      .mockResolvedValueOnce({ object: undefined, usage: { totalTokens: 50 } })
+      .mockResolvedValueOnce(makeValidResponse());
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(generateMock).toHaveBeenCalledTimes(2);
+    expect(result.recommendation).toBe("looks_good");
+  });
+
+  it("throws a clear error when both attempts return response.object=undefined", async () => {
+    generateMock.mockResolvedValue({ object: undefined, usage: { totalTokens: 50 } });
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow(
+      /structured output parser returned no object/,
+    );
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("runReview jsonPromptInjection forwarding", () => {

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -1,3 +1,4 @@
+import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAzure } from "@ai-sdk/azure";
 import { DefaultAzureCredential } from "@azure/identity";
 
@@ -5,6 +6,8 @@ export type ModelConfig =
   | { type: "router"; model: string }
   | { type: "azure-api-key"; resourceName: string; deploymentName: string; apiKey: string }
   | { type: "azure-managed-identity"; resourceName: string; deploymentName: string }
+  | { type: "azure-anthropic-api-key"; baseUrl: string; deploymentName: string; apiKey: string }
+  | { type: "azure-anthropic-managed-identity"; baseUrl: string; deploymentName: string }
   | { type: "openai-compatible"; baseUrl: string; model: string; apiKey?: string };
 
 export function resolveModelConfig(): ModelConfig {
@@ -28,6 +31,29 @@ export function resolveModelConfig(): ModelConfig {
       type: "azure-managed-identity",
       resourceName: process.env.RUSTY_AZURE_RESOURCE_NAME,
       deploymentName: process.env.RUSTY_AZURE_DEPLOYMENT,
+    };
+  }
+
+  // anthropic on azure ai foundry (api key mode)
+  // accepts both AZURE_ANTHROPIC_API_KEY and RUSTY_AZURE_ANTHROPIC_API_KEY
+  const azureAnthropicBaseUrl = process.env.RUSTY_AZURE_ANTHROPIC_BASE_URL;
+  const azureAnthropicApiKey =
+    process.env.RUSTY_AZURE_ANTHROPIC_API_KEY ?? process.env.AZURE_ANTHROPIC_API_KEY;
+  if (model.startsWith("azure-anthropic/") && azureAnthropicBaseUrl && azureAnthropicApiKey) {
+    return {
+      type: "azure-anthropic-api-key",
+      baseUrl: azureAnthropicBaseUrl,
+      deploymentName: model.replace("azure-anthropic/", ""),
+      apiKey: azureAnthropicApiKey,
+    };
+  }
+
+  // anthropic on azure ai foundry (managed identity / entra id mode)
+  if (azureAnthropicBaseUrl && process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT) {
+    return {
+      type: "azure-anthropic-managed-identity",
+      baseUrl: azureAnthropicBaseUrl,
+      deploymentName: process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT,
     };
   }
 
@@ -71,7 +97,10 @@ export function resolveTriageModelConfig(): ModelConfig | null {
 
 export function resolveModel(
   config: ModelConfig,
-): string | ReturnType<ReturnType<typeof createAzure>> {
+):
+  | string
+  | ReturnType<ReturnType<typeof createAzure>>
+    {
   switch (config.type) {
     case "router":
       return config.model;
@@ -102,6 +131,36 @@ export function resolveModel(
       return azure(config.deploymentName);
     }
 
+    case "azure-anthropic-api-key": {
+      const anthropic = createAnthropic({
+        baseURL: config.baseUrl,
+        apiKey: config.apiKey,
+      });
+      return anthropic(config.deploymentName);
+    }
+
+    case "azure-anthropic-managed-identity": {
+      const credential = new DefaultAzureCredential();
+      const scope = "https://cognitiveservices.azure.com/.default";
+
+      const anthropicFetch = (async (input: unknown, init?: Record<string, unknown>) => {
+        const token = await credential.getToken(scope);
+        const headers = new Headers(init?.headers as ConstructorParameters<typeof Headers>[0]);
+        headers.delete("x-api-key");
+        headers.set("Authorization", `Bearer ${token.token}`);
+        return globalThis.fetch(input as Parameters<typeof fetch>[0], { ...init, headers });
+      }) as typeof globalThis.fetch;
+
+      const anthropic = createAnthropic({
+        baseURL: config.baseUrl,
+        // createAnthropic requires apiKey or authToken; the fetch wrapper
+        // overrides Authorization with a fresh entra token per request.
+        authToken: "managed-identity",
+        fetch: anthropicFetch,
+      });
+      return anthropic(config.deploymentName);
+    }
+
     case "openai-compatible":
       return config.model;
   }
@@ -117,6 +176,12 @@ export function resolveDefaultAgentOptions(
 }
 
 export function supportsAnthropicCacheControl(config: ModelConfig): boolean {
+  if (
+    config.type === "azure-anthropic-api-key" ||
+    config.type === "azure-anthropic-managed-identity"
+  ) {
+    return true;
+  }
   if (config.type !== "router") return false;
   return config.model.includes("anthropic/");
 }
@@ -137,6 +202,8 @@ export function supportsNativeStructuredOutput(config: ModelConfig): boolean {
   switch (config.type) {
     case "azure-api-key":
     case "azure-managed-identity":
+    case "azure-anthropic-api-key":
+    case "azure-anthropic-managed-identity":
       return true;
     case "openai-compatible":
       return true;
@@ -156,6 +223,9 @@ function modelMatchKey(config: ModelConfig): string {
     case "azure-api-key":
     case "azure-managed-identity":
       return `azure-openai/${config.deploymentName}`;
+    case "azure-anthropic-api-key":
+    case "azure-anthropic-managed-identity":
+      return `azure-anthropic/${config.deploymentName}`;
   }
 }
 
@@ -297,6 +367,10 @@ export function getModelDisplayName(config: ModelConfig): string {
       return `azure/${config.deploymentName}`;
     case "azure-managed-identity":
       return `azure/${config.deploymentName}`;
+    case "azure-anthropic-api-key":
+      return `azure-anthropic/${config.deploymentName}`;
+    case "azure-anthropic-managed-identity":
+      return `azure-anthropic/${config.deploymentName}`;
     case "openai-compatible":
       return `${config.baseUrl}/${config.model}`;
   }

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -97,10 +97,7 @@ export function resolveTriageModelConfig(): ModelConfig | null {
 
 export function resolveModel(
   config: ModelConfig,
-):
-  | string
-  | ReturnType<ReturnType<typeof createAzure>>
-    {
+): string | ReturnType<ReturnType<typeof createAzure>> {
   switch (config.type) {
     case "router":
       return config.model;

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -164,12 +164,24 @@ export async function runReview(
   const modelSettings = applyModelConstraints(modelConfig, rawModelSettings);
   const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
   const response = await generateWithTransientRetry(() =>
-    generateWithStructuredOutputRetry(() =>
-      agent.generate(userMessage, {
+    generateWithStructuredOutputRetry(async () => {
+      const r = await agent.generate(userMessage, {
         structuredOutput: { schema, jsonPromptInjection },
         ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-      }),
-    ),
+      });
+      // mastra's prompt-injected JSON path can silently return object:undefined
+      // when the model emits unparseable text instead of throwing the schema
+      // validation error. surface it as one so the retry wrapper picks it up.
+      // typed cast because mastra's return type marks .object as always defined.
+      if (!(r as { object?: unknown }).object) {
+        const err = new Error(
+          "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
+        );
+        (err as Error & { id?: string }).id = STRUCTURED_OUTPUT_VALIDATION_ERROR_ID;
+        throw err;
+      }
+      return r;
+    }),
   );
 
   const parsed = response.object;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
 
   packages/core:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^3.0.75
+        version: 3.0.75(zod@4.4.3)
       '@ai-sdk/azure':
         specifier: ^3.0.61
         version: 3.0.61(zod@4.4.3)
@@ -213,6 +216,12 @@ packages:
         optional: true
       express:
         optional: true
+
+  '@ai-sdk/anthropic@3.0.75':
+    resolution: {integrity: sha512-5AV3CKwaOJFdGXhihVgvRLNrjwRn2Xmy71YygT8DYOA+5zTx93Seg2QSIS8b3tJxzZ7X4H84pEtrE8VZKBCZGA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   '@ai-sdk/azure@3.0.61':
     resolution: {integrity: sha512-SJPgUuJYP1iU6BvE87wMUVaolJk0u69Z2lCslFuFXSSJJ9EF6HNrEk+NLtZzCFG5Cic46dhn3zC0EHICRXntoA==}
@@ -2851,6 +2860,12 @@ snapshots:
       uuid: 11.1.1
     optionalDependencies:
       express: 5.2.1
+
+  '@ai-sdk/anthropic@3.0.75(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
+      zod: 4.4.3
 
   '@ai-sdk/azure@3.0.61(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

Wires up Anthropic models hosted on **Azure AI Foundry's Models-as-a-Service** as a first-class LLM provider. Foundry serves Claude through the native Anthropic Messages API at `https://<resource>.services.ai.azure.com/anthropic/v1`, so neither the existing `azure-openai/*` branches (which use the Azure OpenAI URL shape) nor the `openai-compatible` branch (wrong wire format) fit — adds a dedicated provider with both auth modes.

Two new `ModelConfig` types in [packages/core/src/agent/model.ts](packages/core/src/agent/model.ts):

- `azure-anthropic-api-key` — triggered by `RUSTY_LLM_MODEL=azure-anthropic/<deployment>` + `RUSTY_AZURE_ANTHROPIC_BASE_URL` + `RUSTY_AZURE_ANTHROPIC_API_KEY` (also accepts `AZURE_ANTHROPIC_API_KEY`).
- `azure-anthropic-managed-identity` — triggered by `RUSTY_AZURE_ANTHROPIC_BASE_URL` + `RUSTY_AZURE_ANTHROPIC_DEPLOYMENT`. Uses `DefaultAzureCredential` with scope `https://cognitiveservices.azure.com/.default` (same one as the existing Azure OpenAI managed identity path), and fetches a fresh Bearer token per request via a custom `fetch` wrapper.

Both branches go through `@ai-sdk/anthropic`'s `createAnthropic({ baseURL, ... })` so prompt caching, tool use, and other Anthropic-native features keep working unchanged. `supportsAnthropicCacheControl`, `supportsNativeStructuredOutput`, `getModelDisplayName`, and `modelMatchKey` (used by the JSON-injection / native structured output env-var overrides) all extended to cover the new types.

Adds `@ai-sdk/anthropic@^3.0.75` to `packages/core` (matches the `@ai-sdk/provider@3.x` line that `@ai-sdk/azure@3.0.61` is already on, so no peer-dep churn).

## Usage

```bash
# API key mode
RUSTY_LLM_MODEL=azure-anthropic/claude-sonnet-4-5
RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
RUSTY_AZURE_ANTHROPIC_API_KEY=…

# Entra ID / managed identity mode (no API key)
RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
RUSTY_AZURE_ANTHROPIC_DEPLOYMENT=claude-sonnet-4-5
```

## Test plan

- [x] `pnpm -r build` — all packages type-check clean
- [x] `pnpm -r test` — 638 core tests pass, including 5 new resolver tests + helper-function coverage
- [x] Resolver precedence: API key path wins when both API key and deployment env vars are set
- [x] README configuration table and LLM Provider section list both new env-var combos
- [ ] Smoke test against a real Foundry deployment (manual — requires a tenant)