### PR TITLE
fix: raise undici headers/body timeouts to 10 min for slow LLM routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_FAIL_ON_CRITICAL` | exit 1 on critical findings (pipeline/action mode) | `true` |
 | `RUSTY_REVIEW_DRAFTS` | review draft PRs in GitHub Action mode | `false` |
 | `RUSTY_INCREMENTAL_REVIEW` | review only the diff since the last reviewed commit (GitHub, GitLab) or PR iteration (Azure DevOps); previous summary + findings are carried forward as context | `true` |
+| `RUSTY_LLM_HEADERS_TIMEOUT_MS` | undici headers timeout for outbound `fetch` (LLM router + provider APIs) — raised above the 300s default to accommodate slow upstream models on large prompts | `600000` |
+| `RUSTY_LLM_BODY_TIMEOUT_MS` | undici body timeout for outbound `fetch`; resets per chunk so generations longer than this still complete as long as chunks keep arriving | `600000` |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |
@@ -534,6 +536,19 @@ When a PR gets new commits after a previous review, the bot only fetches the dif
 - Carry-forward state is provider-side: it survives bot-comment cleanup because the markers are read **before** old comments are deleted on each run.
 - If a force-push or rebase makes the prior SHA unreachable, the bot transparently falls back to a full review — there is no fragile state.
 - Disable with `RUSTY_INCREMENTAL_REVIEW=false`; the bot then re-reviews the full PR every time and posts no carry-forward markers.
+
+### LLM Request Timeouts
+
+Node's underlying HTTP client (undici) defaults to a **300-second headers timeout**. On large PRs reviewed with slower upstream routes — particularly Requesty proxying to Fireworks/Kimi or other long-tail providers — the response headers may not arrive within that window even though the model is making forward progress. The default would surface as a `HeadersTimeoutError` (`UND_ERR_HEADERS_TIMEOUT`) on the affected pass.
+
+Each CLI entry point calls `configureGlobalHttp()` at startup, which installs an undici dispatcher with a longer headers + body timeout. Defaults:
+
+- `RUSTY_LLM_HEADERS_TIMEOUT_MS=600000` (10 min)
+- `RUSTY_LLM_BODY_TIMEOUT_MS=600000` (resets per response chunk)
+
+These apply to **all** outbound `fetch` calls (LLM routes + GitHub/GitLab/ADO APIs). Raising the timeout never harms a fast request — it only delays the failure mode for slow ones.
+
+If you keep seeing headers-timeout failures on a specific consensus pass, bump `RUSTY_LLM_HEADERS_TIMEOUT_MS` to `900000` or `1200000`. If the failure persists past 15 minutes, the upstream model is genuinely stuck (not slow) — the right fix is to drop that model from `RUSTY_REVIEW_MODELS` rather than extend the timeout further.
 
 ### OpenGrep Pre-scan
 

--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -32,6 +32,7 @@ import {
   isConventionalTitle,
   filterAnchorableFindings,
   buildPriorContextFromReview,
+  configureGlobalHttp,
 } from "@rusty-bot/core";
 import { AzureDevOpsProvider } from "./provider.js";
 
@@ -94,6 +95,8 @@ export function parseConfig(): {
 }
 
 async function main(): Promise<void> {
+  configureGlobalHttp();
+
   const { provider, config, failOnCritical, incrementalReview, env } = parseConfig();
 
   const metadata = await provider.getPRMetadata();

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import {
+  configureGlobalHttp,
   expandContext,
   fetchConventionFile,
   filterAnchorableFindings,
@@ -169,6 +170,8 @@ export async function run(args: CliArgs): Promise<number> {
 }
 
 async function main(): Promise<number> {
+  configureGlobalHttp();
+
   let args: CliArgs;
   try {
     args = parseArgs(process.argv.slice(2), process.env);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -32,6 +32,7 @@
     "tree-sitter-python": "^0.25.0",
     "tree-sitter-rust": "^0.24.0",
     "tree-sitter-typescript": "^0.23.2",
+    "undici": "^8.2.0",
     "web-tree-sitter": "^0.26.8",
     "zod": "^4.4.3"
   },

--- a/packages/core/src/__tests__/http-config.test.ts
+++ b/packages/core/src/__tests__/http-config.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const setGlobalDispatcherMock = vi.fn();
+const agentCtorSpy = vi.fn();
+
+vi.mock("undici", () => {
+  class FakeAgent {
+    readonly __mock = true;
+    constructor(opts: unknown) {
+      agentCtorSpy(opts);
+    }
+  }
+  return {
+    setGlobalDispatcher: setGlobalDispatcherMock,
+    Agent: FakeAgent,
+  };
+});
+
+describe("configureGlobalHttp", () => {
+  beforeEach(() => {
+    setGlobalDispatcherMock.mockReset();
+    agentCtorSpy.mockReset();
+    delete process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS;
+    delete process.env.RUSTY_LLM_BODY_TIMEOUT_MS;
+    vi.resetModules();
+  });
+
+  it("uses 600000ms defaults when env vars are unset", async () => {
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledTimes(1);
+    expect(agentCtorSpy).toHaveBeenCalledWith({
+      headersTimeout: 600_000,
+      bodyTimeout: 600_000,
+    });
+    expect(setGlobalDispatcherMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors RUSTY_LLM_HEADERS_TIMEOUT_MS and RUSTY_LLM_BODY_TIMEOUT_MS when set", async () => {
+    process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS = "900000";
+    process.env.RUSTY_LLM_BODY_TIMEOUT_MS = "1200000";
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledWith({
+      headersTimeout: 900_000,
+      bodyTimeout: 1_200_000,
+    });
+  });
+
+  it("falls back to defaults when env values are non-numeric", async () => {
+    process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS = "abc";
+    process.env.RUSTY_LLM_BODY_TIMEOUT_MS = "";
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledWith({
+      headersTimeout: 600_000,
+      bodyTimeout: 600_000,
+    });
+  });
+
+  it("falls back to defaults when env values are zero or negative", async () => {
+    process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS = "0";
+    process.env.RUSTY_LLM_BODY_TIMEOUT_MS = "-5000";
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledWith({
+      headersTimeout: 600_000,
+      bodyTimeout: 600_000,
+    });
+  });
+
+  it("floors fractional millisecond values", async () => {
+    process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS = "750000.9";
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledWith({
+      headersTimeout: 750_000,
+      bodyTimeout: 600_000,
+    });
+  });
+
+  it("is idempotent — second call is a no-op", async () => {
+    const { configureGlobalHttp } = await import("../http-config.js");
+    configureGlobalHttp();
+    configureGlobalHttp();
+    configureGlobalHttp();
+
+    expect(agentCtorSpy).toHaveBeenCalledTimes(1);
+    expect(setGlobalDispatcherMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/http-config.ts
+++ b/packages/core/src/http-config.ts
@@ -1,0 +1,59 @@
+import { Agent, setGlobalDispatcher } from "undici";
+import { logger } from "./logger.js";
+
+const log = logger.child({ module: "http-config" });
+
+/** node 18+ undici default. raised here because slow LLM routes (notably
+ * Requesty → Kimi) routinely buffer >300s before sending the first response
+ * header, especially on large prompts with active tool-calling. */
+const DEFAULT_HEADERS_TIMEOUT_MS = 600_000;
+
+/** body timeout matches headers — once headers arrive, the body should follow
+ * promptly even on long generations because each chunk resets the timer. */
+const DEFAULT_BODY_TIMEOUT_MS = 600_000;
+
+let configured = false;
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+/**
+ * configure undici's global dispatcher so all `fetch` calls (including
+ * ai-sdk → Mastra → upstream LLM) get longer headers/body timeouts than
+ * the 300s default. idempotent — safe to call from each CLI entry point.
+ *
+ * controlled by:
+ *   - `RUSTY_LLM_HEADERS_TIMEOUT_MS` (default 600000 = 10 min)
+ *   - `RUSTY_LLM_BODY_TIMEOUT_MS` (default 600000 = 10 min)
+ *
+ * affects all outbound fetch calls (LLM routes, GitHub/GitLab/ADO APIs).
+ * that's intentional — every consumer here is upstream API I/O, and
+ * raising the timeout never harms a fast request.
+ */
+export function configureGlobalHttp(): void {
+  if (configured) return;
+  configured = true;
+
+  const headersTimeout = parsePositiveInt(
+    process.env.RUSTY_LLM_HEADERS_TIMEOUT_MS,
+    DEFAULT_HEADERS_TIMEOUT_MS,
+  );
+  const bodyTimeout = parsePositiveInt(
+    process.env.RUSTY_LLM_BODY_TIMEOUT_MS,
+    DEFAULT_BODY_TIMEOUT_MS,
+  );
+
+  setGlobalDispatcher(
+    new Agent({
+      headersTimeout,
+      bodyTimeout,
+      // keep-alive defaults are fine; we don't churn many distinct hosts.
+    }),
+  );
+
+  log.info({ headersTimeout, bodyTimeout }, "configured global http dispatcher");
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -35,6 +35,7 @@ export type {
 
 export { getMastra, getStorage } from "./mastra.js";
 export { logger, flushLogger } from "./logger.js";
+export { configureGlobalHttp } from "./http-config.js";
 export * from "./formatter/index.js";
 export * from "./tickets/index.js";
 export * from "./diff/index.js";

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -37,6 +37,7 @@ import {
   parseDiff,
   filterAnchorableFindings,
   buildPriorContextFromReview,
+  configureGlobalHttp,
 } from "@rusty-bot/core";
 import { GitHubProvider, createOctokitIssueFetcher } from "@rusty-bot/github";
 import {
@@ -498,6 +499,8 @@ export async function runAction(config: ActionConfig): Promise<number> {
 }
 
 async function main(): Promise<number> {
+  configureGlobalHttp();
+
   const eventPath = process.env.GITHUB_EVENT_PATH;
   if (!eventPath) {
     throw new Error("GITHUB_EVENT_PATH is not set — this CLI must run inside a GitHub Action");

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -5,7 +5,7 @@ import { resolve, dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { readFile, stat } from "node:fs/promises";
 import type { FocusArea } from "@rusty-bot/core";
-import { ReviewStyleSchema, logger } from "@rusty-bot/core";
+import { ReviewStyleSchema, configureGlobalHttp, logger } from "@rusty-bot/core";
 import { validateWebhookSignature, parseWebhookEvent } from "./webhook.js";
 import { createAppOctokit } from "./auth.js";
 import { orchestrateReview } from "./orchestrator.js";
@@ -218,6 +218,7 @@ if (dashboardEnabled) {
 }
 
 if (process.env.NODE_ENV !== "test") {
+  configureGlobalHttp();
   const port = Number(process.env.PORT ?? 3000);
   serve({ fetch: app.fetch, port });
   log.info({ port }, "server listening");

--- a/packages/gitlab/src/cli.ts
+++ b/packages/gitlab/src/cli.ts
@@ -35,6 +35,7 @@ import {
   isConventionalTitle,
   filterAnchorableFindings,
   buildPriorContextFromReview,
+  configureGlobalHttp,
 } from "@rusty-bot/core";
 import { GitLabProvider } from "./provider.js";
 
@@ -499,6 +500,8 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
 }
 
 async function main(): Promise<number> {
+  configureGlobalHttp();
+
   // GitLab CI runs this CLI on every pipeline; only proceed when triggered by an MR event.
   const eventType = process.env.CI_PIPELINE_SOURCE;
   if (eventType && eventType !== "merge_request_event" && !process.env.CI_MERGE_REQUEST_IID) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       tree-sitter-typescript:
         specifier: ^0.23.2
         version: 0.23.2
+      undici:
+        specifier: ^8.2.0
+        version: 8.2.0
       web-tree-sitter:
         specifier: ^0.26.8
         version: 0.26.8
@@ -2631,6 +2634,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@8.2.0:
+    resolution: {integrity: sha512-Z+4Hx9GE26Lh9Upwfnc8C7SsrpBPGaM/Gm6kMFtiG7c+5IvQKlXi/t+9x9DrrCh29cww5TSP9YdVaBcnLDs5fQ==}
+    engines: {node: '>=22.19.0'}
 
   unicorn-magic@0.3.0:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
@@ -5457,6 +5464,8 @@ snapshots:
   underscore@1.13.8: {}
 
   undici-types@7.19.2: {}
+
+  undici@8.2.0: {}
 
   unicorn-magic@0.3.0: {}
 


### PR DESCRIPTION
## Why

Recurring bot failure on production PRs:

```
{"level":40,"err":{"type":"APICallError",
 "message":"Cannot connect to API: Headers Timeout Error",
 "code":"UND_ERR_HEADERS_TIMEOUT"},
 "url":"https://router.requesty.ai/v1/chat/completions",
 "modelId":"fireworks/kimi-k2.6"}
```

Timeline of one observed run on PR #412 of the user's downstream repo:

| Time | Event |
|---|---|
| `17:30:45` | consensus start (3 passes: kimi, MiniMax, grok) |
| `17:31:07` | grok-4.3 done — 22s, 77K input |
| `17:32:20` | MiniMax-M2.7 done — 95s, 79K input |
| `17:35:46` | **kimi-k2.6 FAILED — 5m01s after consensus started** |

Five minutes flat — that's **undici's default headers timeout (300s)** firing exactly. `statusCode: undefined`, `responseHeaders: undefined` — Requesty never sent the first byte of response headers. The model was making forward progress; undici just gave up.

The other two passes routed through the same proxy and finished in <100s, so they never hit it. Kimi via Requesty/Fireworks consistently pushes past 300s on large prompts and starves.

## What changes

New `packages/core/src/http-config.ts` exporting `configureGlobalHttp()`. Calls undici's `setGlobalDispatcher()` with a configurable `Agent`:

```ts
new Agent({ headersTimeout, bodyTimeout })
```

Wired into every entry point: `packages/{github-action,gitlab,azure-devops,cli}/src/cli.ts` plus `packages/github/src/server.ts`. Idempotent — multiple calls are no-ops.

Defaults:
- `RUSTY_LLM_HEADERS_TIMEOUT_MS=600000` (10 min)
- `RUSTY_LLM_BODY_TIMEOUT_MS=600000` (resets per chunk, so generations longer than this still complete as long as chunks keep arriving)

These apply to **all** outbound `fetch` (LLM routes + GitHub/GitLab/ADO APIs). Intentional — every consumer here is upstream API I/O, and raising the timeout never harms a fast request.

## Why this and not deeper

This is a stopgap, deliberately. The deeper question — *why* does Kimi via Requesty/Fireworks routinely take >5 minutes on large prompts — is FOLLOWUPS #3. Two competing hypotheses:

1. **Requesty buffers responses.** It holds the full body before sending headers; with a slow upstream, headers wait until the body is ready.
2. **Kimi tool-call loops.** Even after PRs #163/#164 capped tool-result sizes, the loop *count* may still be unbounded, so the model spends 5 minutes shuffling tokens before final generation.

Disambiguating those needs per-step `finishReason`/`stepNumber` logging on the agent (FOLLOWUPS #3 action item), which is a separate change. This PR removes the immediate pain — every Kimi pass dying at exactly 5 minutes — while we collect data for the actual fix.

If you keep seeing headers-timeouts past 10 min after this lands, bump `RUSTY_LLM_HEADERS_TIMEOUT_MS=900000` in your env. If the failure persists past 15 min, the upstream model is genuinely stuck (not slow), and the right move is to drop it from `RUSTY_REVIEW_MODELS` rather than extend the timeout.

## Test plan

- [x] **http-config.test.ts** (6 new tests): default 600 000 ms when env unset; honors `RUSTY_LLM_HEADERS_TIMEOUT_MS` / `RUSTY_LLM_BODY_TIMEOUT_MS` when set; falls back to defaults on non-numeric, zero, and negative values; floors fractional millisecond values; idempotent across multiple calls
- [x] Full suite: **899 tests passing** (893 existing + 6 new)
- [x] All packages build clean (`pnpm -r build`)
- [x] README updated: dedicated `### LLM Request Timeouts` subsection + env-var table entries

## Files

- **NEW**: `packages/core/src/http-config.ts` — the dispatcher setup
- **NEW**: `packages/core/src/__tests__/http-config.test.ts` — env parsing + idempotency
- `packages/core/package.json` — adds `undici` direct dep (Node bundles it transitively, but the public configuration API needs the package)
- `packages/core/src/index.ts` — exports `configureGlobalHttp`
- `packages/{github-action,gitlab,azure-devops,cli}/src/cli.ts` — calls `configureGlobalHttp()` at the top of `main()`
- `packages/github/src/server.ts` — calls it before `serve()`
- `README.md` — env-var table + new subsection