### PR TITLE
feat(core): wire Anthropic prompt caching for the judge agent

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -11,6 +11,8 @@ vi.mock("@mastra/core/agent", () => ({
 
 const resolveJsonPromptInjectionMock = vi.fn(() => false);
 
+const supportsAnthropicCacheControlMock = vi.fn(() => false);
+
 vi.mock("../agent/model.js", () => ({
   resolveModelConfig: vi.fn(() => ({ type: "router", model: "test-model" })),
   resolveModelConfigWithOverride: vi.fn((model: string) => ({ type: "router", model })),
@@ -23,10 +25,12 @@ vi.mock("../agent/model.js", () => ({
   resolveModelSettings: vi.fn(() => ({})),
   resolveDefaultAgentOptions: vi.fn(() => undefined),
   resolveJsonPromptInjection: resolveJsonPromptInjectionMock,
+  supportsAnthropicCacheControl: supportsAnthropicCacheControlMock,
   applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
 
-const { judgeFindings, judgeReviewResult, resolveJudgeConfig } = await import("../agent/judge.js");
+const { judgeFindings, judgeReviewResult, resolveJudgeConfig, buildJudgeUserMessage } =
+  await import("../agent/judge.js");
 
 const DIFF = `--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,5 @@\n+import { z } from "zod";\n const app = express();\n+app.get("/health", (req, res) => res.json({ ok: true }));\n`;
 
@@ -143,8 +147,11 @@ describe("judgeFindings", () => {
     await judgeFindings(findings, DIFF, enabledConfig);
 
     const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
-    const instructions = agentConfig?.instructions as (() => string) | undefined;
-    const prompt = instructions?.();
+    const instructions = agentConfig?.instructions as
+      | (() => string | { role: "system"; content: string }[])
+      | undefined;
+    const result = instructions?.();
+    const prompt = typeof result === "string" ? result : (result?.[0]?.content ?? "");
     expect(prompt).toContain("Default to rejection");
     expect(prompt).toContain("missing-test complaints");
     expect(prompt).toContain("severity-inflated findings");
@@ -531,5 +538,131 @@ describe("judgeFindings jsonPromptInjection forwarding", () => {
 
     const callArgs = generateMock.mock.calls[0][1];
     expect(callArgs.structuredOutput.jsonPromptInjection).toBe(false);
+  });
+});
+
+describe("buildJudgeUserMessage", () => {
+  it("returns a plain string when anthropicCacheControl is false", () => {
+    const result = buildJudgeUserMessage([makeFinding()], DIFF, { anthropicCacheControl: false });
+    expect(typeof result).toBe("string");
+    expect(result).toContain("## Diff under review");
+    expect(result).toContain("## Findings to evaluate");
+    expect(result).toContain(DIFF);
+  });
+
+  it("returns a multi-part user message when anthropicCacheControl is true", () => {
+    const result = buildJudgeUserMessage([makeFinding()], DIFF, { anthropicCacheControl: true });
+    expect(typeof result).toBe("object");
+    if (typeof result === "string") return;
+    expect(result.role).toBe("user");
+    expect(result.content).toHaveLength(2);
+  });
+
+  it("places cacheControl on the diff block, not the findings block", () => {
+    const result = buildJudgeUserMessage([makeFinding()], DIFF, { anthropicCacheControl: true });
+    if (typeof result === "string") throw new Error("expected multi-part");
+    const [diffPart, findingsPart] = result.content;
+    expect(diffPart.text).toContain("## Diff under review");
+    expect(diffPart.text).toContain(DIFF);
+    expect(diffPart.providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+    expect(findingsPart.text).toContain("## Findings to evaluate");
+    expect(findingsPart.providerOptions).toBeUndefined();
+  });
+
+  it("includes the same finding metadata in both modes (cached and non-cached)", () => {
+    const finding = makeFinding({ message: "specific issue text", line: 42 });
+    const stringForm = buildJudgeUserMessage([finding], DIFF, { anthropicCacheControl: false });
+    const partsForm = buildJudgeUserMessage([finding], DIFF, { anthropicCacheControl: true });
+    if (typeof partsForm === "string") throw new Error("expected multi-part");
+
+    const partsCombined = partsForm.content.map((p) => p.text).join("\n");
+    expect(stringForm).toContain("specific issue text");
+    expect(partsCombined).toContain("specific issue text");
+    expect(stringForm).toContain("**Line:** 42");
+    expect(partsCombined).toContain("**Line:** 42");
+  });
+});
+
+describe("judgeFindings cache wiring", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+    supportsAnthropicCacheControlMock.mockReset();
+  });
+
+  it("passes a multi-part user message to agent.generate when supportsAnthropicCacheControl is true", async () => {
+    supportsAnthropicCacheControlMock.mockReturnValue(true);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const messages = generateMock.mock.calls[0][0] as {
+      role: string;
+      content: { providerOptions?: unknown }[];
+    }[];
+    expect(Array.isArray(messages)).toBe(true);
+    expect(messages[0].role).toBe("user");
+    expect(messages[0].content[0].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  it("passes a plain string user message when supportsAnthropicCacheControl is false", async () => {
+    supportsAnthropicCacheControlMock.mockReturnValue(false);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const userMessage = generateMock.mock.calls[0][0];
+    expect(typeof userMessage).toBe("string");
+  });
+
+  it("wraps system prompt with anthropic cacheControl when supported", async () => {
+    supportsAnthropicCacheControlMock.mockReturnValue(true);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const { Agent } = await import("@mastra/core/agent");
+    const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
+    const instructions = agentConfig?.instructions as
+      | (() => string | { role: "system"; content: string; providerOptions?: unknown }[])
+      | undefined;
+    const result = instructions?.();
+    expect(Array.isArray(result)).toBe(true);
+    if (!Array.isArray(result)) return;
+    expect(result[0].providerOptions).toEqual({
+      anthropic: { cacheControl: { type: "ephemeral" } },
+    });
+  });
+
+  it("returns a plain system prompt when anthropic cacheControl is not supported", async () => {
+    supportsAnthropicCacheControlMock.mockReturnValue(false);
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 25 },
+    });
+
+    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+
+    const { Agent } = await import("@mastra/core/agent");
+    const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
+    const instructions = agentConfig?.instructions as
+      | (() => string | { role: "system"; content: string; providerOptions?: unknown }[])
+      | undefined;
+    const result = instructions?.();
+    if (Array.isArray(result)) {
+      expect(result[0].providerOptions).toBeUndefined();
+    }
   });
 });

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -8,8 +8,10 @@ import {
   resolveModelSettings,
   resolveDefaultAgentOptions,
   resolveJsonPromptInjection,
+  supportsAnthropicCacheControl,
   applyModelConstraints,
 } from "./model.js";
+import { buildCachedSystemMessages } from "./prompts.js";
 import type { Finding, ReviewResult } from "../types.js";
 import { logger } from "../logger.js";
 
@@ -73,13 +75,12 @@ Reject or heavily penalize findings that are:
 
 You MUST return exactly one evaluation per finding, in the same order they were provided.`;
 
-function formatFindingsForJudge(findings: readonly Finding[], diff: string): string {
-  const parts: string[] = [];
+function buildDiffBlock(diff: string): string {
+  return `## Diff under review\n\n${diff}\n`;
+}
 
-  parts.push("## Diff under review\n");
-  parts.push(diff);
-  parts.push("\n## Findings to evaluate\n");
-
+function buildFindingsBlock(findings: readonly Finding[]): string {
+  const parts: string[] = ["## Findings to evaluate\n"];
   for (let i = 0; i < findings.length; i++) {
     const f = findings[i];
     const lineRange = f.endLine ? `${f.line}-${f.endLine}` : `${f.line}`;
@@ -94,8 +95,57 @@ function formatFindingsForJudge(findings: readonly Finding[], diff: string): str
     }
     parts.push("");
   }
-
   return parts.join("\n");
+}
+
+interface CacheableTextPart {
+  type: "text";
+  text: string;
+  providerOptions?: { anthropic: { cacheControl: { type: "ephemeral" } } };
+}
+
+interface CacheableUserMessage {
+  role: "user";
+  content: CacheableTextPart[];
+}
+
+/**
+ * Build the user message for the judge. When the underlying provider supports
+ * Anthropic-style ephemeral cache markers, the diff (the bulk of the input) is
+ * placed in its own text block with cacheControl set so it can be reused
+ * across calls. The findings list comes after the cache breakpoint so it
+ * doesn't invalidate the cached prefix.
+ *
+ * Real cache hits require the cached prefix (system + earlier blocks + this
+ * block) to be byte-identical, AND the prefix to clear Anthropic's 1024-token
+ * floor for ephemeral cache. So this only earns its keep when the same diff
+ * is judged again within ~5 minutes — typically a manual re-run of the same
+ * PR. For non-Anthropic providers we fall back to a plain string and let
+ * Azure OpenAI's automatic prefix caching do its thing server-side.
+ */
+export function buildJudgeUserMessage(
+  findings: readonly Finding[],
+  diff: string,
+  options: { anthropicCacheControl: boolean },
+): string | CacheableUserMessage {
+  const diffBlock = buildDiffBlock(diff);
+  const findingsBlock = buildFindingsBlock(findings);
+
+  if (!options.anthropicCacheControl) {
+    return `${diffBlock}\n${findingsBlock}`;
+  }
+
+  return {
+    role: "user",
+    content: [
+      {
+        type: "text",
+        text: diffBlock,
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      },
+      { type: "text", text: findingsBlock },
+    ],
+  };
 }
 
 function resolveJudgeModel(judgeModelOverride?: string) {
@@ -148,25 +198,29 @@ export async function judgeFindings(
   );
 
   const defaultOptions = resolveDefaultAgentOptions(modelConfig);
+  const anthropicCacheControl = supportsAnthropicCacheControl(modelConfig);
   const agent = new Agent({
     id: "review-judge",
     name: "Rusty Bot Judge",
-    instructions: () => JUDGE_SYSTEM_PROMPT,
+    instructions: () => buildCachedSystemMessages(JUDGE_SYSTEM_PROMPT, { anthropicCacheControl }),
     model: () => resolveModel(modelConfig),
     ...(defaultOptions && { defaultOptions }),
   });
 
-  const userMessage = formatFindingsForJudge(findings, diff);
+  const userMessage = buildJudgeUserMessage(findings, diff, { anthropicCacheControl });
 
   let evaluations: JudgeEvaluation[];
   let tokenCount = 0;
   try {
     const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("judge"));
     const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
-    const response = await agent.generate(userMessage, {
-      structuredOutput: { schema: JudgeOutputSchema, jsonPromptInjection },
-      ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
-    });
+    const response = await agent.generate(
+      typeof userMessage === "string" ? userMessage : [userMessage],
+      {
+        structuredOutput: { schema: JudgeOutputSchema, jsonPromptInjection },
+        ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
+      },
+    );
     evaluations = response.object.evaluations;
     tokenCount = response.usage.totalTokens ?? 0;
   } catch (err) {


### PR DESCRIPTION
## Summary

The judge agent runs on `azure-anthropic/claude-sonnet-4-6` in typical multi-model configs but neither its system prompt nor the diff in its user message were marked with `cache_control`. This PR wraps the system prompt via `buildCachedSystemMessages` (mirroring how `runReview` already does it) and splits the user message into two text blocks so the diff can be its own cacheable ephemeral checkpoint. The findings list comes *after* the cache breakpoint so it doesn't invalidate the cached prefix.

## Honest savings estimate

Modest, by design. The judge runs once per chunk, and each chunk's diff is unique within a single PR, so intra-PR cache hits don't materialize. The win is for **re-runs of the same PR within Anthropic's ~5-minute ephemeral cache window** — when the bot is retried (CI flake, force-push, etc.), the second run's judge call reuses the prior diff cache instead of paying for it again.

The architectural value is bigger than the immediate token savings: this PR establishes the cache-marker pattern (multi-part user message with a diff block) that a follow-up can wire into the review agent. Once review and judge use the **same byte-identical** cacheable diff block format and run on the same Anthropic deployment, review→judge can share the cache for the same chunk in a single run.

## What changes

- `judge.ts`: `JUDGE_SYSTEM_PROMPT` now flows through `buildCachedSystemMessages`. The user message is built by a new exported helper `buildJudgeUserMessage` that returns either a plain string (non-Anthropic providers) or a multi-part user message with `cache_control: ephemeral` on the diff block (Anthropic-supporting configs). `formatFindingsForJudge` was split into `buildDiffBlock` + `buildFindingsBlock` for the multi-part path.
- The `agent.generate` call now passes either a string or `[userMessage]` depending on the provider.
- For non-Anthropic providers (e.g. `azure-openai/*`, `requesty/*`) the wire format is unchanged — they get the same single string they got before, and Azure OpenAI's server-side prefix caching continues to work.

## Test plan

- [x] Eight new tests cover both `buildJudgeUserMessage` shapes (string + multi-part), cache-control placement on the diff (not on findings), parity of finding metadata between modes, agent-level wiring (system message gets `cacheControl: ephemeral` only when supported), and that the right user-message shape reaches `agent.generate`.
- [x] Full workspace suite green (833 tests across 29 files).
- [x] Existing judge test that asserts on the system prompt content updated to handle both string and array shapes.
- [ ] Production verify: run a re-attempt of the same PR within 5 min, look at the judge call's `cachedInputTokens` in the response usage. If &gt; 0, caching is firing.

## Related

- Investigation that motivated this: caching audit done in conversation. Top three fixes identified; this is fix #1.
- Fix #2 (review agent diff cache breakpoint) — separate PR. Will share the diff-block format with this PR.