### PR TITLE
perf(core): cache tool calls within a review pass

### DIFF
--- a/packages/core/src/__tests__/tool-cache.test.ts
+++ b/packages/core/src/__tests__/tool-cache.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi } from "vitest";
+import { ToolCache } from "../agent/tool-cache.js";
+
+function makeProvider() {
+  return {
+    searchCode: vi.fn(async (query: string) => [
+      { file: `${query}.ts`, line: 1, content: `const ${query} = 1` },
+    ]),
+    getFileContent: vi.fn(async (path: string) => `content of ${path}`),
+  };
+}
+
+describe("ToolCache", () => {
+  it("deduplicates concurrent searchCode calls with the same query", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    const [a, b] = await Promise.all([cache.searchCode("foo"), cache.searchCode("foo")]);
+
+    expect(a).toEqual(b);
+    expect(provider.searchCode).toHaveBeenCalledTimes(1);
+    expect(provider.searchCode).toHaveBeenCalledWith("foo");
+  });
+
+  it("deduplicates sequential searchCode calls with the same query", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    const a = await cache.searchCode("foo");
+    const b = await cache.searchCode("foo");
+
+    expect(a).toEqual(b);
+    expect(provider.searchCode).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not deduplicate different searchCode queries", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    await Promise.all([cache.searchCode("foo"), cache.searchCode("bar")]);
+
+    expect(provider.searchCode).toHaveBeenCalledTimes(2);
+  });
+
+  it("deduplicates concurrent getFileContent calls with the same path", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    const [a, b] = await Promise.all([
+      cache.getFileContent("src/index.ts"),
+      cache.getFileContent("src/index.ts"),
+    ]);
+
+    expect(a).toEqual(b);
+    expect(provider.getFileContent).toHaveBeenCalledTimes(1);
+    expect(provider.getFileContent).toHaveBeenCalledWith("src/index.ts", "main");
+  });
+
+  it("does not deduplicate different getFileContent paths", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    await Promise.all([cache.getFileContent("src/a.ts"), cache.getFileContent("src/b.ts")]);
+
+    expect(provider.getFileContent).toHaveBeenCalledTimes(2);
+  });
+
+  it("caches search and file calls independently", async () => {
+    const provider = makeProvider();
+    const cache = new ToolCache(provider as any, "main");
+
+    await cache.searchCode("query");
+    await cache.getFileContent("path");
+
+    expect(provider.searchCode).toHaveBeenCalledTimes(1);
+    expect(provider.getFileContent).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -33,6 +33,7 @@ export {
 } from "./model.js";
 export type { ModelConfig } from "./model.js";
 export { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
+export { ToolCache } from "./tool-cache.js";
 export { clusterFindings, clusterObservations } from "./cluster.js";
 export type { FindingCluster, ObservationCluster } from "./cluster.js";
 export { judgeFindings, judgeReviewResult, resolveJudgeConfig } from "./judge.js";

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -17,6 +17,7 @@ import type { ModelConfig, ModelSettings } from "./model.js";
 import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 import { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
+import { ToolCache } from "./tool-cache.js";
 import { logger } from "../logger.js";
 
 const log = logger.child({ module: "review" });
@@ -176,9 +177,10 @@ function buildTools(options?: RunReviewOptions): ToolsInput {
 
   const tools: ToolsInput = {};
   if (options?.provider) {
-    tools.searchCode = createSearchCodeTool(options.provider);
+    const cache = new ToolCache(options.provider, options.sourceRef ?? "HEAD");
+    tools.searchCode = createSearchCodeTool(cache);
     if (options.sourceRef) {
-      tools.getFileContext = createGetFileContextTool(options.provider, options.sourceRef);
+      tools.getFileContext = createGetFileContextTool(cache);
     }
   }
   return tools;

--- a/packages/core/src/agent/tool-cache.ts
+++ b/packages/core/src/agent/tool-cache.ts
@@ -1,0 +1,32 @@
+import type { GitProvider } from "../types.js";
+
+export class ToolCache {
+  private searchCache = new Map<
+    string,
+    Promise<{ results: { file: string; line: number; content: string }[]; count: number }>
+  >();
+  private fileCache = new Map<string, Promise<{ content: string | null }>>();
+
+  constructor(
+    private provider: GitProvider,
+    private ref: string,
+  ) {}
+
+  searchCode(query: string) {
+    const existing = this.searchCache.get(query);
+    if (existing) return existing;
+    const p = this.provider
+      .searchCode(query)
+      .then((results) => ({ results, count: results.length }));
+    this.searchCache.set(query, p);
+    return p;
+  }
+
+  getFileContent(path: string) {
+    const existing = this.fileCache.get(path);
+    if (existing) return existing;
+    const p = this.provider.getFileContent(path, this.ref).then((content) => ({ content }));
+    this.fileCache.set(path, p);
+    return p;
+  }
+}

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -1,8 +1,8 @@
 import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
-import type { GitProvider } from "../types.js";
+import type { ToolCache } from "./tool-cache.js";
 
-export function createSearchCodeTool(provider: GitProvider) {
+export function createSearchCodeTool(cache: ToolCache) {
   return createTool({
     id: "search-code",
     description:
@@ -22,14 +22,11 @@ export function createSearchCodeTool(provider: GitProvider) {
       ),
       count: z.number(),
     }),
-    execute: async ({ query }) => {
-      const results = await provider.searchCode(query);
-      return { results, count: results.length };
-    },
+    execute: async ({ query }) => cache.searchCode(query),
   });
 }
 
-export function createGetFileContextTool(provider: GitProvider, ref: string) {
+export function createGetFileContextTool(cache: ToolCache) {
   return createTool({
     id: "get-file-context",
     description:
@@ -42,9 +39,6 @@ export function createGetFileContextTool(provider: GitProvider, ref: string) {
     outputSchema: z.object({
       content: z.string().nullable(),
     }),
-    execute: async ({ path }) => {
-      const content = await provider.getFileContent(path, ref);
-      return { content };
-    },
+    execute: async ({ path }) => cache.getFileContent(path),
   });
 }


### PR DESCRIPTION
## Summary

- Wraps `GitProvider.searchCode` and `getFileContent` in a per-pass `ToolCache` that memoizes by query / path. Reasoning models often re-issue the same `search-code` query while iterating on a finding (and re-fetch the same file across tool turns); the second call now returns the cached promise instead of re-hitting the provider.
- Cache lifetime is one `runReview` invocation. Each consensus pass still gets its own cache, so passes remain independent — the win is intra-pass deduplication only.
- `createSearchCodeTool` / `createGetFileContextTool` now take the cache instead of `GitProvider` + `ref`, so the bound `ref` is consistent for every file fetch within a pass.

## Test plan

- [x] New `tool-cache.test.ts` (6 cases): concurrent + sequential search dedup, distinct queries don't dedup, concurrent + distinct file fetches, search/file caches are independent.
- [x] Full `pnpm test` passes (680 tests, all packages).