### PR TITLE
ci(review): set RUSTY_LLM_MAX_STEPS=8 on the bot's self-review

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -37,6 +37,11 @@ jobs:
           RUSTY_LLM_JSON_PROMPT_INJECTION: requesty/fireworks/kimi-k2.6
           RUSTY_REVIEW_TEMPERATURES: "1,0.2,0.3"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
+          # cap tool-using trajectories so tool-happy models (Kimi/Anthropic)
+          # can't terminate with finishReason="tool-calls" and zero text. the
+          # final allowed step gets toolChoice="none" so the model has to emit
+          # the structured-output JSON. see #152.
+          RUSTY_LLM_MAX_STEPS: "8"
           RUSTY_JUDGE_ENABLED: "true"
           RUSTY_JUDGE_MODEL: requesty/anthropic/claude-sonnet-4-6
           RUSTY_JUDGE_TEMPERATURE: "0"


### PR DESCRIPTION
## Summary

The bot's self-review consensus has been failing intermittently when one of the review models (typically Kimi-K2.6 on Fireworks) terminates with `finishReason: "tool-calls"` and zero text — see the failed run on PR #154 which produced `toolCallCount: 6, textLength: 0`. With consensus threshold 2 and only one of two passes succeeding, the whole job fails.

[#152](https://github.com/jegork/rusty-bot/pull/152) (shipped in v1.9.0) added `RUSTY_LLM_MAX_STEPS`, which both caps the trajectory and forces `toolChoice: "none"` on the final allowed step so the model has to emit the structured output it owes. This PR wires it into the bot's own self-review workflow.

`8` gives the model 7 tool-using rounds plus a forced final-answer step — enough for any reasonable code-search exploration before the cap kicks in. The previous failure showed Kimi using 6 tool calls, so 8 has headroom.

## Test plan

- [x] Workflow YAML still parses (`actionlint` clean implicitly via the patch being a single line addition).
- [ ] Verify on this PR's own CI run: the `review` job should pass on the first try, with no `finishReason: "tool-calls"` warnings in the log.