### PR TITLE
feat(core): enable adaptive pass planning by default

### DIFF
--- a/docs/src/content/docs/guides/consensus-voting.md
+++ b/docs/src/content/docs/guides/consensus-voting.md
@@ -31,7 +31,6 @@ RUSTY_REVIEW_MODELS=requesty/anthropic/claude-sonnet-4-6,requesty/openai/gpt-5-m
 RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
 RUSTY_JUDGE_MODEL=requesty/anthropic/claude-sonnet-4-6
 RUSTY_JUDGE_TEMPERATURE=0
-RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
 
 Treat model IDs as provider-specific configuration. If your router uses different current aliases, keep the same role split: cheap structured model for triage, diverse review models for consensus, and a well-calibrated model for the judge.
@@ -50,7 +49,6 @@ RUSTY_REVIEW_MODELS=requesty/anthropic/claude-sonnet-4-6,requesty/openai/gpt-5-m
 RUSTY_REVIEW_TEMPERATURES=0.2,0.2,0.3
 RUSTY_JUDGE_MODEL=requesty/anthropic/claude-sonnet-4-6
 RUSTY_JUDGE_TEMPERATURE=0
-RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
 
 ### ⚖️ Balanced — open-weight reviews + proprietary judge (~$0.10–$0.50/PR) **recommended**
@@ -63,7 +61,6 @@ RUSTY_REVIEW_MODELS=requesty/fireworks/deepseek-v4-pro,requesty/moonshot/kimi-k2
 RUSTY_REVIEW_TEMPERATURES=0.2,1,0.3
 RUSTY_JUDGE_MODEL=requesty/anthropic/claude-sonnet-4-6
 RUSTY_JUDGE_TEMPERATURE=0
-RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
 
 > Use the `requesty/fireworks/` route for DeepSeek V4 Pro. Fireworks proxies `json_schema` natively and exposes the model's reasoning in a separate `reasoning_content` field, so structured output stays intact while thinking still happens. The direct `requesty/deepseek/` route currently corrupts JSON when thinking mode is on ([vllm-project/vllm#41132](https://github.com/vllm-project/vllm/issues/41132)).
@@ -78,7 +75,6 @@ RUSTY_REVIEW_MODELS=requesty/fireworks/deepseek-v4-pro,requesty/moonshot/kimi-k2
 RUSTY_REVIEW_TEMPERATURES=0.2,1,0.3
 RUSTY_JUDGE_MODEL=requesty/fireworks/deepseek-v4-pro
 RUSTY_JUDGE_TEMPERATURE=0
-RUSTY_REVIEW_ADAPTIVE_PASSES=true
 ```
 
 ### Picking a judge
@@ -90,13 +86,13 @@ The judge is the single highest-ROI pass — it runs once per PR over surviving 
 - **`deepseek/deepseek-v4-pro`** — best open-weight option for judge. Cheaper than Sonnet but slightly more permissive.
 - **Avoid for judge**: Gemini Pro (scores inflate ~1pt — too agreeable), reasoning models like o3/o4-mini (overthink, hallucinate severity), Opus 4.7 (overkill — reserve for architecture review).
 
-Adaptive pass planning is opt-in:
+Adaptive pass planning is on by default. Ordinary deep-review chunks use 2 passes, while large or security-sensitive chunks keep up to 3 passes. Explicit `consensusPasses` still caps the maximum number of passes.
+
+To force every chunk through the full pass count:
 
 ```bash
-RUSTY_REVIEW_ADAPTIVE_PASSES=true
+RUSTY_REVIEW_ADAPTIVE_PASSES=false
 ```
-
-With adaptive planning enabled, ordinary deep-review chunks use 2 passes, while large or security-sensitive chunks keep up to 3 passes. Explicit `consensusPasses` still caps the maximum number of passes.
 
 ## How it works
 

--- a/docs/src/content/docs/reference/env-vars.md
+++ b/docs/src/content/docs/reference/env-vars.md
@@ -61,7 +61,7 @@ The managed identity vars (`RUSTY_AZURE_*`) take priority over the API-key vars 
 | `RUSTY_REVIEW_MODELS` | `RUSTY_LLM_MODEL` | Comma-separated per-pass review models for consensus, e.g. `anthropic/claude-sonnet,openai/gpt-5-mini` |
 | `RUSTY_REVIEW_TEMPERATURES` | `RUSTY_REVIEW_TEMPERATURE` | Comma-separated per-pass review temperatures |
 | `RUSTY_REVIEW_TOP_PS` | `RUSTY_REVIEW_TOP_P` | Comma-separated per-pass review top-p values |
-| `RUSTY_REVIEW_ADAPTIVE_PASSES` | `false` | When `true`, ordinary deep-review chunks use fewer consensus passes while large or security-sensitive chunks keep up to 3 |
+| `RUSTY_REVIEW_ADAPTIVE_PASSES` | `true` | Ordinary deep-review chunks use fewer consensus passes (2) while large or security-sensitive chunks keep up to 3. Set to `false` to force every chunk through the full pass count. |
 | `RUSTY_TRIAGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the triage agent |
 | `RUSTY_JUDGE_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the judge agent |
 | `RUSTY_DESCRIPTION_TEMPERATURE` | `RUSTY_LLM_TEMPERATURE` | Temperature override for the description agent |

--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -84,6 +84,7 @@ describe("runConsensusReview", () => {
     delete process.env.RUSTY_REVIEW_TEMPERATURES;
     delete process.env.RUSTY_REVIEW_TOP_PS;
     delete process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "false";
     delete process.env.RUSTY_LLM_MODEL;
     vi.clearAllMocks();
   });
@@ -154,11 +155,23 @@ describe("runConsensusReview", () => {
     expect(result.tokenCount).toBe(300);
   });
 
-  it("defaults to 3 passes when consensusPasses not set", async () => {
+  it("defaults to 3 passes when adaptive pass planning is disabled", async () => {
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "false";
+
     const result = await runConsensusReview([], config, prMetadata, "diff content");
     const { runReview } = await import("../agent/review.js");
     expect(runReview).toHaveBeenCalledTimes(3);
     expect(result.consensusMetadata?.passes).toBe(3);
+  });
+
+  it("defaults to 2 passes with small patches when adaptive is on (default)", async () => {
+    delete process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
+
+    const result = await runConsensusReview([], config, prMetadata, "diff content");
+    const { runReview } = await import("../agent/review.js");
+    expect(runReview).toHaveBeenCalledTimes(2);
+    expect(result.consensusMetadata?.passes).toBe(2);
+    expect(result.consensusMetadata?.passPlanReason).toBe("ordinary deep-review chunk");
   });
 
   it("passes per-pass model configs and settings to each review pass", async () => {
@@ -183,8 +196,8 @@ describe("runConsensusReview", () => {
     ]);
   });
 
-  it("reduces ordinary deep-review chunks to two passes when adaptive pass planning is enabled", async () => {
-    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "true";
+  it("reduces ordinary deep-review chunks to two passes by default (adaptive pass planning)", async () => {
+    delete process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
 
     const patches = [
       {
@@ -212,7 +225,7 @@ describe("runConsensusReview", () => {
   });
 
   it("keeps three adaptive passes for security-sensitive chunks", async () => {
-    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "true";
+    delete process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
 
     const patches = [
       {
@@ -351,6 +364,7 @@ describe("runConsensusReview failure tolerance", () => {
   beforeEach(() => {
     callCount = 0;
     mockBehavior = "default";
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "false";
     vi.clearAllMocks();
   });
 

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -343,7 +343,7 @@ describe("runMultiCallReview", () => {
 
   it("routes through consensus when consensusPasses > 1", async () => {
     const consensusConfig: ReviewConfig = { ...config, consensusPasses: 3 };
-    const patches = [makePatch("small.ts", 10)];
+    const patches = [makePatch("src/auth/handler.ts", 10)];
     const result = await runMultiCallReview(patches, consensusConfig, prMetadata);
     expect(result.consensusMetadata).toMatchObject({ passes: 3, threshold: 2 });
     expect(result.findings.length).toBeGreaterThanOrEqual(1);

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -61,6 +61,7 @@ function deriveRecommendation(
 
 function isAdaptivePassPlanningEnabled(): boolean {
   const raw = process.env.RUSTY_REVIEW_ADAPTIVE_PASSES;
+  if (raw === undefined || raw === "") return true;
   return raw === "true" || raw === "1";
 }
 


### PR DESCRIPTION
## Summary

- `RUSTY_REVIEW_ADAPTIVE_PASSES` now defaults to `true` when unset. Ordinary deep-review chunks run 2 consensus passes; large or security-sensitive chunks keep the full 3.
- Set the variable to `false` to opt back into always-3-passes behavior.
- Updates `docs/guides/consensus-voting.md` and `docs/reference/env-vars.md`. Removes the now-redundant `RUSTY_REVIEW_ADAPTIVE_PASSES=true` lines from the Premium / Balanced / Budget stack recipes.

## Why

Adaptive pass planning was previously opt-in. Most chunks don't benefit from the 3rd pass, so the default 3-pass behavior was paying ~50% extra LLM cost for marginal recall gain on ordinary code. Flipping the default makes the cheaper path the common case while still giving security-sensitive chunks full coverage.

## Test plan

- [x] `consensus.test.ts` updated: existing 3-pass tests now opt out explicitly with `RUSTY_REVIEW_ADAPTIVE_PASSES=false`. New test confirms small ordinary patches drop to 2 passes by default with `passPlanReason: "ordinary deep-review chunk"`.
- [x] `multi-call.test.ts` test that asserts `passes: 3` was switched from `small.ts` to `src/auth/handler.ts` so the security-sensitive heuristic keeps it at 3.
- [x] Full `pnpm test` passes (681 tests, all packages).