### PR TITLE
feat(core): route non-OpenAI Azure AI Foundry models via chat completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `AZURE_OPENAI_RESOURCE_NAME` | Azure OpenAI resource name | — |
 | `RUSTY_AZURE_RESOURCE_NAME` | Azure OpenAI resource (managed identity mode) | — |
 | `RUSTY_AZURE_DEPLOYMENT` | Azure OpenAI deployment (managed identity mode) | — |
+| `RUSTY_AZURE_FOUNDRY_RESOURCE_NAME` | Azure AI Foundry resource for non-OpenAI models (managed identity mode) | — |
+| `RUSTY_AZURE_FOUNDRY_DEPLOYMENT` | Azure AI Foundry deployment for non-OpenAI models (managed identity mode) | — |
 | `RUSTY_AZURE_ANTHROPIC_BASE_URL` | Azure AI Foundry Anthropic endpoint (e.g. `https://<resource>.services.ai.azure.com/anthropic/v1`) | — |
 | `RUSTY_AZURE_ANTHROPIC_API_KEY` | Foundry API key for the Anthropic deployment (or `AZURE_ANTHROPIC_API_KEY`) | — |
 | `RUSTY_AZURE_ANTHROPIC_DEPLOYMENT` | Foundry deployment name (managed identity / Entra ID mode) | — |
@@ -310,7 +312,7 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 
 ### LLM Provider Configuration
 
-Rusty Bot supports six ways to connect to an LLM, resolved in this order:
+Rusty Bot supports eight ways to connect to an LLM, resolved in this order:
 
 **1. Azure OpenAI with API key** — for Azure AI Foundry GPT deployments:
 ```bash
@@ -319,7 +321,7 @@ AZURE_OPENAI_API_KEY=your-key
 AZURE_OPENAI_RESOURCE_NAME=ai-code-review-foundry
 ```
 
-The resource name is the subdomain from your endpoint URL (e.g. `https://ai-code-review-foundry.cognitiveservices.azure.com` → `ai-code-review-foundry`). Uses `@ai-sdk/azure` directly.
+The resource name is the subdomain from your endpoint URL (e.g. `https://ai-code-review-foundry.cognitiveservices.azure.com` → `ai-code-review-foundry`). Uses `@ai-sdk/azure` directly with the Responses API (`/v1/responses`).
 
 **2. Azure OpenAI with Managed Identity** — no API keys needed when running on Azure:
 ```bash
@@ -329,7 +331,24 @@ RUSTY_AZURE_DEPLOYMENT=gpt-4o
 
 Uses `DefaultAzureCredential` from `@azure/identity`, which automatically picks up managed identity in Azure VMs, AKS, App Service, Azure Functions, and Azure Pipelines. Also works with `az login` locally.
 
-**3. Anthropic on Azure AI Foundry with API key** — for Claude deployments served from Foundry's Models-as-a-Service:
+**3. Non-OpenAI models on Azure AI Foundry with API key** — Kimi, Llama, Mistral, etc. served from the Foundry endpoint but only reachable via Chat Completions:
+```bash
+RUSTY_LLM_MODEL=azure-foundry/Kimi-K2.6
+AZURE_OPENAI_API_KEY=your-key
+AZURE_OPENAI_RESOURCE_NAME=ai-code-review-foundry
+```
+
+Identical config to `azure-openai/`, but routes through `/v1/chat/completions` instead of `/v1/responses` because non-OpenAI Foundry models don't support the Responses API. Use this prefix whenever the deployment isn't a first-party OpenAI model.
+
+**4. Non-OpenAI models on Azure AI Foundry with Managed Identity**:
+```bash
+RUSTY_AZURE_FOUNDRY_RESOURCE_NAME=ai-code-review-foundry
+RUSTY_AZURE_FOUNDRY_DEPLOYMENT=Kimi-K2.6
+```
+
+Same `DefaultAzureCredential` path as the OpenAI MI mode, but kept on separate env vars so the two can coexist on the same machine.
+
+**5. Anthropic on Azure AI Foundry with API key** — for Claude deployments served from Foundry's Models-as-a-Service:
 ```bash
 RUSTY_LLM_MODEL=azure-anthropic/claude-sonnet-4-5
 RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
@@ -338,7 +357,7 @@ RUSTY_AZURE_ANTHROPIC_API_KEY=your-foundry-key
 
 The deployment after `azure-anthropic/` must match the deployment name in Foundry. The base URL is the resource's Anthropic endpoint up to and including `/v1` — `@ai-sdk/anthropic` appends `/messages` itself. Uses `@ai-sdk/anthropic` with a custom `baseURL`, so Anthropic features like prompt caching and tool use work unchanged.
 
-**4. Anthropic on Azure AI Foundry with Entra ID** — managed identity / `az login`, no API key:
+**6. Anthropic on Azure AI Foundry with Entra ID** — managed identity / `az login`, no API key:
 ```bash
 RUSTY_AZURE_ANTHROPIC_BASE_URL=https://my-foundry.services.ai.azure.com/anthropic/v1
 RUSTY_AZURE_ANTHROPIC_DEPLOYMENT=claude-sonnet-4-5
@@ -346,14 +365,14 @@ RUSTY_AZURE_ANTHROPIC_DEPLOYMENT=claude-sonnet-4-5
 
 Uses `DefaultAzureCredential` to fetch a fresh token (scope `https://cognitiveservices.azure.com/.default`) for every request, just like the Azure OpenAI managed identity path.
 
-**5. OpenAI-compatible endpoint** — for LiteLLM, vLLM, Ollama, or any proxy:
+**7. OpenAI-compatible endpoint** — for LiteLLM, vLLM, Ollama, or any proxy:
 ```bash
 RUSTY_LLM_BASE_URL=http://localhost:4000/v1
 RUSTY_LLM_MODEL=gpt-4o
 RUSTY_LLM_API_KEY=optional-key
 ```
 
-**6. Mastra model router (default)** — direct provider API keys:
+**8. Mastra model router (default)** — direct provider API keys:
 ```bash
 RUSTY_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 ANTHROPIC_API_KEY=sk-ant-...

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -31,6 +31,8 @@ function clearEnv() {
   delete process.env.RUSTY_AZURE_ANTHROPIC_API_KEY;
   delete process.env.AZURE_ANTHROPIC_API_KEY;
   delete process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT;
+  delete process.env.RUSTY_AZURE_FOUNDRY_RESOURCE_NAME;
+  delete process.env.RUSTY_AZURE_FOUNDRY_DEPLOYMENT;
   delete process.env.RUSTY_LLM_BASE_URL;
   delete process.env.RUSTY_LLM_API_KEY;
   delete process.env.REQUESTY_API_KEY;
@@ -157,6 +159,62 @@ describe("resolveModelConfig", () => {
 
     const config = resolveModelConfig();
     expect(config.type).toBe("azure-anthropic-api-key");
+  });
+
+  it("builds azure-foundry-api-key when prefix + api key + resource name are present", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-foundry/Kimi-K2.6";
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "ai-code-review-foundry";
+
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "azure-foundry-api-key",
+      resourceName: "ai-code-review-foundry",
+      deploymentName: "Kimi-K2.6",
+      apiKey: "secret",
+    });
+  });
+
+  it("falls through to router when azure-foundry prefix is set but resource name is missing", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-foundry/Kimi-K2.6";
+    process.env.AZURE_API_KEY = "secret";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("router");
+  });
+
+  it("builds azure-foundry-managed-identity from foundry-specific resource + deployment env vars", () => {
+    process.env.RUSTY_AZURE_FOUNDRY_RESOURCE_NAME = "ai-code-review-foundry";
+    process.env.RUSTY_AZURE_FOUNDRY_DEPLOYMENT = "Kimi-K2.6";
+
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "azure-foundry-managed-identity",
+      resourceName: "ai-code-review-foundry",
+      deploymentName: "Kimi-K2.6",
+    });
+  });
+
+  it("does not collide with azure-managed-identity when only OpenAI MI vars are set", () => {
+    process.env.RUSTY_AZURE_RESOURCE_NAME = "openai-resource";
+    process.env.RUSTY_AZURE_DEPLOYMENT = "gpt-5.4";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-managed-identity");
+  });
+
+  it("prefers azure-foundry-api-key over foundry MI when both are configured with the prefix", () => {
+    process.env.RUSTY_LLM_MODEL = "azure-foundry/Kimi-K2.6";
+    process.env.AZURE_API_KEY = "secret";
+    process.env.AZURE_OPENAI_RESOURCE_NAME = "ai-code-review-foundry";
+    process.env.RUSTY_AZURE_FOUNDRY_RESOURCE_NAME = "fallback-resource";
+    process.env.RUSTY_AZURE_FOUNDRY_DEPLOYMENT = "fallback-deployment";
+
+    const config = resolveModelConfig();
+    expect(config.type).toBe("azure-foundry-api-key");
+    if (config.type === "azure-foundry-api-key") {
+      expect(config.deploymentName).toBe("Kimi-K2.6");
+    }
   });
 });
 
@@ -475,6 +533,24 @@ describe("supportsNativeStructuredOutput", () => {
       }),
     ).toBe(true);
   });
+
+  it("returns false for azure-foundry configs (deployments vary; default to prompt-injected JSON)", () => {
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-foundry-api-key",
+        resourceName: "ai-code-review-foundry",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+    expect(
+      supportsNativeStructuredOutput({
+        type: "azure-foundry-managed-identity",
+        resourceName: "ai-code-review-foundry",
+        deploymentName: "Kimi-K2.6",
+      }),
+    ).toBe(false);
+  });
 });
 
 describe("resolveJsonPromptInjection", () => {
@@ -636,6 +712,24 @@ describe("getModelDisplayName", () => {
         deploymentName: "claude-sonnet-4-5",
       }),
     ).toBe("azure-anthropic/claude-sonnet-4-5");
+  });
+
+  it("returns azure-foundry/<deployment> for both azure-foundry config types", () => {
+    expect(
+      getModelDisplayName({
+        type: "azure-foundry-api-key",
+        resourceName: "ai-code-review-foundry",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe("azure-foundry/Kimi-K2.6");
+    expect(
+      getModelDisplayName({
+        type: "azure-foundry-managed-identity",
+        resourceName: "ai-code-review-foundry",
+        deploymentName: "Kimi-K2.6",
+      }),
+    ).toBe("azure-foundry/Kimi-K2.6");
   });
 });
 

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -6,6 +6,8 @@ export type ModelConfig =
   | { type: "router"; model: string }
   | { type: "azure-api-key"; resourceName: string; deploymentName: string; apiKey: string }
   | { type: "azure-managed-identity"; resourceName: string; deploymentName: string }
+  | { type: "azure-foundry-api-key"; resourceName: string; deploymentName: string; apiKey: string }
+  | { type: "azure-foundry-managed-identity"; resourceName: string; deploymentName: string }
   | { type: "azure-anthropic-api-key"; baseUrl: string; deploymentName: string; apiKey: string }
   | { type: "azure-anthropic-managed-identity"; baseUrl: string; deploymentName: string }
   | { type: "openai-compatible"; baseUrl: string; model: string; apiKey?: string };
@@ -31,6 +33,26 @@ export function resolveModelConfig(): ModelConfig {
       type: "azure-managed-identity",
       resourceName: process.env.RUSTY_AZURE_RESOURCE_NAME,
       deploymentName: process.env.RUSTY_AZURE_DEPLOYMENT,
+    };
+  }
+
+  // non-OpenAI models on Azure AI Foundry (Kimi, Llama, Mistral, etc.) — they
+  // share the AOAI endpoint shape but only support /chat/completions, not the
+  // newer /responses API that azure(deployment) defaults to.
+  if (model.startsWith("azure-foundry/") && azureApiKey && process.env.AZURE_OPENAI_RESOURCE_NAME) {
+    return {
+      type: "azure-foundry-api-key",
+      resourceName: process.env.AZURE_OPENAI_RESOURCE_NAME,
+      deploymentName: model.replace("azure-foundry/", ""),
+      apiKey: azureApiKey,
+    };
+  }
+
+  if (process.env.RUSTY_AZURE_FOUNDRY_RESOURCE_NAME && process.env.RUSTY_AZURE_FOUNDRY_DEPLOYMENT) {
+    return {
+      type: "azure-foundry-managed-identity",
+      resourceName: process.env.RUSTY_AZURE_FOUNDRY_RESOURCE_NAME,
+      deploymentName: process.env.RUSTY_AZURE_FOUNDRY_DEPLOYMENT,
     };
   }
 
@@ -128,6 +150,34 @@ export function resolveModel(
       return azure(config.deploymentName);
     }
 
+    case "azure-foundry-api-key": {
+      const azure = createAzure({
+        resourceName: config.resourceName,
+        apiKey: config.apiKey,
+      });
+      // .chat() routes to /v1/chat/completions; the default azure() picks
+      // /v1/responses, which non-OpenAI Foundry models reject
+      return azure.chat(config.deploymentName);
+    }
+
+    case "azure-foundry-managed-identity": {
+      const credential = new DefaultAzureCredential();
+      const scope = "https://cognitiveservices.azure.com/.default";
+
+      const azureFetch = (async (input: unknown, init?: Record<string, unknown>) => {
+        const token = await credential.getToken(scope);
+        const headers = new Headers(init?.headers as ConstructorParameters<typeof Headers>[0]);
+        headers.set("Authorization", `Bearer ${token.token}`);
+        return globalThis.fetch(input as Parameters<typeof fetch>[0], { ...init, headers });
+      }) as typeof globalThis.fetch;
+
+      const azure = createAzure({
+        resourceName: config.resourceName,
+        fetch: azureFetch,
+      });
+      return azure.chat(config.deploymentName);
+    }
+
     case "azure-anthropic-api-key": {
       const anthropic = createAnthropic({
         baseURL: config.baseUrl,
@@ -202,6 +252,11 @@ export function supportsNativeStructuredOutput(config: ModelConfig): boolean {
     case "azure-anthropic-api-key":
     case "azure-anthropic-managed-identity":
       return true;
+    case "azure-foundry-api-key":
+    case "azure-foundry-managed-identity":
+      // Foundry chat completions for non-OpenAI models (Kimi, Llama, etc.)
+      // varies by deployment; default to prompt-injected JSON to be safe
+      return false;
     case "openai-compatible":
       return true;
     case "router":
@@ -220,6 +275,9 @@ function modelMatchKey(config: ModelConfig): string {
     case "azure-api-key":
     case "azure-managed-identity":
       return `azure-openai/${config.deploymentName}`;
+    case "azure-foundry-api-key":
+    case "azure-foundry-managed-identity":
+      return `azure-foundry/${config.deploymentName}`;
     case "azure-anthropic-api-key":
     case "azure-anthropic-managed-identity":
       return `azure-anthropic/${config.deploymentName}`;
@@ -364,6 +422,10 @@ export function getModelDisplayName(config: ModelConfig): string {
       return `azure/${config.deploymentName}`;
     case "azure-managed-identity":
       return `azure/${config.deploymentName}`;
+    case "azure-foundry-api-key":
+      return `azure-foundry/${config.deploymentName}`;
+    case "azure-foundry-managed-identity":
+      return `azure-foundry/${config.deploymentName}`;
     case "azure-anthropic-api-key":
       return `azure-anthropic/${config.deploymentName}`;
     case "azure-anthropic-managed-identity":


### PR DESCRIPTION
## Summary

- Non-OpenAI Foundry deployments (Kimi, Llama, Mistral, etc.) reject the Responses API that `azure(deployment)` defaults to: `"This model is not supported by Responses API."` Add an `azure-foundry/<deployment>` prefix that routes through `azure.chat(deployment)` so the request hits `/v1/chat/completions` instead of `/v1/responses`.
- API-key path reuses `AZURE_OPENAI_API_KEY` + `AZURE_OPENAI_RESOURCE_NAME`. Managed-identity path uses dedicated `RUSTY_AZURE_FOUNDRY_RESOURCE_NAME` + `RUSTY_AZURE_FOUNDRY_DEPLOYMENT` so it can coexist with an OpenAI MI deployment on the same machine.
- `supportsNativeStructuredOutput` returns `false` for `azure-foundry/*` because Foundry's `json_schema` support varies by model. Users on a known-good deployment (e.g. Kimi K2.6) can opt back in via `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=azure-foundry/Kimi-K2.6`.

## Migration

```diff
- RUSTY_LLM_MODEL=azure-openai/Kimi-K2.6
+ RUSTY_LLM_MODEL=azure-foundry/Kimi-K2.6
```

`azure-openai/` keeps its existing semantics (Responses API) for first-party OpenAI models.

## Test plan

- [x] New tests in `model.test.ts` cover both Foundry branches: prefix + API key path, MI path, MI-vs-OpenAI-MI env-var disambiguation, prefix-takes-precedence over MI.
- [x] `supportsNativeStructuredOutput` and `getModelDisplayName` exercised on both new variants.
- [x] Full suite green (647/647).
- [ ] Smoke-test against a live Foundry Kimi deployment.