### PR TITLE
perf(judge): send per-finding diff excerpts instead of the full PR diff

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Finding, ReviewResult } from "../types.js";
+import type { FilePatch, Finding, ReviewResult } from "../types.js";
 
 const generateMock = vi.fn();
 
@@ -26,9 +26,32 @@ vi.mock("../agent/model.js", () => ({
   applyModelConstraints: vi.fn((_config, settings) => settings),
 }));
 
-const { judgeFindings, judgeReviewResult, resolveJudgeConfig } = await import("../agent/judge.js");
+const { judgeFindings, judgeReviewResult, resolveJudgeConfig, buildFindingExcerpt } =
+  await import("../agent/judge.js");
 
-const DIFF = `--- a/src/app.ts\n+++ b/src/app.ts\n@@ -1,3 +1,5 @@\n+import { z } from "zod";\n const app = express();\n+app.get("/health", (req, res) => res.json({ ok: true }));\n`;
+const PATCHES: FilePatch[] = [
+  {
+    path: "src/app.ts",
+    hunks: [
+      {
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 5,
+        content: [
+          '+import { z } from "zod";',
+          " const app = express();",
+          '+app.get("/health", (req, res) => res.json({ ok: true }));',
+          " const port = 3000;",
+          " app.listen(port);",
+        ].join("\n"),
+      },
+    ],
+    additions: 2,
+    deletions: 0,
+    isBinary: false,
+  },
+];
 
 function makeFinding(overrides: Partial<Finding> = {}): Finding {
   return {
@@ -112,7 +135,7 @@ describe("judgeFindings", () => {
 
   it("passes through all findings when judge is disabled", async () => {
     const findings = [makeFinding(), makeFinding({ line: 2 })];
-    const result = await judgeFindings(findings, DIFF, disabledConfig);
+    const result = await judgeFindings(findings, PATCHES, disabledConfig);
 
     expect(result.accepted).toHaveLength(2);
     expect(result.rejected).toHaveLength(0);
@@ -122,7 +145,7 @@ describe("judgeFindings", () => {
   });
 
   it("passes through all findings when list is empty", async () => {
-    const result = await judgeFindings([], DIFF, enabledConfig);
+    const result = await judgeFindings([], PATCHES, enabledConfig);
 
     expect(result.accepted).toHaveLength(0);
     expect(result.rejected).toHaveLength(0);
@@ -140,7 +163,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 200 },
     });
 
-    await judgeFindings(findings, DIFF, enabledConfig);
+    await judgeFindings(findings, PATCHES, enabledConfig);
 
     const agentConfig = vi.mocked(Agent).mock.calls.at(-1)?.[0];
     const instructions = agentConfig?.instructions as (() => string) | undefined;
@@ -169,7 +192,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 350 },
     });
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
 
     expect(result.accepted).toHaveLength(2);
     expect(result.accepted[0].message).toBe("real bug");
@@ -189,7 +212,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 200 },
     });
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
     expect(result.accepted).toHaveLength(1);
     expect(result.rejected).toHaveLength(0);
   });
@@ -204,7 +227,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 200 },
     });
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
     expect(result.accepted).toHaveLength(0);
     expect(result.rejected).toHaveLength(1);
   });
@@ -222,7 +245,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 250 },
     });
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
     expect(result.accepted).toHaveLength(0);
     expect(result.rejected).toHaveLength(2);
   });
@@ -244,7 +267,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 150 },
     });
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
     // first finding passes, remaining two have no evaluation → kept (safe default)
     expect(result.accepted).toHaveLength(3);
     expect(result.rejected).toHaveLength(0);
@@ -255,7 +278,7 @@ describe("judgeFindings", () => {
 
     generateMock.mockRejectedValueOnce(new Error("API rate limit"));
 
-    const result = await judgeFindings(findings, DIFF, enabledConfig);
+    const result = await judgeFindings(findings, PATCHES, enabledConfig);
     expect(result.accepted).toHaveLength(1);
     expect(result.rejected).toHaveLength(0);
     expect(result.evaluations).toHaveLength(0);
@@ -273,7 +296,7 @@ describe("judgeFindings", () => {
     });
 
     const strictConfig = { enabled: true, threshold: 8 };
-    const result = await judgeFindings(findings, DIFF, strictConfig);
+    const result = await judgeFindings(findings, PATCHES, strictConfig);
     expect(result.accepted).toHaveLength(0);
     expect(result.rejected).toHaveLength(1);
   });
@@ -289,7 +312,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 200 },
     });
 
-    await judgeFindings(findings, DIFF, {
+    await judgeFindings(findings, PATCHES, {
       enabled: true,
       threshold: 6,
       model: "anthropic/claude-haiku",
@@ -315,7 +338,7 @@ describe("judgeFindings", () => {
       usage: { totalTokens: 200 },
     });
 
-    await judgeFindings(findings, DIFF, {
+    await judgeFindings(findings, PATCHES, {
       enabled: true,
       threshold: 6,
       model: "azure-openai/gpt-5.4-mini",
@@ -335,7 +358,7 @@ describe("judgeReviewResult", () => {
 
   it("passes through unchanged when judge is disabled", async () => {
     const review = makeReviewResult([makeFinding()]);
-    const result = await judgeReviewResult(review, DIFF, { enabled: false, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: false, threshold: 6 });
 
     expect(result.findings).toHaveLength(1);
     expect(result.filteredCount).toBeUndefined();
@@ -359,7 +382,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 300 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.findings).toHaveLength(1);
     expect(result.filteredCount).toBe(1);
     expect(result.judgeTokenCount).toBe(300);
@@ -375,7 +398,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 200 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.findings).toHaveLength(0);
     expect(result.recommendation).toBe("looks_good");
   });
@@ -397,7 +420,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 280 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.recommendation).toBe("address_before_merge");
     expect(result.filteredCount).toBe(1);
   });
@@ -420,7 +443,7 @@ describe("judgeReviewResult", () => {
       },
     };
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.findings).toHaveLength(0);
     expect(result.recommendation).toBe("address_before_merge");
   });
@@ -450,7 +473,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 200 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.findings).toHaveLength(0);
     expect(result.recommendation).toBe("looks_good");
   });
@@ -473,7 +496,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 200 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.observations).toHaveLength(1);
     expect(result.filesReviewed).toEqual(["src/app.ts", "src/b.ts"]);
     expect(result.modelUsed).toBe("claude-sonnet");
@@ -496,7 +519,7 @@ describe("judgeReviewResult", () => {
       usage: { totalTokens: 50 },
     });
 
-    const result = await judgeReviewResult(review, DIFF, { enabled: true, threshold: 6 });
+    const result = await judgeReviewResult(review, PATCHES, { enabled: true, threshold: 6 });
     expect(result.droppedFindings).toEqual(review.droppedFindings);
   });
 });
@@ -514,7 +537,7 @@ describe("judgeFindings jsonPromptInjection forwarding", () => {
       usage: { totalTokens: 25 },
     });
 
-    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+    await judgeFindings([makeFinding()], PATCHES, { enabled: true, threshold: 6 });
 
     const callArgs = generateMock.mock.calls[0][1];
     expect(callArgs.structuredOutput.jsonPromptInjection).toBe(true);
@@ -527,9 +550,118 @@ describe("judgeFindings jsonPromptInjection forwarding", () => {
       usage: { totalTokens: 25 },
     });
 
-    await judgeFindings([makeFinding()], DIFF, { enabled: true, threshold: 6 });
+    await judgeFindings([makeFinding()], PATCHES, { enabled: true, threshold: 6 });
 
     const callArgs = generateMock.mock.calls[0][1];
     expect(callArgs.structuredOutput.jsonPromptInjection).toBe(false);
+  });
+});
+
+describe("buildFindingExcerpt", () => {
+  const TWO_HUNK_PATCH: FilePatch = {
+    path: "src/multi.ts",
+    hunks: [
+      {
+        oldStart: 10,
+        oldLines: 3,
+        newStart: 10,
+        newLines: 3,
+        content: ["+near top change", " context line", " more context"].join("\n"),
+      },
+      {
+        oldStart: 50,
+        oldLines: 4,
+        newStart: 52,
+        newLines: 5,
+        content: [" before", "-removed mid", "+replacement", "+inserted", " after"].join("\n"),
+      },
+    ],
+    additions: 3,
+    deletions: 1,
+    isBinary: false,
+  };
+
+  it("emits the file header plus the hunk that contains the finding line", () => {
+    const finding = makeFinding({ file: "src/app.ts", line: 1 });
+    const excerpt = buildFindingExcerpt(PATCHES, finding);
+
+    expect(excerpt.startsWith("## src/app.ts")).toBe(true);
+    expect(excerpt).toContain("__new hunk__");
+    expect(excerpt).toContain('1 +import { z } from "zod";');
+  });
+
+  it("returns the not-found sentinel when the file isn't in the patches", () => {
+    const finding = makeFinding({ file: "src/missing.ts", line: 1 });
+    const excerpt = buildFindingExcerpt(PATCHES, finding);
+
+    expect(excerpt).toContain("[no matching hunk");
+    expect(excerpt).not.toContain("## src/");
+  });
+
+  it("returns the not-found sentinel when the line is outside every hunk", () => {
+    const finding = makeFinding({ file: "src/app.ts", line: 999 });
+    const excerpt = buildFindingExcerpt(PATCHES, finding);
+
+    expect(excerpt).toContain("[no matching hunk");
+  });
+
+  it("picks the second hunk when the finding lands inside it", () => {
+    const finding = makeFinding({ file: "src/multi.ts", line: 53 });
+    const excerpt = buildFindingExcerpt([TWO_HUNK_PATCH], finding);
+
+    expect(excerpt).toContain("## src/multi.ts");
+    expect(excerpt).toContain("53 +replacement");
+    expect(excerpt).not.toContain("near top change");
+  });
+
+  it("includes both hunks when the finding range spans them", () => {
+    const finding = makeFinding({ file: "src/multi.ts", line: 11, endLine: 53 });
+    const excerpt = buildFindingExcerpt([TWO_HUNK_PATCH], finding);
+
+    expect(excerpt).toContain("near top change");
+    expect(excerpt).toContain("53 +replacement");
+  });
+
+  it("renders both old and new hunks for diffs with removals", () => {
+    const finding = makeFinding({ file: "src/multi.ts", line: 53 });
+    const excerpt = buildFindingExcerpt([TWO_HUNK_PATCH], finding);
+
+    expect(excerpt).toContain("__old hunk__");
+    expect(excerpt).toContain("__new hunk__");
+    expect(excerpt).toContain("-removed mid");
+  });
+});
+
+describe("judge formatter", () => {
+  it("inlines a per-finding excerpt and does not dump the full repo diff", async () => {
+    generateMock.mockReset();
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 9, reasoning: "ok" }] },
+      usage: { totalTokens: 30 },
+    });
+
+    const finding = makeFinding({ file: "src/app.ts", line: 1 });
+    await judgeFindings([finding], PATCHES, { enabled: true, threshold: 6 });
+
+    const userMessage = generateMock.mock.calls[0][0] as string;
+    expect(userMessage).toContain("## Findings to evaluate");
+    expect(userMessage).toContain("### Finding 0");
+    expect(userMessage).toContain("- **Diff context:**");
+    expect(userMessage).toContain("## src/app.ts");
+    expect(userMessage).not.toContain("## Diff under review");
+  });
+
+  it("uses the not-found sentinel for findings whose file isn't in the patches", async () => {
+    generateMock.mockReset();
+    generateMock.mockResolvedValueOnce({
+      object: { evaluations: [{ index: 0, confidence: 4, reasoning: "no evidence" }] },
+      usage: { totalTokens: 30 },
+    });
+
+    const finding = makeFinding({ file: "ghost.ts", line: 12 });
+    await judgeFindings([finding], PATCHES, { enabled: true, threshold: 6 });
+
+    const userMessage = generateMock.mock.calls[0][0] as string;
+    expect(userMessage).toContain("[no matching hunk");
   });
 });

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -10,8 +10,67 @@ import {
   resolveJsonPromptInjection,
   applyModelConstraints,
 } from "./model.js";
-import type { Finding, ReviewResult } from "../types.js";
+import type { FilePatch, Finding, Hunk, ReviewResult } from "../types.js";
 import { logger } from "../logger.js";
+
+const EXCERPT_NO_HUNK =
+  "[no matching hunk for this finding — line is outside the diff or the file isn't in the PR]";
+
+function findOverlappingHunks(hunks: Hunk[], line: number, endLine: number): Hunk[] {
+  return hunks.filter((h) => {
+    const hStart = h.newStart;
+    const hEnd = h.newStart + h.newLines - 1;
+    return hStart <= endLine && hEnd >= line;
+  });
+}
+
+function formatHunkExcerpt(hunk: Hunk): string[] {
+  const lines = hunk.content.split("\n");
+  const oldLines: string[] = [];
+  const newLines: string[] = [];
+  let oldLine = hunk.oldStart;
+  let newLine = hunk.newStart;
+  for (const line of lines) {
+    if (line.startsWith("-")) {
+      oldLines.push(`${oldLine} ${line}`);
+      oldLine++;
+    } else if (line.startsWith("+")) {
+      newLines.push(`${newLine} ${line}`);
+      newLine++;
+    } else if (line.startsWith("\\")) {
+      continue;
+    } else if (line.startsWith("~")) {
+      oldLines.push(line);
+      newLines.push(line);
+    } else {
+      oldLines.push(`${oldLine} ${line}`);
+      newLines.push(`${newLine} ${line}`);
+      oldLine++;
+      newLine++;
+    }
+  }
+  const parts: string[] = [];
+  if (oldLines.length > 0) {
+    parts.push("__old hunk__");
+    parts.push(...oldLines);
+  }
+  if (newLines.length > 0) {
+    parts.push("__new hunk__");
+    parts.push(...newLines);
+  }
+  return parts;
+}
+
+export function buildFindingExcerpt(patches: readonly FilePatch[], finding: Finding): string {
+  const patch = patches.find((p) => p.path === finding.file);
+  if (!patch) return EXCERPT_NO_HUNK;
+  const endLine = finding.endLine ?? finding.line;
+  const hunks = findOverlappingHunks(patch.hunks, finding.line, endLine);
+  if (hunks.length === 0) return EXCERPT_NO_HUNK;
+  const parts: string[] = [`## ${patch.path}`];
+  for (const h of hunks) parts.push(...formatHunkExcerpt(h));
+  return parts.join("\n");
+}
 
 const log = logger.child({ module: "judge" });
 
@@ -73,12 +132,11 @@ Reject or heavily penalize findings that are:
 
 You MUST return exactly one evaluation per finding, in the same order they were provided.`;
 
-function formatFindingsForJudge(findings: readonly Finding[], diff: string): string {
-  const parts: string[] = [];
-
-  parts.push("## Diff under review\n");
-  parts.push(diff);
-  parts.push("\n## Findings to evaluate\n");
+function formatFindingsForJudge(
+  findings: readonly Finding[],
+  patches: readonly FilePatch[],
+): string {
+  const parts: string[] = ["## Findings to evaluate\n"];
 
   for (let i = 0; i < findings.length; i++) {
     const f = findings[i];
@@ -92,6 +150,7 @@ function formatFindingsForJudge(findings: readonly Finding[], diff: string): str
     if (f.suggestedFix) {
       parts.push(`- **Suggested fix:**\n\`\`\`\n${f.suggestedFix}\n\`\`\``);
     }
+    parts.push(`- **Diff context:**\n\`\`\`\n${buildFindingExcerpt(patches, f)}\n\`\`\``);
     parts.push("");
   }
 
@@ -133,7 +192,7 @@ export interface JudgeResult {
 
 export async function judgeFindings(
   findings: readonly Finding[],
-  diff: string,
+  patches: readonly FilePatch[],
   config: JudgeConfig,
 ): Promise<JudgeResult> {
   if (!config.enabled || findings.length === 0) {
@@ -156,7 +215,7 @@ export async function judgeFindings(
     ...(defaultOptions && { defaultOptions }),
   });
 
-  const userMessage = formatFindingsForJudge(findings, diff);
+  const userMessage = formatFindingsForJudge(findings, patches);
 
   let evaluations: JudgeEvaluation[];
   let tokenCount = 0;
@@ -221,14 +280,14 @@ export async function judgeFindings(
 
 export async function judgeReviewResult(
   result: ReviewResult,
-  diff: string,
+  patches: readonly FilePatch[],
   config: JudgeConfig,
 ): Promise<ReviewResult> {
   if (!config.enabled) {
     return result;
   }
 
-  const { accepted, rejected, tokenCount } = await judgeFindings(result.findings, diff, config);
+  const { accepted, rejected, tokenCount } = await judgeFindings(result.findings, patches, config);
 
   // when consensus elevated the recommendation based on pass votes (not findings),
   // and there are no findings for the judge to evaluate, preserve it

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -494,9 +494,7 @@ export async function runMultiCallReview(
     }
 
     const judgeConfig = resolveJudgeConfig();
-    const judgeDiff =
-      skippedFiles.length === 0 ? compressed : compressDiff(patches, Infinity).compressed;
-    return await judgeReviewResult(result, judgeDiff, judgeConfig);
+    return await judgeReviewResult(result, patches, judgeConfig);
   } finally {
     if (mcpDisconnect) {
       try {
@@ -598,9 +596,8 @@ export async function runCascadeReview(
     const merged = mergeResults(allResults, allResults[0]?.modelUsed ?? "unknown");
 
     const allPatches = [...skimPatches, ...deepPatches];
-    const judgeDiff = compressDiff(allPatches, Infinity).compressed;
     const judgeConfig = resolveJudgeConfig();
-    return await judgeReviewResult(merged, judgeDiff, judgeConfig);
+    return await judgeReviewResult(merged, allPatches, judgeConfig);
   } finally {
     if (mcpDisconnect) {
       try {


### PR DESCRIPTION
## Why

Today the judge user prompt prepends the **entire PR diff** (`judgeDiff`) and then lists every finding. On large PRs this is the dominant judge token cost — and most of the diff is context the judge doesn't need to verdict any specific finding. The judge wastes input tokens (and attention) re-reading the whole diff for each finding it evaluates.

This is also a precondition for FOLLOWUPS item #2 (judge calibration). Evaluating Sonnet's accuracy was unfair while it was drowning in irrelevant context — accuracy concerns might have been calibration *or* attention-budget exhaustion. Now we can isolate the variable.

## What changes

- New `buildFindingExcerpt(patches, finding)`: walks the FilePatch hunks, returns the file-prefixed excerpt of the hunk(s) overlapping the finding's `line..endLine` range. When a finding's file/line falls outside the diff (hallucinated), returns a clear sentinel `[no matching hunk for this finding — line is outside the diff or the file isn't in the PR]`. The judge prompt already instructs it to reject "hallucinated line numbers or code references that don't match the diff", so the sentinel is a strong direct signal.
- `formatFindingsForJudge` no longer dumps the full diff; instead each finding gains a `Diff context:` field with its own focused excerpt.
- `judgeFindings` and `judgeReviewResult` now take `FilePatch[]` instead of a precomputed diff string. Multi-call call sites (`multi-call.ts:496-499` and `:600-603`) already had patches in scope, so the boundary change is mechanical and removes a redundant `compressDiff(patches, Infinity)` call.

## Token-cost intuition

For a finding on `src/foo.ts:42` in a PR touching 30 files: the judge previously saw all 30 files' diffs; now it sees only the hunk(s) around line 42. On the largest PRs we'd routinely save 80-95% of the judge's input tokens. Smaller PRs see less savings (less to drop), but still gain focused attention per finding.

## Test plan

- [x] All 29 existing `judge.test.ts` cases migrated to a `FilePatch[]` fixture and pass unchanged.
- [x] 6 new `buildFindingExcerpt` cases: file-not-found, line-outside-any-hunk, single-hunk match, multi-hunk overlap when finding spans them, picks the second hunk when finding lands in it, renders both old/new sides for diffs with removals.
- [x] 2 new formatter cases: judge prompt now contains `## Findings to evaluate` + per-finding `Diff context:`, no longer contains `## Diff under review`; hallucinated file path surfaces the sentinel in the prompt.
- [x] Full `pnpm test` passes (701 tests, all packages).