### PR TITLE
perf(core): cap search-code tool results to 5 hits with 300-char fragments

### DIFF
--- a/packages/core/src/__tests__/tools.test.ts
+++ b/packages/core/src/__tests__/tools.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { capSearchResults, MAX_SEARCH_RESULTS, MAX_SEARCH_FRAGMENT_CHARS } from "../agent/tools.js";
+
+function makeResult(file: string, content: string) {
+  return { file, line: 1, content };
+}
+
+describe("capSearchResults", () => {
+  it("slices results down to MAX_SEARCH_RESULTS", () => {
+    const results = Array.from({ length: 20 }, (_, i) => makeResult(`f${i}.ts`, "x"));
+    const out = capSearchResults({ results, count: results.length });
+
+    expect(out.results).toHaveLength(MAX_SEARCH_RESULTS);
+    expect(out.shown).toBe(MAX_SEARCH_RESULTS);
+    expect(out.totalMatches).toBe(20);
+  });
+
+  it("preserves all results when there are fewer than the cap", () => {
+    const results = [makeResult("a.ts", "x"), makeResult("b.ts", "y")];
+    const out = capSearchResults({ results, count: results.length });
+
+    expect(out.results).toHaveLength(2);
+    expect(out.shown).toBe(2);
+    expect(out.totalMatches).toBe(2);
+  });
+
+  it("truncates fragments longer than MAX_SEARCH_FRAGMENT_CHARS and appends an ellipsis", () => {
+    const longContent = "a".repeat(MAX_SEARCH_FRAGMENT_CHARS + 50);
+    const out = capSearchResults({
+      results: [makeResult("big.ts", longContent)],
+      count: 1,
+    });
+
+    const content = out.results[0].content;
+    expect(content.length).toBe(MAX_SEARCH_FRAGMENT_CHARS + 1);
+    expect(content.endsWith("…")).toBe(true);
+    expect(content.startsWith("a".repeat(MAX_SEARCH_FRAGMENT_CHARS))).toBe(true);
+  });
+
+  it("leaves fragments at exactly the threshold untouched", () => {
+    const content = "a".repeat(MAX_SEARCH_FRAGMENT_CHARS);
+    const out = capSearchResults({ results: [makeResult("edge.ts", content)], count: 1 });
+
+    expect(out.results[0].content).toBe(content);
+    expect(out.results[0].content.endsWith("…")).toBe(false);
+  });
+
+  it("reports the original total even after slicing", () => {
+    const results = Array.from({ length: 50 }, (_, i) => makeResult(`f${i}.ts`, "x"));
+    const out = capSearchResults({ results, count: 137 });
+
+    expect(out.results).toHaveLength(MAX_SEARCH_RESULTS);
+    expect(out.shown).toBe(MAX_SEARCH_RESULTS);
+    expect(out.totalMatches).toBe(137);
+  });
+
+  it("handles an empty result set", () => {
+    const out = capSearchResults({ results: [], count: 0 });
+
+    expect(out.results).toHaveLength(0);
+    expect(out.shown).toBe(0);
+    expect(out.totalMatches).toBe(0);
+  });
+
+  it("preserves file and line metadata while truncating content", () => {
+    const longContent = "z".repeat(MAX_SEARCH_FRAGMENT_CHARS + 1);
+    const out = capSearchResults({
+      results: [{ file: "src/a.ts", line: 42, content: longContent }],
+      count: 1,
+    });
+
+    expect(out.results[0].file).toBe("src/a.ts");
+    expect(out.results[0].line).toBe(42);
+    expect(out.results[0].content.length).toBe(MAX_SEARCH_FRAGMENT_CHARS + 1);
+  });
+});

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -2,13 +2,32 @@ import { createTool } from "@mastra/core/tools";
 import { z } from "zod";
 import type { ToolCache } from "./tool-cache.js";
 
+export const MAX_SEARCH_RESULTS = 5;
+export const MAX_SEARCH_FRAGMENT_CHARS = 300;
+
+export function capSearchResults(input: {
+  results: { file: string; line: number; content: string }[];
+  count: number;
+}) {
+  const results = input.results.slice(0, MAX_SEARCH_RESULTS).map((r) => ({
+    ...r,
+    content:
+      r.content.length > MAX_SEARCH_FRAGMENT_CHARS
+        ? r.content.slice(0, MAX_SEARCH_FRAGMENT_CHARS) + "…"
+        : r.content,
+  }));
+  return { results, totalMatches: input.count, shown: results.length };
+}
+
 export function createSearchCodeTool(cache: ToolCache) {
   return createTool({
     id: "search-code",
     description:
       "Search the codebase for references to a symbol, function name, import, or string. " +
       "Use this to verify whether removed or renamed exports are still used elsewhere " +
-      "before reporting them as issues. Returns matching files and snippets.",
+      `before reporting them as issues. Returns up to ${MAX_SEARCH_RESULTS} matches with ` +
+      `snippets truncated to ${MAX_SEARCH_FRAGMENT_CHARS} characters; if totalMatches ` +
+      "exceeds shown, narrow the query to see more.",
     inputSchema: z.object({
       query: z.string().describe("symbol name, function name, or search term to find usages of"),
     }),
@@ -20,9 +39,10 @@ export function createSearchCodeTool(cache: ToolCache) {
           content: z.string(),
         }),
       ),
-      count: z.number(),
+      totalMatches: z.number(),
+      shown: z.number(),
     }),
-    execute: async ({ query }) => cache.searchCode(query),
+    execute: async ({ query }) => capSearchResults(await cache.searchCode(query)),
   });
 }
 


### PR DESCRIPTION
## Why

Tool-happy reviewer models can chain `searchCode` calls until cumulative tool results crowd the trajectory's text out of the context window. Observed in the wild on `requesty/fireworks/kimi-k2.6` deep-review:

```
"finishReason":"tool-calls"
"textLength":0
"toolCallCount":10
"outputTokens":4245
"totalTokens":234950
```

`maxSteps=10` was set and `prepareStep` should have stripped tools on step 9, but by then the input was bloated past Kimi's effective context window. Most of those 234K tokens were tool results: every `searchCode` call returned up to 20 hits, each carrying a (potentially long) snippet — provider-dependent (worst on GitLab, which returns whole-file blocks).

PR #159 (cache) bounds repeated calls; this bounds novel ones.

## What this changes

- `MAX_SEARCH_RESULTS = 5` and `MAX_SEARCH_FRAGMENT_CHARS = 300` constants in `packages/core/src/agent/tools.ts`.
- New `capSearchResults` helper applied at the tool layer so all four providers benefit (github text-match fragments, gitlab full-file snippets, ado, local ripgrep).
- Output schema rename: `count` → `{ totalMatches, shown }` — the model can now tell when its query was too broad and narrow it down. Tool description updated to call out the cap.
- `getFileContext` left alone for now; tracked in the followup queue.

## Cost analysis (back-of-envelope)

For one searchCode call: previously ~20 results × ~200-500 char fragments ≈ 4K-10K chars (~1K-2.5K tokens). After cap: 5 × 300 chars = 1500 chars (~400 tokens). **~70% reduction per call** in the typical case, much more for GitLab.

## Test plan

- [x] New `tools.test.ts` (7 cases): slice when over cap, preserve when under, truncate fragments with ellipsis, exact-threshold passthrough, original total preserved across slicing, empty results, file/line metadata preserved.
- [x] Full `pnpm test` passes (688 tests, all packages).