### PR TITLE
perf: emit diff context once instead of duplicating across hunk blocks

### DIFF
--- a/packages/core/src/__tests__/compress-tokens.test.ts
+++ b/packages/core/src/__tests__/compress-tokens.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it } from "vitest";
+import { compressDiff, countTokens } from "../diff/compress.js";
+import type { FilePatch } from "../types.js";
+
+/**
+ * Token-decrease benchmark for `compressDiff`. Asserts that the post-refactor
+ * implementation (which emits context lines exactly once) is at least 30% cheaper
+ * than the pre-refactor dual-emit shape on a context-heavy fixture.
+ *
+ * Why a percentage instead of an absolute cap: countTokens uses a rough
+ * Math.ceil(length/4) heuristic, which is volatile under small format tweaks
+ * (block markers, blank lines). What we actually care about is the relative
+ * win — context lines must not appear twice anymore.
+ */
+
+function makeContextHeavyHunk(contextLines: number, addLines: number, removeLines: number) {
+  const lines: string[] = [];
+  for (let i = 0; i < contextLines; i++) {
+    lines.push(` const x${i} = ${i};`);
+  }
+  for (let i = 0; i < addLines; i++) {
+    lines.push(`+const newConst${i} = ${i};`);
+  }
+  for (let i = 0; i < removeLines; i++) {
+    lines.push(`-const goneConst${i} = ${i};`);
+  }
+  return lines.join("\n");
+}
+
+function makeFixture(): FilePatch[] {
+  // representative shape: 4 files, mostly context (the worst case for the old shape)
+  return [
+    {
+      path: "src/a.ts",
+      additions: 5,
+      deletions: 0,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 100,
+          newStart: 1,
+          newLines: 105,
+          content: makeContextHeavyHunk(100, 5, 0),
+        },
+      ],
+    },
+    {
+      path: "src/b.ts",
+      additions: 3,
+      deletions: 2,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 80,
+          newStart: 1,
+          newLines: 81,
+          content: makeContextHeavyHunk(80, 3, 2),
+        },
+      ],
+    },
+    {
+      path: "src/c.ts",
+      additions: 0,
+      deletions: 4,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 60,
+          newStart: 1,
+          newLines: 56,
+          content: makeContextHeavyHunk(60, 0, 4),
+        },
+      ],
+    },
+    {
+      path: "src/d.ts",
+      additions: 10,
+      deletions: 10,
+      isBinary: false,
+      hunks: [
+        {
+          oldStart: 1,
+          oldLines: 40,
+          newStart: 1,
+          newLines: 40,
+          content: makeContextHeavyHunk(40, 10, 10),
+        },
+      ],
+    },
+  ];
+}
+
+/** simulate the pre-refactor dual-emit shape so the benchmark is self-contained. */
+function legacyCompressedSize(patches: FilePatch[]): number {
+  const parts: string[] = [];
+  for (const patch of patches) {
+    parts.push(`## ${patch.path}`);
+    for (const hunk of patch.hunks) {
+      const lines = hunk.content.split("\n");
+      const oldLines: string[] = [];
+      const newLines: string[] = [];
+      let oldLine = hunk.oldStart;
+      let newLine = hunk.newStart;
+      for (const line of lines) {
+        if (line.startsWith("-")) {
+          oldLines.push(`${oldLine} ${line}`);
+          oldLine++;
+        } else if (line.startsWith("+")) {
+          newLines.push(`${newLine} ${line}`);
+          newLine++;
+        } else if (line.startsWith("\\")) {
+          continue;
+        } else if (line.startsWith("~")) {
+          oldLines.push(line);
+          newLines.push(line);
+        } else {
+          oldLines.push(`${oldLine} ${line}`);
+          newLines.push(`${newLine} ${line}`);
+          oldLine++;
+          newLine++;
+        }
+      }
+      if (oldLines.length > 0) {
+        parts.push("__old hunk__");
+        parts.push(...oldLines);
+      }
+      if (newLines.length > 0) {
+        parts.push("__new hunk__");
+        parts.push(...newLines);
+      }
+    }
+  }
+  return countTokens(parts.join("\n"));
+}
+
+describe("compressDiff token-decrease benchmark", () => {
+  it("emits at least 30% fewer tokens than the pre-refactor dual-emit shape on a context-heavy fixture", () => {
+    const patches = makeFixture();
+    const newTokens = countTokens(compressDiff(patches, Infinity).compressed);
+    const oldTokens = legacyCompressedSize(patches);
+
+    expect(newTokens).toBeLessThan(oldTokens);
+
+    const ratio = newTokens / oldTokens;
+    expect(ratio).toBeLessThan(0.7);
+  });
+
+  it("does not duplicate context lines in the output", () => {
+    const patches = makeFixture();
+    const { compressed } = compressDiff(patches, Infinity);
+    // pick a context line we know exists exactly once per file in the fixture
+    const occurrences = compressed.split("\n").filter((l) => l.endsWith(" const x42 = 42;"));
+    // x42 appears in three files (a, b, c — d only has 40 context lines so no x42)
+    expect(occurrences).toHaveLength(3);
+  });
+});

--- a/packages/core/src/__tests__/diff.test.ts
+++ b/packages/core/src/__tests__/diff.test.ts
@@ -290,13 +290,149 @@ describe("countTokens", () => {
 });
 
 describe("compressDiff", () => {
-  it("compresses patches into formatted output", () => {
+  it("emits the file header and a __new hunk__ block for an additions-only diff", () => {
     const patches = parseDiff(singleFileDiff);
     const result = compressDiff(patches, 10000);
     expect(result.compressed).toContain("## src/index.ts");
     expect(result.compressed).toContain("__new hunk__");
-    expect(result.compressed).toContain("__old hunk__");
+    // singleFileDiff has zero removed lines — old block must be omitted entirely
+    expect(result.compressed).not.toContain("__old hunk__");
     expect(result.skippedFiles).toEqual([]);
+  });
+
+  it("emits __old hunk__ only when a hunk has removals", () => {
+    const patches = parseDiff(multiFileDiff);
+    const result = compressDiff(patches, 10000);
+    // multiFileDiff has file2.ts with a removal
+    expect(result.compressed).toContain("__old hunk__");
+    expect(result.compressed).toContain("__new hunk__");
+  });
+
+  it("omits __new hunk__ when a hunk has only removals (no context, no additions)", () => {
+    // hand-built patch avoids the parser's trailing-newline phantom-context quirk
+    const patches: FilePatch[] = [
+      {
+        path: "src/all-gone.ts",
+        additions: 0,
+        deletions: 2,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 1,
+            oldLines: 2,
+            newStart: 0,
+            newLines: 0,
+            content: "-line one\n-line two",
+          },
+        ],
+      },
+    ];
+    const result = compressDiff(patches, 10000);
+    expect(result.compressed).toContain("## src/all-gone.ts");
+    expect(result.compressed).toContain("__old hunk__");
+    expect(result.compressed).not.toContain("__new hunk__");
+  });
+
+  it("emits each context line exactly once (no duplication across blocks)", () => {
+    // mixed hunk: context + addition + removal — context must appear once total
+    const patches: FilePatch[] = [
+      {
+        path: "src/mixed.ts",
+        additions: 1,
+        deletions: 1,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 10,
+            oldLines: 4,
+            newStart: 10,
+            newLines: 4,
+            content: [" unchanged-before", "-removed-line", "+added-line", " unchanged-after"].join(
+              "\n",
+            ),
+          },
+        ],
+      },
+    ];
+    const { compressed } = compressDiff(patches, 10000);
+    const lines = compressed.split("\n");
+    expect(lines.filter((l) => l.includes("unchanged-before"))).toHaveLength(1);
+    expect(lines.filter((l) => l.includes("unchanged-after"))).toHaveLength(1);
+    // both blocks present
+    expect(compressed).toContain("__new hunk__");
+    expect(compressed).toContain("__old hunk__");
+  });
+
+  it("places sibling signature annotations only in the new-side block", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/sig.ts",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 5,
+            oldLines: 1,
+            newStart: 5,
+            newLines: 2,
+            content: ["~ // ... function outer() {", " context-line", "+added"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const { compressed } = compressDiff(patches, 10000);
+    expect(compressed.match(/~ \/\/ \.\.\. function outer/g)).toHaveLength(1);
+    // new block only — pure-add hunk has no old block
+    expect(compressed).not.toContain("__old hunk__");
+  });
+
+  it("advances new-side line numbers across context lines", () => {
+    // context advances both counters even though only the new-side prefix is emitted
+    const patches: FilePatch[] = [
+      {
+        path: "src/counter.ts",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 100,
+            oldLines: 3,
+            newStart: 100,
+            newLines: 4,
+            content: [" first context", " second context", "+added line"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const { compressed } = compressDiff(patches, 10000);
+    expect(compressed).toContain("100  first context");
+    expect(compressed).toContain("101  second context");
+    expect(compressed).toContain("102 +added line");
+  });
+
+  it("removed lines are prefixed with old-side line numbers", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/removal.ts",
+        additions: 0,
+        deletions: 2,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 50,
+            oldLines: 4,
+            newStart: 50,
+            newLines: 2,
+            content: [" before", "-gone-1", "-gone-2", " after"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const { compressed } = compressDiff(patches, 10000);
+    expect(compressed).toContain("51 -gone-1");
+    expect(compressed).toContain("52 -gone-2");
   });
 
   it("skips files when budget is exhausted", () => {

--- a/packages/core/src/diff/compress.ts
+++ b/packages/core/src/diff/compress.ts
@@ -9,40 +9,45 @@ function formatHunks(patch: FilePatch): string {
 
   for (const hunk of patch.hunks) {
     const lines = hunk.content.split("\n");
-    const oldLines: string[] = [];
-    const newLines: string[] = [];
+    // context, additions, and sibling signatures collect into the new-side block;
+    // removals collect into the old-side block. context lines are NOT duplicated
+    // across blocks — the model can read context once from the new-hunk block and
+    // still understand removals from the old-hunk block via line numbers.
+    const oldRemovedLines: string[] = [];
+    const newSideLines: string[] = [];
     let oldLine = hunk.oldStart;
     let newLine = hunk.newStart;
 
     for (const line of lines) {
       if (line.startsWith("-")) {
-        oldLines.push(`${oldLine} ${line}`);
+        oldRemovedLines.push(`${oldLine} ${line}`);
         oldLine++;
       } else if (line.startsWith("+")) {
-        newLines.push(`${newLine} ${line}`);
+        newSideLines.push(`${newLine} ${line}`);
         newLine++;
       } else if (line.startsWith("\\")) {
         // no-newline marker, keep in whichever section was last
         continue;
       } else if (line.startsWith("~")) {
-        // sibling signature annotation: emit without line number, do not advance counters
-        oldLines.push(line);
-        newLines.push(line);
+        // sibling signature annotation from tree-sitter scope expansion. emit without
+        // line number, do not advance counters. only needed in the new-side block —
+        // it's a hint about the surrounding scope, not historical state.
+        newSideLines.push(line);
       } else {
-        oldLines.push(`${oldLine} ${line}`);
-        newLines.push(`${newLine} ${line}`);
+        // unchanged context: advance both counters but emit only on the new side.
+        newSideLines.push(`${newLine} ${line}`);
         oldLine++;
         newLine++;
       }
     }
 
-    if (oldLines.length > 0) {
-      parts.push("__old hunk__");
-      parts.push(...oldLines);
-    }
-    if (newLines.length > 0) {
+    if (newSideLines.length > 0) {
       parts.push("__new hunk__");
-      parts.push(...newLines);
+      parts.push(...newSideLines);
+    }
+    if (oldRemovedLines.length > 0) {
+      parts.push("__old hunk__");
+      parts.push(...oldRemovedLines);
     }
   }
 


### PR DESCRIPTION
## Why

`formatHunks` in `packages/core/src/diff/compress.ts` emitted every unchanged context line **twice** — once inside `__old hunk__` and once inside `__new hunk__`. That's wasted input tokens on the dominant prompt path (every consensus pass, every cascade tier). The lines are byte-identical and the model already infers "before / after" from `+`/`-` prefixes alone.

FOLLOWUPS item #6. Now that #166 (judge per-finding excerpts) and #168 (prior-context carry-forward) are merged, this is the next-largest waste in the reviewer prompt.

## What changes

Keep both block markers. Move all context (and `~` sibling-signature lines) into `__new hunk__`. `__old hunk__` carries only removed lines. Either block is **omitted entirely** when its side is empty — most feature PRs are pure-add, so `__old hunk__` disappears in the common case.

```
Before:                              After:
## src/example.ts                    ## src/example.ts
__old hunk__                         __new hunk__
10  import { foo } from "./foo";     10  import { foo } from "./foo";
11                                   11  
12 -export const old = 1;            12 +export const replaced = 2;
13  export function main() {         13  export function main() {
14    return 0;                       14    return 0;
15  }                                 15  }
__new hunk__                         __old hunk__
10  import { foo } from "./foo";     12 -export const old = 1;
11  
12 +export const replaced = 2;
13  export function main() {
14    return 0;
15  }
```

Verified on the actual output (see commit log).

## Why this shape

- **Keep the markers.** `__old hunk__` / `__new hunk__` aren't explained anywhere in the system prompt (`grep -rn "__old hunk__" packages/core/src/prompts/` returns zero hits). The model has been inferring their meaning from training-distribution patterns; that inference still holds because the surface form is nearly identical — only the duplication is gone.
- **Context lives in the new block.** Reviewers anchor findings to NEW-side line numbers, so the new block is the authoritative source for surrounding code. The old block becomes a "what was removed at these old line numbers" lookup.
- **Counters still advance for context.** Both `oldLine` and `newLine` are incremented on each context line — only the new-side prefix is emitted, but old-side line numbers for subsequent removals remain accurate.

## Format consumers checked

| Consumer | File:line | Re-parses output? |
|---|---|---|
| `runReview` reviewer prompt | `multi-call.ts:317-464`, `consensus.ts:139` | No — opaque string |
| Title generation | `title/generate.ts:29` | No |
| Description generation | `description/generate.ts:101` | No |
| Token counting | `multi-call.ts:48` | No |
| `filterAnchorableFindings` | `anchor.ts:13-25` | **No — operates on `FilePatch.hunks`** |
| `judge.ts buildFindingExcerpt` | `judge.ts:64-72` | **No — operates on `FilePatch.hunks`** |
| `treesitter.test.ts:507, 593` | line-prefix lookup | Yes — but looks for new-side context lines, which still appear |

The only consumers that re-parse are two test cases that look up specific NEW-side context lines via prefix matching (`compressed.split("\n").find((l) => l.startsWith("250 "))`). Those continue to work because new-side context still appears in `__new hunk__` with its NEW-side prefix.

## Token savings

Benchmark in `packages/core/src/__tests__/compress-tokens.test.ts`: **>30% reduction** on a context-heavy fixture (4 files, 80% context). The benchmark replays the legacy dual-emit shape locally to compute the ratio, so it's self-contained and stable.

Real-world expectation: savings scale with the context-to-change ratio per hunk. Typical feature PRs have ~80-95% context per hunk → ~50% reduction in compress output size, which compounds across consensus passes (2-3× per chunk).

## Out of scope

`packages/core/src/agent/judge.ts` `formatHunkExcerpt` (lines 27-62) has the same dual-emit pattern but operates independently on per-finding excerpts, not the full diff. Per-finding tokens are already small (one hunk's worth), so the savings are modest. Documented in `FOLLOWUPS.md` as a follow-up; mechanical port when judge tokens become a concern.

## Test plan

- [x] **diff.test.ts** (existing assertion + 6 new edge cases): pure-add hunk omits `__old hunk__`; pure-remove hunk omits `__new hunk__`; mixed hunk has both with context appearing exactly once; sibling signatures emitted only on new side; line-number counters advance correctly across context lines; removed lines prefixed with old-side line numbers
- [x] **compress-tokens.test.ts** (new): >30% token reduction on context-heavy fixture; context line appears exactly once per occurrence
- [x] **treesitter.test.ts**: passes unchanged (the no-re-parsing claim verified)
- [x] Full suite: **893 tests passing** (885 existing + 8 new)
- [x] All packages build clean (`pnpm -r build`)
- [x] Manual eyeball on a mixed-hunk fixture confirms the new shape