### PR TITLE
feat(core): surface structuring model and zero-token responses in review logs

### DIFF
--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -301,10 +301,31 @@ export async function runReview(
   };
   const totalTokens = usage.totalTokens ?? 0;
 
+  if (totalTokens === 0) {
+    // some upstream providers (notably non-OpenAI Azure Foundry deployments)
+    // return chat-completions responses without a populated usage block, so the
+    // ai-sdk parser collapses every token field to undefined. dump the raw shape
+    // once per occurrence so we can tell missing usage apart from a zero-cost
+    // cache hit and adapt the parser if the field is just nested somewhere else.
+    const diag = response as {
+      usage?: unknown;
+      warnings?: unknown;
+      providerMetadata?: unknown;
+    };
+    log.warn(
+      {
+        ...logBindings,
+        rawUsage: diag.usage,
+        warnings: diag.warnings,
+        providerMetadata: diag.providerMetadata,
+      },
+      "review pass returned zero total tokens — capturing diagnostic snapshot",
+    );
+  }
+
   log.info(
     {
-      model: modelName,
-      tier,
+      ...logBindings,
       tokens: totalTokens,
       inputTokens: usage.inputTokens,
       outputTokens: usage.outputTokens,


### PR DESCRIPTION
## Why

A recent CI run logged \`tokens:0\` for an \`azure-foundry/DeepSeek-V4-Flash\` consensus pass while a sibling \`azure/gpt-5.3-codex\` pass logged a full breakdown:

\`\`\`
"model":"azure/gpt-5.3-codex",          "tokens":12453,"inputTokens":11819,"outputTokens":634,"cachedInputTokens":2048
"model":"azure-foundry/DeepSeek-V4-Flash","tokens":0
\`\`\`

The pass otherwise succeeded — its recommendation appears in the consensus voting log — so the LLM responded; only the usage data was lost. The DeepSeek line is missing every breakdown field, which means \`response.usage\` came back \`undefined\` from the AI SDK parser (\`convertOpenAIChatUsage\` collapses every token field to \`undefined\` when the upstream \`usage\` block is null/missing).

This is a known class of issue with non-OpenAI Foundry deployments. We're silently undercounting consensus cost on those models.

## What this changes

Two visibility-only edits to \`review.ts\`:

1. **Spread \`logBindings\` in the per-pass 'review pass complete' log.** It used to redeclare \`model: modelName, tier\`, which dropped \`structuringModel\` from the steady-state log. Spreading \`logBindings\` means every pass log now records which structuring model (if any) drove the JSON output.

2. **Emit a \`log.warn\` when \`totalTokens === 0\`** with \`response.usage\`, \`response.warnings\`, and \`response.providerMetadata\`. One log line per occurrence — gives us the actual response shape on the next foundry pass so we can either parse usage from a non-standard location or fall back to a tokenizer estimate.

No behavior change. No new env vars. No tests because the change is a logging refactor.

## Next steps (separate PRs)

- **PR 2** depends on what this surfaces:
  - If \`response.providerMetadata\` or another field carries the usage in a different shape → write a fallback parser.
  - If usage is genuinely missing from the API → tokenizer-based estimate (\`tiktoken\` is already a dep).
- **PR 3**: tests + an Azure Foundry note in the env-vars doc.

## Test plan

- [x] \`pnpm test\` passes (681 tests, all packages).