### PR TITLE
feat(core): add RUSTY_LLM_DISABLE_THINKING per-deployment knob for Foundry

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_LLM_MAX_RETRIES` | application-level retries on transient LLM errors (max 2) | `2` |
 | `RUSTY_LLM_JSON_PROMPT_INJECTION` | comma-separated model IDs (or `prefix*` wildcards) to force-on prompt-injected JSON output, overriding the auto-detected default | — |
 | `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT` | comma-separated model IDs (or `prefix*` wildcards) to force-on native `json_schema` structured output, overriding the auto-detected default | — |
+| `RUSTY_LLM_DISABLE_THINKING` | comma-separated `azure-foundry/<deployment>` IDs (or `prefix*` wildcards) to send `thinking: { type: "disabled" }` on chat-completions requests. Useful for Moonshot Kimi K2 deployments whose thinking trace eats the output budget and causes JSON truncation. Only takes effect on `azure-foundry/*` configs. | — |
 | `RUSTY_LLM_TEMPERATURE` | global LLM temperature | provider default |
 | `RUSTY_LLM_TOP_P` | global LLM top-p | provider default |
 | `RUSTY_REVIEW_TEMPERATURE` | temperature override for the review agent | `RUSTY_LLM_TEMPERATURE` |

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -6,10 +6,12 @@ import {
   resolveReviewPassModelConfigs,
   getModelDisplayName,
   resolveDefaultAgentOptions,
+  resolveDisableThinking,
   resolveJsonPromptInjection,
   supportsAnthropicCacheControl,
   supportsNativeStructuredOutput,
   applyModelConstraints,
+  mutateBodyForFoundry,
 } from "../agent/model.js";
 
 function clearEnv() {
@@ -39,6 +41,7 @@ function clearEnv() {
   delete process.env.RUSTY_PROMPT_CACHE;
   delete process.env.RUSTY_LLM_JSON_PROMPT_INJECTION;
   delete process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT;
+  delete process.env.RUSTY_LLM_DISABLE_THINKING;
 }
 
 describe("resolveModelConfig", () => {
@@ -677,6 +680,161 @@ describe("resolveJsonPromptInjection", () => {
     expect(
       resolveJsonPromptInjection({ type: "router", model: "requesty/openai/gpt-5-mini" }),
     ).toBe(false);
+  });
+});
+
+describe("resolveDisableThinking", () => {
+  beforeEach(clearEnv);
+
+  it("returns false when env var is unset", () => {
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for an azure-foundry config that matches the env list", () => {
+    process.env.RUSTY_LLM_DISABLE_THINKING = "azure-foundry/Kimi-K2.6";
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-managed-identity",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+      }),
+    ).toBe(true);
+  });
+
+  it("supports trailing-* wildcard for foundry deployments", () => {
+    process.env.RUSTY_LLM_DISABLE_THINKING = "azure-foundry/Kimi-*";
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Llama-3.3",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+  });
+
+  it("only takes effect on azure-foundry configs (other types ignored even if matched)", () => {
+    process.env.RUSTY_LLM_DISABLE_THINKING =
+      "azure-openai/gpt-5.4-mini,anthropic/claude-sonnet-4-6";
+    expect(
+      resolveDisableThinking({
+        type: "azure-api-key",
+        resourceName: "r",
+        deploymentName: "gpt-5.4-mini",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+    expect(resolveDisableThinking({ type: "router", model: "anthropic/claude-sonnet-4-6" })).toBe(
+      false,
+    );
+  });
+
+  it("matches one foundry deployment without affecting another", () => {
+    process.env.RUSTY_LLM_DISABLE_THINKING = "azure-foundry/Kimi-K2.6";
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(true);
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Llama-3.3",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores empty env var", () => {
+    process.env.RUSTY_LLM_DISABLE_THINKING = "";
+    expect(
+      resolveDisableThinking({
+        type: "azure-foundry-api-key",
+        resourceName: "r",
+        deploymentName: "Kimi-K2.6",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+  });
+});
+
+describe("mutateBodyForFoundry", () => {
+  it("injects thinking:{type:disabled} into a JSON body when disableThinking is set", () => {
+    const init: Record<string, unknown> = {
+      body: JSON.stringify({ model: "Kimi-K2.6", messages: [{ role: "user", content: "hi" }] }),
+    };
+    mutateBodyForFoundry(init, { disableThinking: true });
+    expect(JSON.parse(init.body as string)).toEqual({
+      model: "Kimi-K2.6",
+      messages: [{ role: "user", content: "hi" }],
+      thinking: { type: "disabled" },
+    });
+  });
+
+  it("overrides any caller-provided thinking field", () => {
+    const init: Record<string, unknown> = {
+      body: JSON.stringify({ model: "x", thinking: { type: "enabled" } }),
+    };
+    mutateBodyForFoundry(init, { disableThinking: true });
+    expect((JSON.parse(init.body as string) as Record<string, unknown>).thinking).toEqual({
+      type: "disabled",
+    });
+  });
+
+  it("is a no-op when no flags are set", () => {
+    const init: Record<string, unknown> = { body: JSON.stringify({ model: "x" }) };
+    mutateBodyForFoundry(init, {});
+    expect(init.body).toBe(JSON.stringify({ model: "x" }));
+  });
+
+  it("silently leaves non-JSON bodies alone", () => {
+    const formData = "form-data-not-json";
+    const init: Record<string, unknown> = { body: formData };
+    mutateBodyForFoundry(init, { disableThinking: true });
+    expect(init.body).toBe(formData);
+  });
+
+  it("silently leaves missing body alone", () => {
+    const init: Record<string, unknown> = {};
+    mutateBodyForFoundry(init, { disableThinking: true });
+    expect(init.body).toBeUndefined();
+  });
+
+  it("silently leaves a JSON body that parses to an array alone", () => {
+    const init: Record<string, unknown> = { body: JSON.stringify([1, 2, 3]) };
+    mutateBodyForFoundry(init, { disableThinking: true });
+    expect(init.body).toBe(JSON.stringify([1, 2, 3]));
+  });
+
+  it("ignores undefined init", () => {
+    expect(() => mutateBodyForFoundry(undefined, { disableThinking: true })).not.toThrow();
   });
 });
 

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -156,7 +156,12 @@ export async function runConsensusReview(
     } else {
       failures.push(outcome.reason);
       logger.warn(
-        { err: outcome.reason, passIndex: i, prId: prMetadata.id },
+        {
+          err: outcome.reason,
+          passIndex: i,
+          model: passModelConfigs[i].displayName,
+          prId: prMetadata.id,
+        },
         "consensus pass failed",
       );
     }
@@ -220,6 +225,11 @@ export async function runConsensusReview(
       droppedObservations: totalRawObservations - survivingObservations.length,
       agreementRate,
       passRecommendations,
+      passModels: passModelConfigs.map((m) => m.displayName),
+      passTokens: settled.map((outcome) =>
+        outcome.status === "fulfilled" ? outcome.value.tokenCount : 0,
+      ),
+      totalTokens,
     },
     "consensus voting complete",
   );

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -117,6 +117,42 @@ export function resolveTriageModelConfig(): ModelConfig | null {
   return resolveModelConfigWithOverride(triageModel);
 }
 
+interface FoundryBodyOptions {
+  disableThinking?: boolean;
+}
+
+// foundry chat completions accepts vendor-specific body fields like
+// `thinking: { type: "disabled" }` (Moonshot/Kimi) that have no equivalent
+// passthrough in @ai-sdk/openai's typed options. mutate the JSON body in-place
+// before it goes on the wire. silently no-ops on non-JSON bodies (streaming
+// uploads, FormData, etc.) — those don't apply to chat completions today.
+export function mutateBodyForFoundry(
+  init: Record<string, unknown> | undefined,
+  opts: FoundryBodyOptions,
+): void {
+  if (!init || typeof init.body !== "string") return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(init.body);
+  } catch {
+    return;
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) return;
+  const body = parsed as Record<string, unknown>;
+  if (opts.disableThinking) {
+    body.thinking = { type: "disabled" };
+  }
+  init.body = JSON.stringify(body);
+}
+
+function makeFoundryFetch(opts: FoundryBodyOptions): typeof globalThis.fetch {
+  return (async (input: unknown, init?: Record<string, unknown>) => {
+    const next = { ...init };
+    mutateBodyForFoundry(next, opts);
+    return globalThis.fetch(input as Parameters<typeof fetch>[0], next);
+  }) as typeof globalThis.fetch;
+}
+
 export function resolveModel(
   config: ModelConfig,
 ): string | ReturnType<ReturnType<typeof createAzure>> {
@@ -151,9 +187,11 @@ export function resolveModel(
     }
 
     case "azure-foundry-api-key": {
+      const disableThinking = resolveDisableThinking(config);
       const azure = createAzure({
         resourceName: config.resourceName,
         apiKey: config.apiKey,
+        ...(disableThinking && { fetch: makeFoundryFetch({ disableThinking: true }) }),
       });
       // .chat() routes to /v1/chat/completions; the default azure() picks
       // /v1/responses, which non-OpenAI Foundry models reject
@@ -163,12 +201,15 @@ export function resolveModel(
     case "azure-foundry-managed-identity": {
       const credential = new DefaultAzureCredential();
       const scope = "https://cognitiveservices.azure.com/.default";
+      const disableThinking = resolveDisableThinking(config);
 
       const azureFetch = (async (input: unknown, init?: Record<string, unknown>) => {
         const token = await credential.getToken(scope);
         const headers = new Headers(init?.headers as ConstructorParameters<typeof Headers>[0]);
         headers.set("Authorization", `Bearer ${token.token}`);
-        return globalThis.fetch(input as Parameters<typeof fetch>[0], { ...init, headers });
+        const next = { ...init, headers };
+        if (disableThinking) mutateBodyForFoundry(next, { disableThinking: true });
+        return globalThis.fetch(input as Parameters<typeof fetch>[0], next);
       }) as typeof globalThis.fetch;
 
       const azure = createAzure({
@@ -306,6 +347,22 @@ export function resolveJsonPromptInjection(config: ModelConfig): boolean {
   if (forceOff.length > 0 && matchesAny(key, forceOff)) return false;
 
   return !supportsNativeStructuredOutput(config);
+}
+
+/**
+ * Whether the deployment should have its thinking/reasoning trace disabled at
+ * request time. Currently only takes effect on azure-foundry/* deployments —
+ * other paths have no Foundry-style `thinking` knob to flip. Matches the
+ * model display name against `RUSTY_LLM_DISABLE_THINKING` (CSV with trailing-*
+ * wildcards), same pattern as `RUSTY_LLM_JSON_PROMPT_INJECTION`.
+ */
+export function resolveDisableThinking(config: ModelConfig): boolean {
+  if (config.type !== "azure-foundry-api-key" && config.type !== "azure-foundry-managed-identity") {
+    return false;
+  }
+  const patterns = readCsvEnv("RUSTY_LLM_DISABLE_THINKING");
+  if (patterns.length === 0) return false;
+  return matchesAny(modelMatchKey(config), patterns);
 }
 
 export interface ModelSettings {

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -51,20 +51,26 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
-async function generateWithStructuredOutputRetry<T>(fn: () => Promise<T>): Promise<T> {
+async function generateWithStructuredOutputRetry<T>(
+  fn: () => Promise<T>,
+  bindings: Record<string, unknown> = {},
+): Promise<T> {
   try {
     return await fn();
   } catch (err) {
     if (!isStructuredOutputValidationError(err)) throw err;
     log.warn(
-      { err },
+      { ...bindings, err },
       "structured output validation failed, retrying once before giving up on this pass",
     );
     return await fn();
   }
 }
 
-async function generateWithTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
+async function generateWithTransientRetry<T>(
+  fn: () => Promise<T>,
+  bindings: Record<string, unknown> = {},
+): Promise<T> {
   const maxRetries = readMaxTransientRetries();
   let lastErr: unknown;
   for (let attempt = 0; attempt <= maxRetries; attempt++) {
@@ -75,7 +81,7 @@ async function generateWithTransientRetry<T>(fn: () => Promise<T>): Promise<T> {
       if (!isTransientRetryableError(err) || attempt === maxRetries) throw err;
       const backoffMs = TRANSIENT_RETRY_BACKOFF_MS[attempt];
       log.warn(
-        { err, attempt: attempt + 1, maxRetries, backoffMs },
+        { ...bindings, err, attempt: attempt + 1, maxRetries, backoffMs },
         "transient LLM error, retrying after backoff",
       );
       await new Promise((resolve) => setTimeout(resolve, backoffMs));
@@ -163,28 +169,52 @@ export async function runReview(
   const rawModelSettings = options?.modelSettings ?? resolveModelSettings("review");
   const modelSettings = applyModelConstraints(modelConfig, rawModelSettings);
   const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
-  const response = await generateWithTransientRetry(() =>
-    generateWithStructuredOutputRetry(async () => {
-      const r = await agent.generate(userMessage, {
-        structuredOutput: { schema, jsonPromptInjection },
-        ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-      });
-      // mastra's prompt-injected JSON path can silently return object:undefined
-      // when the model emits unparseable text instead of throwing the schema
-      // validation error. surface it as one so the retry wrapper picks it up.
-      // typed cast because mastra's return type marks .object as always defined.
-      if (!(r as { object?: unknown }).object) {
-        const err = new Error(
-          "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
-        );
-        (err as Error & { id?: string }).id = STRUCTURED_OUTPUT_VALIDATION_ERROR_ID;
-        throw err;
-      }
-      return r;
-    }),
+  const logBindings = { model: modelName, tier };
+  const response = await generateWithTransientRetry(
+    () =>
+      generateWithStructuredOutputRetry(async () => {
+        const r = await agent.generate(userMessage, {
+          structuredOutput: { schema, jsonPromptInjection },
+          ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+        });
+        // mastra's prompt-injected JSON path can silently return object:undefined
+        // when the model emits unparseable text instead of throwing the schema
+        // validation error. surface it as one so the retry wrapper picks it up.
+        // typed cast because mastra's return type marks .object as always defined.
+        if (!(r as { object?: unknown }).object) {
+          const err = new Error(
+            "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
+          );
+          (err as Error & { id?: string }).id = STRUCTURED_OUTPUT_VALIDATION_ERROR_ID;
+          throw err;
+        }
+        return r;
+      }, logBindings),
+    logBindings,
   );
 
   const parsed = response.object;
+  const usage = response.usage as {
+    inputTokens?: number;
+    outputTokens?: number;
+    totalTokens?: number;
+    cachedInputTokens?: number;
+    reasoningTokens?: number;
+  };
+  const totalTokens = usage.totalTokens ?? 0;
+
+  log.info(
+    {
+      model: modelName,
+      tier,
+      tokens: totalTokens,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+      cachedInputTokens: usage.cachedInputTokens,
+      reasoningTokens: usage.reasoningTokens,
+    },
+    "review pass complete",
+  );
 
   return {
     summary: parsed.summary,
@@ -204,6 +234,6 @@ export async function runReview(
         : [],
     filesReviewed: parsed.filesReviewed,
     modelUsed: modelName,
-    tokenCount: response.usage.totalTokens ?? 0,
+    tokenCount: totalTokens,
   };
 }

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -51,6 +51,39 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
+// captures the fields most useful for diagnosing why r.object came back
+// undefined: did the model truncate (finishReason: "length"), did it emit
+// text wrapped in code fences, or did it pick a tool-call path the parser
+// didn't expect? we cap text snippets so a multi-megabyte response can't
+// blow up the log line.
+const FAILED_RESPONSE_TEXT_PREVIEW_CHARS = 400;
+
+function summarizeFailedResponse(r: unknown): Record<string, unknown> {
+  const resp = r as {
+    finishReason?: unknown;
+    text?: unknown;
+    reasoning?: unknown;
+    warnings?: unknown;
+    toolCalls?: unknown;
+    usage?: { totalTokens?: unknown; outputTokens?: unknown };
+  };
+  const text = typeof resp.text === "string" ? resp.text : undefined;
+  const reasoning = typeof resp.reasoning === "string" ? resp.reasoning : undefined;
+  const toolCallCount = Array.isArray(resp.toolCalls) ? resp.toolCalls.length : undefined;
+  const warningCount = Array.isArray(resp.warnings) ? resp.warnings.length : undefined;
+  return {
+    finishReason: resp.finishReason,
+    textLength: text?.length ?? 0,
+    textPreview: text?.slice(0, FAILED_RESPONSE_TEXT_PREVIEW_CHARS),
+    reasoningLength: reasoning?.length,
+    toolCallCount,
+    warningCount,
+    warnings: warningCount && warningCount > 0 ? resp.warnings : undefined,
+    outputTokens: resp.usage?.outputTokens,
+    totalTokens: resp.usage?.totalTokens,
+  };
+}
+
 async function generateWithStructuredOutputRetry<T>(
   fn: () => Promise<T>,
   bindings: Record<string, unknown> = {},
@@ -182,6 +215,10 @@ export async function runReview(
         // validation error. surface it as one so the retry wrapper picks it up.
         // typed cast because mastra's return type marks .object as always defined.
         if (!(r as { object?: unknown }).object) {
+          log.warn(
+            { ...logBindings, ...summarizeFailedResponse(r) },
+            "structured output produced no object — captured diagnostic snapshot",
+          );
           const err = new Error(
             "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
           );


### PR DESCRIPTION
## Summary

Foundry's chat-completions endpoint accepts a Moonshot-specific body field — `thinking: { type: "disabled" }` — that pins Kimi K2.5/K2.6 to their non-thinking mode. `@ai-sdk/openai`'s typed `OpenAILanguageModelChatOptions` has no passthrough for vendor-specific body fields, so this PR plumbs it via a fetch wrapper that mutates the JSON body before it goes on the wire. Matching is per-deployment, reusing the existing CSV + trailing-`*` wildcard pattern (same shape as `RUSTY_LLM_JSON_PROMPT_INJECTION` / `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT`).

```bash
# disable thinking only for Kimi K2.6
RUSTY_LLM_DISABLE_THINKING=azure-foundry/Kimi-K2.6

# or for all Kimi deployments via wildcard
RUSTY_LLM_DISABLE_THINKING=azure-foundry/Kimi-*
```

## Why

A live `azure-foundry/Kimi-K2.6` consensus pass timed out at undici's 30s headers-timeout. The diagnostic logging from #149 caught the picture: when the response did finally come, `outputTokens` was small but the wall-clock was huge — the model spent the budget on `reasoning_content` before any JSON started, and the request blew past undici's headers ceiling. Disabling thinking shrinks both wall-clock and output payload back to normal.

Also covers: the parallel Claude failure on the same run had `finishReason: "tool-calls"` with 10 parallel tool calls — that's a separate Mastra+Anthropic issue, not addressed here.

## Test plan

- [x] Full suite green (816 tests).
- [x] Direct unit tests for `mutateBodyForFoundry` cover happy path, override of caller-supplied `thinking`, no-op when no flags set, non-JSON bodies, missing body, JSON-array body, undefined init.
- [x] `resolveDisableThinking` covers: unset env, exact match, wildcard match, only takes effect on `azure-foundry/*` configs, empty env.
- [ ] Verify on a live consensus run with `RUSTY_LLM_DISABLE_THINKING=azure-foundry/Kimi-K2.6` set.