### PR TITLE
feat(core): include model and token usage in review pass logs

### DIFF
--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -156,7 +156,12 @@ export async function runConsensusReview(
     } else {
       failures.push(outcome.reason);
       logger.warn(
-        { err: outcome.reason, passIndex: i, prId: prMetadata.id },
+        {
+          err: outcome.reason,
+          passIndex: i,
+          model: passModelConfigs[i].displayName,
+          prId: prMetadata.id,
+        },
         "consensus pass failed",
       );
     }
@@ -220,6 +225,11 @@ export async function runConsensusReview(
       droppedObservations: totalRawObservations - survivingObservations.length,
       agreementRate,
       passRecommendations,
+      passModels: passModelConfigs.map((m) => m.displayName),
+      passTokens: settled.map((outcome) =>
+        outcome.status === "fulfilled" ? outcome.value.tokenCount : 0,
+      ),
+      totalTokens,
     },
     "consensus voting complete",
   );

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -51,20 +51,26 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
-async function generateWithStructuredOutputRetry<T>(fn: () => Promise<T>): Promise<T> {
+async function generateWithStructuredOutputRetry<T>(
+  fn: () => Promise<T>,
+  bindings: Record<string, unknown> = {},
+): Promise<T> {
   try {
     return await fn();
   } catch (err) {
     if (!isStructuredOutputValidationError(err)) throw err;
     log.warn(
-      { err },
+      { ...bindings, err },
       "structured output validation failed, retrying once before giving up on this pass",
     );
     return await fn();
   }
 }
 
-async function generateWithTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+async function generateWithTransientRetry<T>(
+  fn: () => Promise<T>,
+  bindings: Record<string, unknown> = {},
+): Promise<T> {
   const maxRetries = readMaxTransientRetries();
   let lastErr: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -75,7 +81,7 @@ async function generateWithTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
       if (!isTransientRetryableError(err) || attempt === maxRetries) throw err;
       const backoffMs = TRANSIENT_RETRY_BACKOFF_MS[attempt];
       log.warn(
-        { err, attempt: attempt + 1, maxRetries, backoffMs },
+        { ...bindings, err, attempt: attempt + 1, maxRetries, backoffMs },
         "transient LLM error, retrying after backoff",
       );
       await new Promise((resolve) => setTimeout(resolve, backoffMs));
@@ -163,28 +169,52 @@ export async function runReview(
   const rawModelSettings = options?.modelSettings ?? resolveModelSettings("review");
   const modelSettings = applyModelConstraints(modelConfig, rawModelSettings);
   const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
-  const response = await generateWithTransientRetry(() =>
-    generateWithStructuredOutputRetry(async () => {
-      const r = await agent.generate(userMessage, {
-        structuredOutput: { schema, jsonPromptInjection },
-        ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-      });
-      // mastra's prompt-injected JSON path can silently return object:undefined
-      // when the model emits unparseable text instead of throwing the schema
-      // validation error. surface it as one so the retry wrapper picks it up.
-      // typed cast because mastra's return type marks .object as always defined.
-      if (!(r as { object?: unknown }).object) {
-        const err = new Error(
-          "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
-        );
-        (err as Error & { id?: string }).id = STRUCTURED_OUTPUT_VALIDATION_ERROR_ID;
-        throw err;
-      }
-      return r;
-    }),
+  const logBindings = { model: modelName, tier };
+  const response = await generateWithTransientRetry(
+    () =>
+      generateWithStructuredOutputRetry(async () => {
+        const r = await agent.generate(userMessage, {
+          structuredOutput: { schema, jsonPromptInjection },
+          ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+        });
+        // mastra's prompt-injected JSON path can silently return object:undefined
+        // when the model emits unparseable text instead of throwing the schema
+        // validation error. surface it as one so the retry wrapper picks it up.
+        // typed cast because mastra's return type marks .object as always defined.
+        if (!(r as { object?: unknown }).object) {
+          const err = new Error(
+            "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
+          );
+          (err as Error & { id?: string }).id = STRUCTURED_OUTPUT_VALIDATION_ERROR_ID;
+          throw err;
+        }
+        return r;
+      }, logBindings),
+    logBindings,
   );
 
   const parsed = response.object;
+  const usage = response.usage as {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
+  };
+  const totalTokens = usage.totalTokens ?? 0;
+
+  log.info(
+    {
+      model: modelName,
+      tier,
+      tokens: totalTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cachedInputTokens: usage.cachedInputTokens,
+      reasoningTokens: usage.reasoningTokens,
+    },
+    "review pass complete",
+  );
 
   return {
     summary: parsed.summary,
@@ -204,6 +234,6 @@ export async function runReview(
         : [],
     filesReviewed: parsed.filesReviewed,
     modelUsed: modelName,
-    tokenCount: response.usage.totalTokens ?? 0,
+    tokenCount: totalTokens,
   };
 }

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -51,6 +51,39 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
+// captures the fields most useful for diagnosing why r.object came back
+// undefined: did the model truncate (finishReason: "length"), did it emit
+// text wrapped in code fences, or did it pick a tool-call path the parser
+// didn't expect? we cap text snippets so a multi-megabyte response can't
+// blow up the log line.
+const FAILED_RESPONSE_TEXT_PREVIEW_CHARS = 400;
+
+function summarizeFailedResponse(r: unknown): Record<string, unknown> {
+  const resp = r as {
+    finishReason?: unknown;
+    text?: unknown;
+    reasoning?: unknown;
+    warnings?: unknown;
+    toolCalls?: unknown;
+    usage?: { totalTokens?: unknown; outputTokens?: unknown };
+  };
+  const text = typeof resp.text === "string" ? resp.text : undefined;
+  const reasoning = typeof resp.reasoning === "string" ? resp.reasoning : undefined;
+  const toolCallCount = Array.isArray(resp.toolCalls) ? resp.toolCalls.length : undefined;
+  const warningCount = Array.isArray(resp.warnings) ? resp.warnings.length : undefined;
+  return {
+    finishReason: resp.finishReason,
+    textLength: text?.length ?? 0,
+    textPreview: text?.slice(0, FAILED_RESPONSE_TEXT_PREVIEW_CHARS),
+    reasoningLength: reasoning?.length,
+    toolCallCount,
+    warningCount,
+    warnings: warningCount && warningCount > 0 ? resp.warnings : undefined,
+    outputTokens: resp.usage?.outputTokens,
+    totalTokens: resp.usage?.totalTokens,
+  };
+}
+
 async function generateWithStructuredOutputRetry<T>(
   fn: () => Promise<T>,
   bindings: Record<string, unknown> = {},
@@ -182,6 +215,10 @@ export async function runReview(
         // validation error. surface it as one so the retry wrapper picks it up.
         // typed cast because mastra's return type marks .object as always defined.
         if (!(r as { object?: unknown }).object) {
+          log.warn(
+            { ...logBindings, ...summarizeFailedResponse(r) },
+            "structured output produced no object — captured diagnostic snapshot",
+          );
           const err = new Error(
             "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
           );


### PR DESCRIPTION
## Summary

When a heterogeneous consensus run dies (e.g. `azure/gpt-5.3-codex`, `azure-foundry/Kimi-K2.6`, `azure-anthropic/claude-sonnet-4-6` running in parallel), the failure logs identified the dead pass only by `passIndex`, forcing the operator to scroll back to the earlier `starting consensus review` log and count positions to figure out which model failed. The same pattern was missing on token usage — `triage complete` and `generated PR description` already report `model` + `tokens`, but per-pass review didn't.

Plumb `{ model, tier }` through the review-time retry helpers, attach the model display name to the consensus pass-failed warn, and add a per-pass `review pass complete` log with the full token breakdown (input/output/cached/reasoning).

## Before / after

**Before** — failure log had no model:
```json
{"level":40,"module":"review","err":{...},"msg":"structured output validation failed, retrying once before giving up on this pass"}
{"level":40,"err":{...},"passIndex":2,"prId":"2390","msg":"consensus pass failed"}
```

**After** — every retry warn and pass-failure includes the model:
```json
{"level":40,"module":"review","model":"azure-foundry/Kimi-K2.6","tier":"deep-review","err":{...},"msg":"structured output validation failed, retrying once before giving up on this pass"}
{"level":40,"err":{...},"passIndex":2,"model":"azure-anthropic/claude-sonnet-4-6","prId":"2390","msg":"consensus pass failed"}
{"level":30,"model":"azure/gpt-5.3-codex","tier":"deep-review","tokens":12450,"inputTokens":11900,"outputTokens":550,"cachedInputTokens":0,"reasoningTokens":0,"msg":"review pass complete"}
{"level":30,"passes":3,"failedPasses":2,"passModels":["azure/gpt-5.3-codex","azure-foundry/Kimi-K2.6","azure-anthropic/claude-sonnet-4-6"],"passTokens":[12450,0,0],"totalTokens":12450,"msg":"consensus voting complete"}
```

## Test plan

- [x] Full workspace suite (803 tests across 29 files) passes locally.
- [x] Hook-emitted log samples during the test run confirm the new shape (model on failure log; `passModels`/`passTokens`/`totalTokens` on voting-complete).
- [ ] Verify on a live multi-model consensus run.