### PR TITLE
feat: carry prior review context across incremental re-reviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Built on [Mastra](https://mastra.ai/) (TypeScript).
 - **OpenGrep pre-scan** — runs [OpenGrep](https://opengrep.dev/) SAST on changed files before LLM review, feeds findings for triage (gracefully skipped when not installed)
 - **Multi-provider LLM** — OpenAI, Anthropic, Google, or any provider supported by Mastra
 - **PR description generation** — optionally generate a structured PR description from the diff when the description is empty or a placeholder (off by default)
-- **Incremental review** — on subsequent pushes the bot reviews only the diff since the previously-reviewed state (commit on GitHub, PR iteration on Azure DevOps) instead of the entire PR, cutting tokens on multi-commit PRs (on by default; opt out with `RUSTY_INCREMENTAL_REVIEW=false`)
+- **Incremental review** — on subsequent pushes the bot reviews only the diff since the previously-reviewed state (commit on GitHub/GitLab, PR iteration on Azure DevOps) instead of the entire PR, cutting tokens on multi-commit PRs. The previous summary, recommendation, and surfaced findings are carried forward so the agent keeps PR-wide context without re-reading the full diff (on by default; opt out with `RUSTY_INCREMENTAL_REVIEW=false`)
 - **GitHub + GitLab + Azure DevOps + local CLI** — webhook server for GitHub, pipeline task for Azure DevOps, GitLab CI job, a drop-in GitHub Action, or a `rusty-bot` CLI that runs reviews against any local git repo
 - **Web dashboard** — configure repos, review styles, focus areas, and view history
 
@@ -270,7 +270,7 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_IGNORE_PATTERNS` | comma-separated glob patterns to skip | — |
 | `RUSTY_FAIL_ON_CRITICAL` | exit 1 on critical findings (pipeline/action mode) | `true` |
 | `RUSTY_REVIEW_DRAFTS` | review draft PRs in GitHub Action mode | `false` |
-| `RUSTY_INCREMENTAL_REVIEW` | review only the diff since the last reviewed commit (GitHub) or PR iteration (Azure DevOps) | `true` |
+| `RUSTY_INCREMENTAL_REVIEW` | review only the diff since the last reviewed commit (GitHub, GitLab) or PR iteration (Azure DevOps); previous summary + findings are carried forward as context | `true` |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |
@@ -515,6 +515,25 @@ RUSTY_JUDGE_MODEL=anthropic/claude-3-5-haiku-20241022  # optional, cheaper model
 **Cost:** The judge uses a single LLM call with structured output (no tools). Using a cheap model like Haiku adds ~1–3% to total cost. Using the same model as the reviewer adds ~30–50%.
 
 When the judge is disabled (default), the pipeline behaves exactly as before with zero overhead.
+
+### Incremental Review
+
+When a PR gets new commits after a previous review, the bot only fetches the diff since the last reviewed commit (or PR iteration on Azure DevOps) instead of the full PR. To keep PR-wide context without paying for the full diff, the previous review's **summary**, **recommendation**, and **surfaced findings** are carried forward and shown to the agent as established background.
+
+**How it works:**
+
+1. After every review, the bot embeds two hidden markers in its summary comment:
+   - `<!-- rusty-bot:last-sha:... -->` (or `last-iteration` on ADO) — pinpoints what was reviewed
+   - `<!-- rusty-bot:context:... -->` — base64-encoded JSON of the prior summary + findings (capped: 4 000-char summary, 50 findings, 250-char message each)
+2. On the next push, the bot reads both markers from its previous comment, fetches only the new diff, and injects a `## Prior review context` section into the agent's prompt. The agent is explicitly told its summary must describe the **whole** PR, not just the new diff.
+3. The prior-findings list is annotated as "do NOT re-raise unless this commit changes the underlying code", which suppresses duplicate findings across re-reviews.
+
+**Caps and trade-offs:**
+
+- Only the **most recent** prior review is carried forward — chained re-reviews compound the prior summary at every step (the previous summary already absorbed the one before it).
+- Carry-forward state is provider-side: it survives bot-comment cleanup because the markers are read **before** old comments are deleted on each run.
+- If a force-push or rebase makes the prior SHA unreachable, the bot transparently falls back to a full review — there is no fragile state.
+- Disable with `RUSTY_INCREMENTAL_REVIEW=false`; the bot then re-reviews the full PR every time and posts no carry-forward markers.
 
 ### OpenGrep Pre-scan
 

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -1,4 +1,10 @@
-import type { FilePatch, FocusArea, ReviewConfig, TicketRef } from "@rusty-bot/core";
+import type {
+  FilePatch,
+  FocusArea,
+  PriorReviewContext,
+  ReviewConfig,
+  TicketRef,
+} from "@rusty-bot/core";
 import { ReviewStyleSchema } from "@rusty-bot/core";
 import {
   filterFiles,
@@ -25,6 +31,7 @@ import {
   generateConventionalTitle,
   isConventionalTitle,
   filterAnchorableFindings,
+  buildPriorContextFromReview,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -103,9 +110,11 @@ async function main(): Promise<void> {
     config.conventionFile = conventionFile;
   }
 
-  // read incremental marker before deleting old bot comments — otherwise we lose the iteration id
+  // read incremental marker + prior context before deleting old bot comments —
+  // otherwise we lose the iteration id and the carry-forward state
   let lastReviewedIteration: string | null = null;
   let latestIteration: string | null = null;
+  let priorContext: PriorReviewContext | null = null;
   if (incrementalReview) {
     try {
       [lastReviewedIteration, latestIteration] = await Promise.all([
@@ -114,6 +123,13 @@ async function main(): Promise<void> {
       ]);
     } catch (err) {
       log.warn({ err }, "failed to read iteration state, falling back to full review");
+    }
+    if (lastReviewedIteration) {
+      try {
+        priorContext = await provider.getPriorReviewContext();
+      } catch (err) {
+        log.warn({ err }, "failed to read prior review context; continuing without it");
+      }
     }
   } else {
     try {
@@ -299,6 +315,7 @@ async function main(): Promise<void> {
           mcpServers,
           maxTokens: MAX_TOKENS,
           openGrepFindings,
+          priorContext: incrementalUsed && priorContext ? priorContext : undefined,
         },
       );
 
@@ -329,6 +346,7 @@ async function main(): Promise<void> {
         mcpServers,
         maxTokens: MAX_TOKENS,
         openGrepFindings,
+        priorContext: incrementalUsed && priorContext ? priorContext : undefined,
       },
     );
   }
@@ -354,7 +372,12 @@ async function main(): Promise<void> {
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
   await provider.postSummaryComment(
     summaryMarkdown,
-    latestIteration ? { lastReviewedIteration: latestIteration } : undefined,
+    latestIteration
+      ? {
+          lastReviewedIteration: latestIteration,
+          priorContext: buildPriorContextFromReview(review),
+        }
+      : undefined,
   );
 
   const { anchored: inlineFindings, dropped } = filterAnchorableFindings(

--- a/packages/azure-devops/src/provider.ts
+++ b/packages/azure-devops/src/provider.ts
@@ -5,8 +5,13 @@ import type {
   Finding,
   CodeSearchResult,
   PostSummaryCommentOptions,
+  PriorReviewContext,
 } from "@rusty-bot/core";
-import { formatInlineComment } from "@rusty-bot/core";
+import {
+  encodePriorReviewContext,
+  extractPriorReviewContext,
+  formatInlineComment,
+} from "@rusty-bot/core";
 import { structuredPatch } from "diff";
 import type { StructuredPatchHunk } from "diff";
 import type { z } from "zod";
@@ -212,6 +217,25 @@ export class AzureDevOpsProvider implements GitProvider {
       for (const comment of thread.comments) {
         const match = comment.content ? LAST_ITERATION_MARKER_RE.exec(comment.content) : null;
         if (match) return match[1];
+      }
+    }
+    return null;
+  }
+
+  async getPriorReviewContext(): Promise<PriorReviewContext | null> {
+    const threads = await this.request(
+      `${this.baseUrl}/pullRequests/${this.pullRequestId}/threads?${API_VERSION}`,
+      AdoThreadsSchema,
+    );
+
+    for (let i = threads.value.length - 1; i >= 0; i--) {
+      const thread = threads.value[i];
+      const hasBotComment = thread.comments.some((c) => c.content?.includes(BOT_MARKER));
+      if (!hasBotComment) continue;
+      for (const comment of thread.comments) {
+        if (!comment.content) continue;
+        const ctx = extractPriorReviewContext(comment.content);
+        if (ctx) return ctx;
       }
     }
     return null;
@@ -441,6 +465,9 @@ export class AzureDevOpsProvider implements GitProvider {
     }
     if (options?.lastReviewedIteration) {
       headerLines.push(buildLastIterationMarker(options.lastReviewedIteration));
+    }
+    if (options?.priorContext) {
+      headerLines.push(encodePriorReviewContext(options.priorContext));
     }
     const header = headerLines.join("\n");
     await this.fetchApi(

--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -5,7 +5,7 @@ import {
   buildCachedSystemMessages,
 } from "../agent/prompts.js";
 import { ReviewOutputSchema } from "../agent/schema.js";
-import type { ReviewConfig, PRMetadata, TicketInfo } from "../types.js";
+import type { ReviewConfig, PRMetadata, PriorReviewContext, TicketInfo } from "../types.js";
 
 const baseConfig: ReviewConfig = {
   style: "balanced",
@@ -505,5 +505,69 @@ describe("ReviewOutputSchema", () => {
     };
     const result = ReviewOutputSchema.safeParse(invalid);
     expect(result.success).toBe(false);
+  });
+});
+
+describe("buildUserMessage with priorContext", () => {
+  const priorContext: PriorReviewContext = {
+    summary: "PR adds JWT auth flow with refresh tokens.",
+    recommendation: "address_before_merge",
+    findings: [
+      {
+        file: "src/auth.ts",
+        line: 17,
+        severity: "critical",
+        message: "missing csrf check",
+      },
+    ],
+  };
+
+  function buildWithPriorContext(ctx?: PriorReviewContext) {
+    return buildUserMessage(
+      "diff content",
+      prMetadata,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ctx,
+    );
+  }
+
+  it("renders the prior-context section when provided", () => {
+    const msg = buildWithPriorContext(priorContext);
+    expect(msg).toContain("## Prior review context");
+    expect(msg).toContain(priorContext.summary);
+    expect(msg).toContain("Previous recommendation:** address_before_merge");
+  });
+
+  it("does not render the section when prior context is omitted (no leak)", () => {
+    const msg = buildWithPriorContext(undefined);
+    expect(msg).not.toContain("## Prior review context");
+  });
+
+  it("instructs the agent to describe the WHOLE PR in its summary", () => {
+    const msg = buildWithPriorContext(priorContext);
+    expect(msg).toContain("WHOLE PR");
+  });
+
+  it("places prior context before the diff so the agent reads it as background", () => {
+    const msg = buildWithPriorContext(priorContext);
+    const ctxIdx = msg.indexOf("## Prior review context");
+    const diffIdx = msg.indexOf("## Diff");
+    expect(ctxIdx).toBeGreaterThan(-1);
+    expect(diffIdx).toBeGreaterThan(ctxIdx);
+  });
+
+  it("renders each prior finding with file, line, severity, and message", () => {
+    const msg = buildWithPriorContext(priorContext);
+    expect(msg).toContain("`src/auth.ts`:17 (critical) — missing csrf check");
+  });
+
+  it("omits the issues list when prior context has no findings", () => {
+    const msg = buildWithPriorContext({ ...priorContext, findings: [] });
+    expect(msg).not.toContain("Issues already surfaced");
   });
 });

--- a/packages/core/src/__tests__/prior-context.test.ts
+++ b/packages/core/src/__tests__/prior-context.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildPriorContextFromReview,
+  encodePriorReviewContext,
+  extractPriorReviewContext,
+  PRIOR_CONTEXT_LIMITS,
+} from "../agent/prior-context.js";
+import type { PriorReviewContext, ReviewResult } from "../types.js";
+
+function makeContext(overrides: Partial<PriorReviewContext> = {}): PriorReviewContext {
+  return {
+    summary: "this PR adds a /health endpoint and zod validation.",
+    recommendation: "address_before_merge",
+    findings: [
+      {
+        file: "src/app.ts",
+        line: 42,
+        severity: "warning",
+        message: "potential null deref when req.body is missing",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("encode/extract roundtrip", () => {
+  it("roundtrips a normal context unchanged", () => {
+    const ctx = makeContext();
+    const marker = encodePriorReviewContext(ctx);
+    const body = `<!-- rusty-bot-review -->\n${marker}\n# Summary\n…`;
+    const decoded = extractPriorReviewContext(body);
+    expect(decoded).toEqual(ctx);
+  });
+
+  it("roundtrips an empty findings list", () => {
+    const ctx = makeContext({ findings: [] });
+    const decoded = extractPriorReviewContext(encodePriorReviewContext(ctx));
+    expect(decoded?.findings).toEqual([]);
+  });
+
+  it("roundtrips a `looks_good` recommendation", () => {
+    const ctx = makeContext({ recommendation: "looks_good" });
+    const decoded = extractPriorReviewContext(encodePriorReviewContext(ctx));
+    expect(decoded?.recommendation).toBe("looks_good");
+  });
+});
+
+describe("encodePriorReviewContext truncation", () => {
+  it("truncates summaries longer than the cap and appends [truncated]", () => {
+    const huge = "x".repeat(PRIOR_CONTEXT_LIMITS.summaryCharCap + 500);
+    const decoded = extractPriorReviewContext(
+      encodePriorReviewContext(makeContext({ summary: huge })),
+    );
+    expect(decoded?.summary.length).toBeLessThan(huge.length);
+    expect(decoded?.summary).toContain("[truncated]");
+    expect(decoded?.summary.startsWith("xxx")).toBe(true);
+  });
+
+  it("does not touch summaries within the cap", () => {
+    const ctx = makeContext({ summary: "short" });
+    const decoded = extractPriorReviewContext(encodePriorReviewContext(ctx));
+    expect(decoded?.summary).toBe("short");
+  });
+
+  it("caps the findings list at FINDINGS_COUNT_CAP items", () => {
+    const findings = Array.from({ length: PRIOR_CONTEXT_LIMITS.findingsCountCap + 10 }, (_, i) => ({
+      file: `src/f${i}.ts`,
+      line: i + 1,
+      severity: "warning" as const,
+      message: `msg ${i}`,
+    }));
+    const decoded = extractPriorReviewContext(encodePriorReviewContext(makeContext({ findings })));
+    expect(decoded?.findings).toHaveLength(PRIOR_CONTEXT_LIMITS.findingsCountCap);
+    expect(decoded?.findings[0].message).toBe("msg 0");
+    expect(decoded?.findings.at(-1)?.message).toBe(
+      `msg ${PRIOR_CONTEXT_LIMITS.findingsCountCap - 1}`,
+    );
+  });
+
+  it("truncates long finding messages with an ellipsis", () => {
+    const huge = "y".repeat(PRIOR_CONTEXT_LIMITS.findingMessageCharCap + 200);
+    const decoded = extractPriorReviewContext(
+      encodePriorReviewContext(
+        makeContext({
+          findings: [{ file: "src/a.ts", line: 1, severity: "warning", message: huge }],
+        }),
+      ),
+    );
+    expect(decoded?.findings[0].message.length).toBeLessThan(huge.length);
+    expect(decoded?.findings[0].message.endsWith("…")).toBe(true);
+  });
+});
+
+describe("extractPriorReviewContext failure modes", () => {
+  it("returns null when no marker is present", () => {
+    expect(extractPriorReviewContext("# Summary\nno markers here")).toBeNull();
+  });
+
+  it("returns null when the base64 payload is corrupt", () => {
+    expect(extractPriorReviewContext("<!-- rusty-bot:context:!!!notbase64!!! -->")).toBeNull();
+  });
+
+  it("returns null when JSON is missing required fields", () => {
+    const bad = Buffer.from(JSON.stringify({ summary: "ok" }), "utf-8").toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
+
+  it("returns null when recommendation is not a known enum value", () => {
+    const bad = Buffer.from(
+      JSON.stringify({ summary: "x", recommendation: "totally_invalid", findings: [] }),
+      "utf-8",
+    ).toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
+
+  it("returns null when a finding entry has the wrong shape", () => {
+    const bad = Buffer.from(
+      JSON.stringify({
+        summary: "x",
+        recommendation: "looks_good",
+        findings: [{ file: 1, line: "no", severity: "warning", message: "x" }],
+      }),
+      "utf-8",
+    ).toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
+
+  it("returns null when severity is unknown", () => {
+    const bad = Buffer.from(
+      JSON.stringify({
+        summary: "x",
+        recommendation: "looks_good",
+        findings: [{ file: "a.ts", line: 1, severity: "extreme", message: "x" }],
+      }),
+      "utf-8",
+    ).toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
+});
+
+describe("buildPriorContextFromReview", () => {
+  it("carries forward summary, recommendation, and findings (file/line/severity/message only)", () => {
+    const review: ReviewResult = {
+      summary: "This PR refactors auth.",
+      recommendation: "address_before_merge",
+      findings: [
+        {
+          file: "src/auth.ts",
+          line: 17,
+          endLine: 19,
+          severity: "critical",
+          category: "security",
+          message: "missing csrf check",
+          suggestedFix: "add csrf middleware",
+        },
+      ],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: ["src/auth.ts"],
+      modelUsed: "test-model",
+      tokenCount: 1000,
+    };
+
+    const ctx = buildPriorContextFromReview(review);
+    expect(ctx.summary).toBe(review.summary);
+    expect(ctx.recommendation).toBe(review.recommendation);
+    expect(ctx.findings).toEqual([
+      {
+        file: "src/auth.ts",
+        line: 17,
+        severity: "critical",
+        message: "missing csrf check",
+      },
+    ]);
+  });
+
+  it("produces an empty findings array when the review has none", () => {
+    const review: ReviewResult = {
+      summary: "no issues",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: [],
+      modelUsed: "test-model",
+      tokenCount: 0,
+    };
+    expect(buildPriorContextFromReview(review).findings).toEqual([]);
+  });
+});

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -38,3 +38,10 @@ export { clusterFindings, clusterObservations } from "./cluster.js";
 export type { FindingCluster, ObservationCluster } from "./cluster.js";
 export { judgeFindings, judgeReviewResult, resolveJudgeConfig } from "./judge.js";
 export type { JudgeConfig, JudgeResult } from "./judge.js";
+export {
+  buildPriorContextFromReview,
+  encodePriorReviewContext,
+  extractPriorReviewContext,
+  PRIOR_CONTEXT_LIMITS,
+  PRIOR_CONTEXT_MARKER_RE,
+} from "./prior-context.js";

--- a/packages/core/src/agent/prior-context.ts
+++ b/packages/core/src/agent/prior-context.ts
@@ -1,0 +1,96 @@
+import type { PriorReviewContext, PriorReviewContextFinding, ReviewResult } from "../types.js";
+
+const MARKER_PREFIX = "<!-- rusty-bot:context:";
+const MARKER_SUFFIX = " -->";
+export const PRIOR_CONTEXT_MARKER_RE = /<!--\s*rusty-bot:context:([A-Za-z0-9+/=]+)\s*-->/i;
+
+const SUMMARY_CHAR_CAP = 4_000;
+const FINDING_MESSAGE_CHAR_CAP = 250;
+const FINDINGS_COUNT_CAP = 50;
+const TRUNCATED_SUFFIX = "\n\n[truncated]";
+const ELLIPSIS = "…";
+
+const RECOMMENDATIONS = new Set(["looks_good", "address_before_merge", "critical_issues"]);
+
+const SEVERITIES = new Set(["suggestion", "warning", "critical"]);
+
+function truncateMessage(message: string): string {
+  if (message.length <= FINDING_MESSAGE_CHAR_CAP) return message;
+  return message.slice(0, FINDING_MESSAGE_CHAR_CAP) + ELLIPSIS;
+}
+
+function truncateSummary(summary: string): string {
+  if (summary.length <= SUMMARY_CHAR_CAP) return summary;
+  return summary.slice(0, SUMMARY_CHAR_CAP) + TRUNCATED_SUFFIX;
+}
+
+export function buildPriorContextFromReview(review: ReviewResult): PriorReviewContext {
+  return {
+    summary: review.summary,
+    recommendation: review.recommendation,
+    findings: review.findings.map((f) => ({
+      file: f.file,
+      line: f.line,
+      severity: f.severity,
+      message: f.message,
+    })),
+  };
+}
+
+/** serialize prior-context state into a hidden comment marker, applying caps. */
+export function encodePriorReviewContext(ctx: PriorReviewContext): string {
+  const truncated: PriorReviewContext = {
+    summary: truncateSummary(ctx.summary),
+    recommendation: ctx.recommendation,
+    findings: ctx.findings.slice(0, FINDINGS_COUNT_CAP).map((f) => ({
+      file: f.file,
+      line: f.line,
+      severity: f.severity,
+      message: truncateMessage(f.message),
+    })),
+  };
+  const json = JSON.stringify(truncated);
+  const b64 = Buffer.from(json, "utf-8").toString("base64");
+  return `${MARKER_PREFIX}${b64}${MARKER_SUFFIX}`;
+}
+
+function isFinding(value: unknown): value is PriorReviewContextFinding {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.file === "string" &&
+    typeof v.line === "number" &&
+    typeof v.severity === "string" &&
+    SEVERITIES.has(v.severity) &&
+    typeof v.message === "string"
+  );
+}
+
+function isContext(value: unknown): value is PriorReviewContext {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.summary !== "string") return false;
+  if (typeof v.recommendation !== "string") return false;
+  if (!RECOMMENDATIONS.has(v.recommendation)) return false;
+  if (!Array.isArray(v.findings)) return false;
+  return v.findings.every(isFinding);
+}
+
+/** extract a prior-context marker from a comment body. returns null on absence or any malformedness. */
+export function extractPriorReviewContext(commentBody: string): PriorReviewContext | null {
+  const match = PRIOR_CONTEXT_MARKER_RE.exec(commentBody);
+  if (!match) return null;
+  try {
+    const json = Buffer.from(match[1], "base64").toString("utf-8");
+    const parsed: unknown = JSON.parse(json);
+    return isContext(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+export const PRIOR_CONTEXT_LIMITS = {
+  summaryCharCap: SUMMARY_CHAR_CAP,
+  findingMessageCharCap: FINDING_MESSAGE_CHAR_CAP,
+  findingsCountCap: FINDINGS_COUNT_CAP,
+} as const;

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -1,7 +1,14 @@
 import { readFileSync } from "node:fs";
 import { resolve, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { ReviewConfig, PRMetadata, TicketInfo, FocusArea, ReviewStyle } from "../types.js";
+import type {
+  ReviewConfig,
+  PRMetadata,
+  TicketInfo,
+  FocusArea,
+  ReviewStyle,
+  PriorReviewContext,
+} from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -100,6 +107,7 @@ export function buildUserMessage(
   openGrepFindings?: OpenGrepFinding[],
   chunkFiles?: string[],
   rankedContext?: string,
+  priorContext?: PriorReviewContext,
 ): string {
   const parts: string[] = [];
 
@@ -175,8 +183,39 @@ export function buildUserMessage(
     parts.push(rankedContext);
   }
 
+  if (priorContext) {
+    parts.push("");
+    parts.push(buildPriorContextSection(priorContext));
+  }
+
   parts.push("\n## Diff\n");
   parts.push(diff);
 
+  return parts.join("\n");
+}
+
+function buildPriorContextSection(ctx: PriorReviewContext): string {
+  const parts: string[] = [];
+  parts.push("## Prior review context");
+  parts.push(
+    "This PR was reviewed previously; the **Diff** section below contains only the changes pushed since that review. " +
+      "Use the prior summary as established context for the rest of the PR — your published `summary` " +
+      "must describe the WHOLE PR, not just the new diff.",
+  );
+
+  parts.push("\n**Previously published summary:**");
+  parts.push(ctx.summary.trim());
+
+  parts.push(`\n**Previous recommendation:** ${ctx.recommendation}`);
+
+  if (ctx.findings.length > 0) {
+    parts.push(
+      "\n**Issues already surfaced** (do NOT re-raise unless this commit changes the underlying code; " +
+        "if a new commit fixes one of these, mention it in your summary):",
+    );
+    for (const f of ctx.findings) {
+      parts.push(`- \`${f.file}\`:${f.line} (${f.severity}) — ${f.message}`);
+    }
+  }
   return parts.join("\n");
 }

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -14,7 +14,14 @@ import {
   applyModelConstraints,
 } from "./model.js";
 import type { ModelConfig, ModelSettings } from "./model.js";
-import type { ReviewConfig, PRMetadata, TicketInfo, ReviewResult, GitProvider } from "../types.js";
+import type {
+  ReviewConfig,
+  PRMetadata,
+  TicketInfo,
+  ReviewResult,
+  GitProvider,
+  PriorReviewContext,
+} from "../types.js";
 import type { OpenGrepFinding } from "../opengrep/types.js";
 import { createSearchCodeTool, createGetFileContextTool } from "./tools.js";
 import { ToolCache } from "./tool-cache.js";
@@ -166,6 +173,8 @@ export interface RunReviewOptions {
   openGrepFindings?: OpenGrepFinding[];
   /** Ranked dependency context selected under a token budget for deep review. */
   rankedContext?: string;
+  /** PR-wide context carried forward from a previous review (incremental re-reviews only). */
+  priorContext?: PriorReviewContext;
   /** override used by consensus pass planning; defaults to RUSTY_LLM_MODEL. */
   modelConfig?: ModelConfig;
   /** override used by consensus pass planning; defaults to review env settings. */
@@ -204,6 +213,7 @@ export async function runReview(
     options?.openGrepFindings,
     options?.chunkFiles,
     tier === "deep-review" ? options?.rankedContext : undefined,
+    options?.priorContext,
   );
   const modelConfig = options?.modelConfig ?? resolveModelConfig();
   const modelName = getModelDisplayName(modelConfig);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -26,6 +26,8 @@ export type {
   CodeSearchResult,
   GitProvider,
   PostSummaryCommentOptions,
+  PriorReviewContext,
+  PriorReviewContextFinding,
   TicketProvider,
   DroppedFinding,
   ConsensusMetadata,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -114,6 +114,27 @@ export interface PostSummaryCommentOptions {
   lastReviewedSha?: string;
   /** ADO equivalent of lastReviewedSha — iteration id of the just-completed review */
   lastReviewedIteration?: string;
+  /** when set, providers embed an encoded marker the next incremental run can read back as PR-wide context */
+  priorContext?: PriorReviewContext;
+}
+
+export interface PriorReviewContextFinding {
+  file: string;
+  line: number;
+  severity: Severity;
+  message: string;
+}
+
+/**
+ * carry-forward state from a previous review pass. on incremental re-review the next
+ * pass only sees the diff since the last review, so we hand it the prior summary +
+ * already-surfaced findings so it can keep PR-wide situational awareness without
+ * re-reading the full PR diff.
+ */
+export interface PriorReviewContext {
+  summary: string;
+  recommendation: Recommendation;
+  findings: PriorReviewContextFinding[];
 }
 
 export interface Hunk {
@@ -184,6 +205,8 @@ export interface GitProvider {
   getLastReviewedSha?(): Promise<string | null>;
   /** fetch only the diff between an earlier sha and the current head; null if unreachable */
   getDiffSinceSha?(sinceSha: string, headSha: string): Promise<FilePatch[] | null>;
+  /** read PR-wide context (summary + findings) embedded in a previously-posted summary comment, if any */
+  getPriorReviewContext?(): Promise<PriorReviewContext | null>;
 }
 
 export interface TicketProvider {

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -2,6 +2,7 @@ import { Octokit } from "octokit";
 import type {
   FilePatch,
   FocusArea,
+  PriorReviewContext,
   ReviewConfig,
   TicketProvider,
   TicketRef,
@@ -35,6 +36,7 @@ import {
   isConventionalTitle,
   parseDiff,
   filterAnchorableFindings,
+  buildPriorContextFromReview,
 } from "@rusty-bot/core";
 import { GitHubProvider, createOctokitIssueFetcher } from "@rusty-bot/github";
 import {
@@ -223,13 +225,22 @@ export async function runAction(config: ActionConfig): Promise<number> {
     reviewConfig.conventionFile = conventionFile;
   }
 
-  // read incremental marker before deleting old bot comments — otherwise we lose the sha
+  // read incremental marker + prior context before deleting old bot comments —
+  // otherwise we lose the sha and the carry-forward state
   let lastReviewedSha: string | null = null;
+  let priorContext: PriorReviewContext | null = null;
   if (config.incrementalReview && metadata.headSha) {
     try {
       lastReviewedSha = await provider.getLastReviewedSha();
     } catch (err) {
       log.warn({ err }, "failed to read last-reviewed sha, falling back to full review");
+    }
+    if (lastReviewedSha) {
+      try {
+        priorContext = await provider.getPriorReviewContext();
+      } catch (err) {
+        log.warn({ err }, "failed to read prior review context; continuing without it");
+      }
     }
   }
 
@@ -387,6 +398,7 @@ export async function runAction(config: ActionConfig): Promise<number> {
           mcpServers,
           maxTokens: MAX_TOKENS,
           openGrepFindings,
+          priorContext: incrementalUsed && priorContext ? priorContext : undefined,
         },
       );
 
@@ -417,6 +429,7 @@ export async function runAction(config: ActionConfig): Promise<number> {
         mcpServers,
         maxTokens: MAX_TOKENS,
         openGrepFindings,
+        priorContext: incrementalUsed && priorContext ? priorContext : undefined,
       },
     );
   }
@@ -442,7 +455,12 @@ export async function runAction(config: ActionConfig): Promise<number> {
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
   await provider.postSummaryComment(
     summaryMarkdown,
-    metadata.headSha ? { lastReviewedSha: metadata.headSha } : undefined,
+    metadata.headSha
+      ? {
+          lastReviewedSha: metadata.headSha,
+          priorContext: buildPriorContextFromReview(review),
+        }
+      : undefined,
   );
 
   const inlineCandidates = review.findings.filter((f) => f.line > 0);

--- a/packages/github/src/__tests__/provider.test.ts
+++ b/packages/github/src/__tests__/provider.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { GitHubProvider } from "../provider.js";
 import type { Octokit } from "octokit";
-import type { Finding } from "@rusty-bot/core";
+import type { Finding, PriorReviewContext } from "@rusty-bot/core";
+import { encodePriorReviewContext, extractPriorReviewContext } from "@rusty-bot/core";
 
 function createMockOctokit() {
   return {
@@ -118,6 +119,97 @@ describe("GitHubProvider", () => {
         "<!-- rusty-bot:last-sha:abc123def4560000000000000000000000000000 -->",
       );
       expect(call.body).toContain("## Review\nLooks good!");
+    });
+
+    it("embeds the prior-context marker when provided", async () => {
+      octokit.request.mockResolvedValueOnce({ data: {} });
+
+      const priorContext: PriorReviewContext = {
+        summary: "earlier review summary",
+        recommendation: "address_before_merge",
+        findings: [{ file: "src/a.ts", line: 1, severity: "warning", message: "issue" }],
+      };
+
+      await provider.postSummaryComment("## Review\nLooks good!", {
+        lastReviewedSha: "abc123def4560000000000000000000000000000",
+        priorContext,
+      });
+
+      const call = octokit.request.mock.calls[0][1] as { body: string };
+      expect(call.body).toContain("<!-- rusty-bot:last-sha:");
+      expect(call.body).toMatch(/<!--\s*rusty-bot:context:/);
+      const decoded = extractPriorReviewContext(call.body);
+      expect(decoded).toEqual(priorContext);
+    });
+
+    it("does not embed the prior-context marker when omitted", async () => {
+      octokit.request.mockResolvedValueOnce({ data: {} });
+      await provider.postSummaryComment("## Review\nLooks good!", {
+        lastReviewedSha: "abc123def4560000000000000000000000000000",
+      });
+      const call = octokit.request.mock.calls[0][1] as { body: string };
+      expect(call.body).not.toContain("rusty-bot:context:");
+    });
+  });
+
+  describe("getPriorReviewContext", () => {
+    const priorContext: PriorReviewContext = {
+      summary: "earlier review",
+      recommendation: "looks_good",
+      findings: [{ file: "x.ts", line: 1, severity: "suggestion", message: "ok" }],
+    };
+
+    it("returns null when no comments exist", async () => {
+      octokit.request.mockResolvedValueOnce({ data: [] });
+      expect(await provider.getPriorReviewContext()).toBeNull();
+    });
+
+    it("returns null when bot comments exist but lack the context marker", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [{ id: 1, body: "<!-- rusty-bot-review -->\nold review, no context marker" }],
+      });
+      expect(await provider.getPriorReviewContext()).toBeNull();
+    });
+
+    it("returns null when the context marker is malformed", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body: "<!-- rusty-bot-review -->\n<!-- rusty-bot:context:!!!notbase64!!! -->",
+          },
+        ],
+      });
+      expect(await provider.getPriorReviewContext()).toBeNull();
+    });
+
+    it("extracts the most recent prior context when multiple bot comments exist", async () => {
+      const olderCtx: PriorReviewContext = {
+        summary: "OLDER review",
+        recommendation: "critical_issues",
+        findings: [],
+      };
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body: `<!-- rusty-bot-review -->\n${encodePriorReviewContext(olderCtx)}`,
+          },
+          { id: 2, body: "human comment" },
+          {
+            id: 3,
+            body: `<!-- rusty-bot-review -->\n${encodePriorReviewContext(priorContext)}`,
+          },
+        ],
+      });
+      expect(await provider.getPriorReviewContext()).toEqual(priorContext);
+    });
+
+    it("ignores a context marker outside a bot comment", async () => {
+      octokit.request.mockResolvedValueOnce({
+        data: [{ id: 1, body: encodePriorReviewContext(priorContext) }],
+      });
+      expect(await provider.getPriorReviewContext()).toBeNull();
     });
   });
 

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -7,8 +7,14 @@ import type {
   Hunk,
   CodeSearchResult,
   PostSummaryCommentOptions,
+  PriorReviewContext,
 } from "@rusty-bot/core";
-import { formatInlineComment, logger } from "@rusty-bot/core";
+import {
+  encodePriorReviewContext,
+  extractPriorReviewContext,
+  formatInlineComment,
+  logger,
+} from "@rusty-bot/core";
 
 const BOT_MARKER = "<!-- rusty-bot-review -->";
 const LAST_SHA_MARKER_RE = /<!--\s*rusty-bot:last-sha:([0-9a-f]{40})\s*-->/i;
@@ -178,6 +184,26 @@ export class GitHubProvider implements GitProvider {
     return null;
   }
 
+  async getPriorReviewContext(): Promise<PriorReviewContext | null> {
+    const { data: comments } = await this.octokit.request(
+      "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      {
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: this.pullNumber,
+      },
+    );
+
+    // walk newest-first; only return the most recent prior context
+    for (let i = comments.length - 1; i >= 0; i--) {
+      const body = comments[i].body;
+      if (!body?.includes(BOT_MARKER)) continue;
+      const ctx = extractPriorReviewContext(body);
+      if (ctx) return ctx;
+    }
+    return null;
+  }
+
   async getPRMetadata(): Promise<PRMetadata> {
     const { data } = await this.octokit.request("GET /repos/{owner}/{repo}/pulls/{pull_number}", {
       owner: this.owner,
@@ -232,14 +258,18 @@ export class GitHubProvider implements GitProvider {
   }
 
   async postSummaryComment(markdown: string, options?: PostSummaryCommentOptions): Promise<void> {
-    const header = options?.lastReviewedSha
-      ? `${BOT_MARKER}\n${buildLastShaMarker(options.lastReviewedSha)}`
-      : BOT_MARKER;
+    const headerParts: string[] = [BOT_MARKER];
+    if (options?.lastReviewedSha) {
+      headerParts.push(buildLastShaMarker(options.lastReviewedSha));
+    }
+    if (options?.priorContext) {
+      headerParts.push(encodePriorReviewContext(options.priorContext));
+    }
     await this.octokit.request("POST /repos/{owner}/{repo}/issues/{issue_number}/comments", {
       owner: this.owner,
       repo: this.repo,
       issue_number: this.pullNumber,
-      body: `${header}\n${markdown}`,
+      body: `${headerParts.join("\n")}\n${markdown}`,
     });
   }
 

--- a/packages/gitlab/src/cli.ts
+++ b/packages/gitlab/src/cli.ts
@@ -1,6 +1,7 @@
 import type {
   FilePatch,
   FocusArea,
+  PriorReviewContext,
   ReviewConfig,
   TicketProvider,
   TicketRef,
@@ -33,6 +34,7 @@ import {
   generateConventionalTitle,
   isConventionalTitle,
   filterAnchorableFindings,
+  buildPriorContextFromReview,
 } from "@rusty-bot/core";
 import { GitLabProvider } from "./provider.js";
 
@@ -213,13 +215,22 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
     reviewConfig.conventionFile = conventionFile;
   }
 
-  // read incremental marker before deleting old bot comments — otherwise we lose the sha
+  // read incremental marker + prior context before deleting old bot comments —
+  // otherwise we lose the sha and the carry-forward state
   let lastReviewedSha: string | null = null;
+  let priorContext: PriorReviewContext | null = null;
   if (incrementalReview && metadata.headSha) {
     try {
       lastReviewedSha = await provider.getLastReviewedSha();
     } catch (err) {
       log.warn({ err }, "failed to read last-reviewed sha, falling back to full review");
+    }
+    if (lastReviewedSha) {
+      try {
+        priorContext = await provider.getPriorReviewContext();
+      } catch (err) {
+        log.warn({ err }, "failed to read prior review context; continuing without it");
+      }
     }
   }
 
@@ -388,6 +399,7 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
           mcpServers,
           maxTokens: MAX_TOKENS,
           openGrepFindings,
+          priorContext: incrementalUsed && priorContext ? priorContext : undefined,
         },
       );
 
@@ -418,6 +430,7 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
         mcpServers,
         maxTokens: MAX_TOKENS,
         openGrepFindings,
+        priorContext: incrementalUsed && priorContext ? priorContext : undefined,
       },
     );
   }
@@ -443,7 +456,12 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
   const summaryMarkdown = formatSummaryComment(review, { ticketResolution });
   await provider.postSummaryComment(
     summaryMarkdown,
-    metadata.headSha ? { lastReviewedSha: metadata.headSha } : undefined,
+    metadata.headSha
+      ? {
+          lastReviewedSha: metadata.headSha,
+          priorContext: buildPriorContextFromReview(review),
+        }
+      : undefined,
   );
 
   const inlineCandidates = review.findings.filter((f) => f.line > 0);

--- a/packages/gitlab/src/provider.ts
+++ b/packages/gitlab/src/provider.ts
@@ -6,8 +6,14 @@ import type {
   Hunk,
   CodeSearchResult,
   PostSummaryCommentOptions,
+  PriorReviewContext,
 } from "@rusty-bot/core";
-import { formatInlineComment, logger } from "@rusty-bot/core";
+import {
+  encodePriorReviewContext,
+  extractPriorReviewContext,
+  formatInlineComment,
+  logger,
+} from "@rusty-bot/core";
 import type { z } from "zod";
 import {
   GitLabMergeRequestSchema,
@@ -252,6 +258,18 @@ export class GitLabProvider implements GitProvider {
     return null;
   }
 
+  async getPriorReviewContext(): Promise<PriorReviewContext | null> {
+    const notes = await this.request(`${this.mrBase}/notes?per_page=100`, GitLabNotesSchema);
+    for (const note of notes) {
+      if (note.system) continue;
+      const body = note.body;
+      if (!body?.includes(BOT_MARKER)) continue;
+      const ctx = extractPriorReviewContext(body);
+      if (ctx) return ctx;
+    }
+    return null;
+  }
+
   async getFileContent(path: string, ref: string): Promise<string | null> {
     try {
       const url = `${this.projectBase}/repository/files/${encodeURIComponent(
@@ -284,6 +302,9 @@ export class GitLabProvider implements GitProvider {
     const headerLines = [BOT_MARKER];
     if (options?.lastReviewedSha) {
       headerLines.push(buildLastShaMarker(options.lastReviewedSha));
+    }
+    if (options?.priorContext) {
+      headerLines.push(encodePriorReviewContext(options.priorContext));
     }
     const body = `${headerLines.join("\n")}\n${markdown}`;
     await this.fetchApi(`${this.mrBase}/notes`, {


### PR DESCRIPTION
## Why

When a PR gets new commits after a previous review, the bot fetches only the diff since the last reviewed commit/iteration. That kept token costs down on multi-commit PRs but had a quality cost: the agent received only that delta and described it in isolation. Concretely, on one observed re-review:

- the published `summary` text said *"This review is limited to the single diff chunk provided"*
- `filesReviewed` shrank from 6 (initial review) to 1 (re-review) because the new commit only touched 1 file
- the prose summary described only the latest commit, not the whole PR

Disabling the feature would have cost the token savings users explicitly asked for. The right shape was **keep incremental diffs, carry the missing context forward in a tiny side-channel**.

## What changes

After every review, the bot now embeds two hidden markers in its summary comment instead of just one:

```html
<!-- rusty-bot-review -->
<!-- rusty-bot:last-sha:abc123 -->
<!-- rusty-bot:context:BASE64 -->        <!-- new -->
{markdown summary…}
```

The `context` marker holds a base64-encoded JSON of the published `summary`, `recommendation`, and `findings` (file/line/severity/message only). On the next incremental run the provider reads it back and the agent's user-message prompt gains a new section before the diff:

```
## Prior review context

This PR was reviewed previously; the **Diff** section below contains
only the changes pushed since that review. Use the prior summary as
established context for the rest of the PR — your published `summary`
must describe the WHOLE PR, not just the new diff.

**Previously published summary:** …
**Previous recommendation:** address_before_merge

**Issues already surfaced** (do NOT re-raise unless this commit changes
the underlying code; if a new commit fixes one of these, mention it in
your summary):
- `src/foo.ts`:42 (warning) — potential null deref
- …
```

That last paragraph is the active fix for the "filesReviewed shrunk to 1" symptom — the agent is now told its diff scope is incremental but its summary scope is PR-wide.

## Caps and trade-offs

| Field | Cap | Why |
|---|---|---|
| `summary` | 4 000 chars | Prior summaries should be short; if they aren't, append `[truncated]` and move on |
| `findings` | 50 items | Beyond this, the duplicate-suppression value plateaus |
| Per-finding `message` | 250 chars | Same reasoning as summary |
| Chained re-reviews | most-recent only | The previous summary already absorbed the one before it; chaining re-introduces the bloat we're trying to avoid |

Compared to re-fetching the full PR diff (the alternative we discussed and rejected), the marker payload is bounded to ~2-3 KB of base64 regardless of PR size.

## Symmetric across providers

| Provider | Marker carrier | Read on next run |
|---|---|---|
| GitHub | issue comment body | `getPriorReviewContext()` walks `/issues/{n}/comments` newest-first |
| GitLab | MR note body | walks `/notes` newest-first (same pattern as `getLastReviewedSha`) |
| Azure DevOps | thread comment body | walks `/threads` newest-first |

Encode/decode + cap logic lives in `packages/core/src/agent/prior-context.ts`. Each provider just wraps the marker into its own comment carrier.

## Failure modes (all gracefully fall through)

- **Malformed marker / corrupt base64 / wrong shape / unknown enum** → `extractPriorReviewContext` returns `null`, agent runs without prior context
- **Force-push / rebase that orphans the prior SHA** → `getDiffSinceSha` returns `null`, falls back to full diff (same as before this change)
- **`getPriorReviewContext` throws** → CLI logs `warn`, proceeds without prior context
- **Marker present but `RUSTY_INCREMENTAL_REVIEW=false`** → not read; bot does full review every time

## Test plan

- [x] **prior-context.test.ts** (15 tests): encode/extract roundtrip, summary/findings-list/message truncation, all malformed-marker rejection paths, `buildPriorContextFromReview` carries forward only the four documented fields
- [x] **agent.test.ts** (6 new tests): prompt rendering with and without prior context, ordering relative to the diff, `WHOLE PR` instruction present, finding row format, empty-findings list omits the "issues already surfaced" header
- [x] **github provider.test.ts** (7 new tests): `postSummaryComment` emits / doesn't emit the marker, `getPriorReviewContext` returns null on no comments / no marker / malformed marker / non-bot comment, picks most-recent on multiple bot comments
- [x] Full suite: **885 tests passing** (857 existing + 28 new)
- [x] All packages build clean (`pnpm -r build`)

## Out of scope

- Calibrating the judge against findings produced under prior context (separate FOLLOWUPS item)
- Carrying forward observations / ticket compliance / missing tests (only `findings` are surfaced inline; the others live in the summary text and are recovered via the `summary` field)
- GitLab/ADO provider tests for the new methods — followed the same symmetric pattern as `getLastReviewedSha` and the failure modes are exercised by the core tests; can add if review wants them