### PR TITLE
perf(core): cap get-file-context content at 12k chars

### DIFF
--- a/packages/core/src/__tests__/tools.test.ts
+++ b/packages/core/src/__tests__/tools.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { capSearchResults, MAX_SEARCH_RESULTS, MAX_SEARCH_FRAGMENT_CHARS } from "../agent/tools.js";
+import {
+  capSearchResults,
+  capFileContent,
+  MAX_SEARCH_RESULTS,
+  MAX_SEARCH_FRAGMENT_CHARS,
+  MAX_FILE_CONTEXT_CHARS,
+} from "../agent/tools.js";
 
 function makeResult(file: string, content: string) {
   return { file, line: 1, content };
@@ -72,5 +78,53 @@ describe("capSearchResults", () => {
     expect(out.results[0].file).toBe("src/a.ts");
     expect(out.results[0].line).toBe(42);
     expect(out.results[0].content.length).toBe(MAX_SEARCH_FRAGMENT_CHARS + 1);
+  });
+});
+
+describe("capFileContent", () => {
+  it("returns null content untouched and reports zero totalChars", () => {
+    const out = capFileContent({ content: null });
+
+    expect(out.content).toBeNull();
+    expect(out.truncated).toBe(false);
+    expect(out.totalChars).toBe(0);
+  });
+
+  it("passes through content shorter than the cap unchanged", () => {
+    const content = "small file body";
+    const out = capFileContent({ content });
+
+    expect(out.content).toBe(content);
+    expect(out.truncated).toBe(false);
+    expect(out.totalChars).toBe(content.length);
+  });
+
+  it("treats content at exactly the cap as not truncated", () => {
+    const content = "x".repeat(MAX_FILE_CONTEXT_CHARS);
+    const out = capFileContent({ content });
+
+    expect(out.content).toBe(content);
+    expect(out.truncated).toBe(false);
+    expect(out.totalChars).toBe(MAX_FILE_CONTEXT_CHARS);
+  });
+
+  it("truncates content larger than the cap and appends a remaining-char hint", () => {
+    const remaining = 500;
+    const content = "y".repeat(MAX_FILE_CONTEXT_CHARS + remaining);
+    const out = capFileContent({ content });
+
+    expect(out.truncated).toBe(true);
+    expect(out.totalChars).toBe(MAX_FILE_CONTEXT_CHARS + remaining);
+    expect(out.content).not.toBeNull();
+    expect(out.content!.startsWith("y".repeat(MAX_FILE_CONTEXT_CHARS))).toBe(true);
+    expect(out.content!.endsWith(`[file truncated, ${remaining} more characters]`)).toBe(true);
+  });
+
+  it("reports the original totalChars even when content is truncated", () => {
+    const total = MAX_FILE_CONTEXT_CHARS * 5;
+    const out = capFileContent({ content: "z".repeat(total) });
+
+    expect(out.totalChars).toBe(total);
+    expect(out.truncated).toBe(true);
   });
 });

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -46,19 +46,42 @@ export function createSearchCodeTool(cache: ToolCache) {
   });
 }
 
+export const MAX_FILE_CONTEXT_CHARS = 12_000;
+
+export function capFileContent(input: { content: string | null }) {
+  if (input.content === null) {
+    return { content: null, truncated: false, totalChars: 0 };
+  }
+  const totalChars = input.content.length;
+  if (totalChars <= MAX_FILE_CONTEXT_CHARS) {
+    return { content: input.content, truncated: false, totalChars };
+  }
+  const remaining = totalChars - MAX_FILE_CONTEXT_CHARS;
+  return {
+    content:
+      input.content.slice(0, MAX_FILE_CONTEXT_CHARS) +
+      `\n... [file truncated, ${remaining} more characters]`,
+    truncated: true,
+    totalChars,
+  };
+}
+
 export function createGetFileContextTool(cache: ToolCache) {
   return createTool({
     id: "get-file-context",
     description:
-      "Fetch the full content of a file from the repository. " +
-      "Use this when you need to see more context around a change " +
-      "than what the diff provides.",
+      "Fetch the content of a file from the repository. " +
+      "Use this when you need to see more context around a change than what the diff " +
+      `provides. Returns up to ${MAX_FILE_CONTEXT_CHARS} characters; if truncated is ` +
+      "true, narrow your investigation to a more specific path or accept the partial view.",
     inputSchema: z.object({
       path: z.string().describe("file path relative to repo root"),
     }),
     outputSchema: z.object({
       content: z.string().nullable(),
+      truncated: z.boolean(),
+      totalChars: z.number(),
     }),
-    execute: async ({ path }) => cache.getFileContent(path),
+    execute: async ({ path }) => capFileContent(await cache.getFileContent(path)),
   });
 }


### PR DESCRIPTION
## Why

Mirrors PR #163. A tool-happy reviewer model that gets capped on `searchCode` (5 hits × 300-char fragments) can still reproduce the Kimi K2.6 `finishReason: "tool-calls"` / `textLength: 0` / `totalTokens: 234,950` failure by chaining `getFileContext` calls instead — each one returns the **entire** file with no upper bound. Three fetches of moderately large source files easily push 50K+ tokens into the next LLM turn.

PR #163 closed one door; this closes the other.

## What this changes

- `MAX_FILE_CONTEXT_CHARS = 12_000` (~3K tokens). Generous enough that typical handler/schema/type files come back whole; tight enough that worst-case three-fetch trajectories stay under ~9K tokens of tool output.
- New `capFileContent` helper at the tool layer, applied across all four providers (github, gitlab, ado, local CLI).
- Truncation hint appended: `"\n... [file truncated, 4523 more characters]"` — gives the model an actionable signal so it can either narrow the path or accept the partial view.
- Output schema gains `truncated: boolean` and `totalChars: number`, matching the `totalMatches/shown` shape from #163.

## Test plan

- [x] New `capFileContent` describe block in `tools.test.ts` (5 cases): null content, short content unchanged, exactly-at-cap not truncated, over-cap truncated with remaining-char hint, original totalChars preserved through truncation.
- [x] Full `pnpm test` passes (693 tests, all packages).

## Together with #159 and #163

Per-pass tool-result budget is now bounded both ways:
- **Repeated calls**: deduped by `ToolCache` (#159).
- **Novel `searchCode` calls**: capped at 5 × 300 chars (#163).
- **Novel `getFileContext` calls**: capped at 12K chars per fetch (this PR).

Worst-case tool-result contribution per pass: ~10 distinct calls × ~3K tokens = 30K tokens. Within Kimi K2.6's effective window even after system prompt + diff.