### PR TITLE
feat: native Ollama (local + Ollama Cloud) provider, mixable in consensus

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -31,20 +31,33 @@ jobs:
           # mastra's native requesty provider reads this directly; no base-url
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
-          RUSTY_LLM_MODEL: requesty/fireworks/kimi-k2.6
+          # ollama cloud — bearer auth via Authorization header. set
+          # RUSTY_OLLAMA_BASE_URL=https://ollama.com so any `ollama/*` model
+          # in RUSTY_REVIEW_MODELS routes via the hosted endpoint instead of
+          # the local default (http://127.0.0.1:11434).
+          RUSTY_OLLAMA_BASE_URL: https://ollama.com
+          RUSTY_OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
+
+          RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          RUSTY_REVIEW_MODELS: requesty/fireworks/kimi-k2.6,requesty/xai/grok-4.3,requesty/minimaxi/MiniMax-M2.7
-          RUSTY_LLM_JSON_PROMPT_INJECTION: requesty/fireworks/kimi-k2.6
-          RUSTY_REVIEW_TEMPERATURES: "1,0.2,0.3"
+          # cross-provider consensus: two passes via ollama cloud (deepseek + kimi),
+          # one via requesty (grok). different vendors → different finding
+          # distributions → richer overlap before clustering.
+          RUSTY_REVIEW_MODELS: >-
+            ollama/deepseek-v4-pro:cloud,
+            requesty/xai/grok-4.3,
+            ollama/kimi-k2.6:cloud
+          RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
+          RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           # cap tool-using trajectories so tool-happy models (Kimi/Anthropic)
           # can't terminate with finishReason="tool-calls" and zero text. the
           # final allowed step gets toolChoice="none" so the model has to emit
           # the structured-output JSON. see #152.
-          RUSTY_LLM_MAX_STEPS: "8"
+          RUSTY_LLM_MAX_STEPS: "10"
           RUSTY_JUDGE_ENABLED: "true"
-          RUSTY_JUDGE_MODEL: requesty/anthropic/claude-sonnet-4-6
-          RUSTY_JUDGE_TEMPERATURE: "0"
+          RUSTY_JUDGE_MODEL: ollama/deepseek-v4-pro:cloud
+          RUSTY_JUDGE_TEMPERATURE: "0.1"
           RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_TRIAGE_TEMPERATURE: "0"
           RUSTY_REVIEW_STYLE: balanced

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -40,18 +40,15 @@ jobs:
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-provider consensus. ordering matters: planConsensusPasses
-          # picks the FIRST n models for n-pass consensus (n=2 for ordinary
-          # chunks, n=3 for security/large chunks). put requesty's grok in
-          # slot 1 because Ollama Cloud has been observed returning transient
-          # 503 "Server overloaded" — keeping the first slot on a more
-          # reliable provider means a single Ollama hiccup doesn't fail the
-          # whole 2-of-2 ordinary review.
+          # cross-provider consensus: deepseek + kimi via ollama cloud,
+          # grok via requesty. transient Ollama Cloud 5xx/429s are now
+          # retried by isTransientRetryableError (see review.ts) so we
+          # don't have to defensively reorder around them.
           RUSTY_REVIEW_MODELS: >-
+            ollama/deepseek-v4-pro:cloud,
             requesty/xai/grok-4.3,
-            ollama/kimi-k2.6:cloud,
-            ollama/deepseek-v4-pro:cloud
-          RUSTY_REVIEW_TEMPERATURES: "0.3,1,0.3"
+            ollama/kimi-k2.6:cloud
+          RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           # cap tool-using trajectories so tool-happy models (Kimi/Anthropic)

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -40,14 +40,18 @@ jobs:
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-provider consensus: two passes via ollama cloud (deepseek + kimi),
-          # one via requesty (grok). different vendors → different finding
-          # distributions → richer overlap before clustering.
+          # cross-provider consensus. ordering matters: planConsensusPasses
+          # picks the FIRST n models for n-pass consensus (n=2 for ordinary
+          # chunks, n=3 for security/large chunks). put requesty's grok in
+          # slot 1 because Ollama Cloud has been observed returning transient
+          # 503 "Server overloaded" — keeping the first slot on a more
+          # reliable provider means a single Ollama hiccup doesn't fail the
+          # whole 2-of-2 ordinary review.
           RUSTY_REVIEW_MODELS: >-
-            ollama/deepseek-v4-pro:cloud,
             requesty/xai/grok-4.3,
-            ollama/kimi-k2.6:cloud
-          RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
+            ollama/kimi-k2.6:cloud,
+            ollama/deepseek-v4-pro:cloud
+          RUSTY_REVIEW_TEMPERATURES: "0.3,1,0.3"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           # cap tool-using trajectories so tool-happy models (Kimi/Anthropic)

--- a/README.md
+++ b/README.md
@@ -273,6 +273,8 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_INCREMENTAL_REVIEW` | review only the diff since the last reviewed commit (GitHub, GitLab) or PR iteration (Azure DevOps); previous summary + findings are carried forward as context | `true` |
 | `RUSTY_LLM_HEADERS_TIMEOUT_MS` | undici headers timeout for outbound `fetch` (LLM router + provider APIs) — raised above the 300s default to accommodate slow upstream models on large prompts | `600000` |
 | `RUSTY_LLM_BODY_TIMEOUT_MS` | undici body timeout for outbound `fetch`; resets per chunk so generations longer than this still complete as long as chunks keep arriving | `600000` |
+| `RUSTY_OLLAMA_BASE_URL` | base URL for the `ollama/*` provider — set to `https://ollama.com` for [Ollama Cloud](https://ollama.com), or a remote host for self-hosted Ollama | `http://127.0.0.1:11434` |
+| `RUSTY_OLLAMA_API_KEY` | bearer token for the `ollama/*` provider (required for Ollama Cloud, ignored for unauthenticated local instances); falls back to `OLLAMA_API_KEY` | — |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |
@@ -370,14 +372,35 @@ RUSTY_AZURE_ANTHROPIC_DEPLOYMENT=claude-sonnet-4-5
 
 Uses `DefaultAzureCredential` to fetch a fresh token (scope `https://cognitiveservices.azure.com/.default`) for every request, just like the Azure OpenAI managed identity path.
 
-**7. OpenAI-compatible endpoint** — for LiteLLM, vLLM, Ollama, or any proxy:
+**7. OpenAI-compatible endpoint** — for LiteLLM, vLLM, or any proxy:
 ```bash
 RUSTY_LLM_BASE_URL=http://localhost:4000/v1
 RUSTY_LLM_MODEL=gpt-4o
 RUSTY_LLM_API_KEY=optional-key
 ```
 
-**8. Mastra model router (default)** — direct provider API keys:
+**8. Ollama (local or [Ollama Cloud](https://ollama.com))** — uses the native [`ai-sdk-ollama`](https://www.npmjs.com/package/ai-sdk-ollama) provider, so it supports tool calling and can be mixed per-pass with other providers in `RUSTY_REVIEW_MODELS`:
+```bash
+# local Ollama (default)
+RUSTY_LLM_MODEL=ollama/llama3.2
+
+# Ollama Cloud
+RUSTY_LLM_MODEL=ollama/gpt-oss:120b
+RUSTY_OLLAMA_BASE_URL=https://ollama.com
+RUSTY_OLLAMA_API_KEY=...   # get one at https://ollama.com/account
+```
+
+To mix Ollama with other providers in a consensus ensemble:
+
+```bash
+RUSTY_OLLAMA_BASE_URL=https://ollama.com
+RUSTY_OLLAMA_API_KEY=...
+RUSTY_REVIEW_MODELS=anthropic/claude-sonnet-4-5,ollama/gpt-oss:120b,requesty/google/gemini-3.1-pro
+```
+
+Structured output: by default Ollama uses prompt-injected JSON via the structuring model (set `RUSTY_LLM_STRUCTURING_MODEL` to a known-good model like `requesty/google/gemini-3.1-flash-lite-preview`). Opt into native JSON schema for specific models with `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=ollama/gpt-oss*`.
+
+**9. Mastra model router (default)** — direct provider API keys:
 ```bash
 RUSTY_LLM_MODEL=anthropic/claude-sonnet-4-20250514
 ANTHROPIC_API_KEY=sk-ant-...

--- a/action.yml
+++ b/action.yml
@@ -41,7 +41,12 @@ inputs:
 # See the README for the full list of RUSTY_* env vars.
 runs:
   using: docker
-  image: docker://ghcr.io/jegork/rusty-bot:latest
+  # build from local source on every invocation so PR branches that change
+  # the provider/model resolution (e.g. this PR's ollama integration) are
+  # actually exercised by the self-review. published `:latest` is rebuilt
+  # only on push to main; using it here would silently run stale code on
+  # PRs that touch the action's runtime.
+  image: Dockerfile
   env:
     RUSTY_MODE: github-action
     GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/action.yml
+++ b/action.yml
@@ -41,12 +41,7 @@ inputs:
 # See the README for the full list of RUSTY_* env vars.
 runs:
   using: docker
-  # build from local source on every invocation so PR branches that change
-  # the provider/model resolution (e.g. this PR's ollama integration) are
-  # actually exercised by the self-review. published `:latest` is rebuilt
-  # only on push to main; using it here would silently run stale code on
-  # PRs that touch the action's runtime.
-  image: Dockerfile
+  image: docker://ghcr.io/jegork/rusty-bot:latest
   env:
     RUSTY_MODE: github-action
     GITHUB_TOKEN: ${{ inputs.github-token }}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "@mastra/core": "^1.32.1",
     "@mastra/libsql": "^1.10.0",
     "@mastra/mcp": "^1.7.0",
+    "ai-sdk-ollama": "^3",
     "picomatch": "^4.0.4",
     "pino": "^10.3.1",
     "tiktoken": "^1.0.0",

--- a/packages/core/src/__tests__/model.test.ts
+++ b/packages/core/src/__tests__/model.test.ts
@@ -42,6 +42,9 @@ function clearEnv() {
   delete process.env.RUSTY_LLM_JSON_PROMPT_INJECTION;
   delete process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT;
   delete process.env.RUSTY_LLM_DISABLE_THINKING;
+  delete process.env.RUSTY_OLLAMA_BASE_URL;
+  delete process.env.RUSTY_OLLAMA_API_KEY;
+  delete process.env.OLLAMA_API_KEY;
 }
 
 describe("resolveModelConfig", () => {
@@ -219,6 +222,67 @@ describe("resolveModelConfig", () => {
       expect(config.deploymentName).toBe("Kimi-K2.6");
     }
   });
+
+  it("builds ollama config from `ollama/` prefix with no env vars (local default)", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/llama3.2";
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "ollama",
+      model: "llama3.2",
+      baseUrl: undefined,
+      apiKey: undefined,
+    });
+  });
+
+  it("preserves colons in ollama model identifiers (e.g. gpt-oss:120b)", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/gpt-oss:120b";
+    const config = resolveModelConfig();
+    expect(config.type).toBe("ollama");
+    if (config.type === "ollama") {
+      expect(config.model).toBe("gpt-oss:120b");
+    }
+  });
+
+  it("threads RUSTY_OLLAMA_BASE_URL into the ollama config (cloud routing)", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/gpt-oss:120b";
+    process.env.RUSTY_OLLAMA_BASE_URL = "https://ollama.com";
+    process.env.RUSTY_OLLAMA_API_KEY = "ol-secret";
+    const config = resolveModelConfig();
+    expect(config).toEqual({
+      type: "ollama",
+      model: "gpt-oss:120b",
+      baseUrl: "https://ollama.com",
+      apiKey: "ol-secret",
+    });
+  });
+
+  it("falls back to OLLAMA_API_KEY when RUSTY_OLLAMA_API_KEY is unset", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/llama3.2";
+    process.env.OLLAMA_API_KEY = "fallback-key";
+    const config = resolveModelConfig();
+    expect(config.type).toBe("ollama");
+    if (config.type === "ollama") {
+      expect(config.apiKey).toBe("fallback-key");
+    }
+  });
+
+  it("prefers RUSTY_OLLAMA_API_KEY over OLLAMA_API_KEY when both set", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/llama3.2";
+    process.env.RUSTY_OLLAMA_API_KEY = "rusty-key";
+    process.env.OLLAMA_API_KEY = "fallback-key";
+    const config = resolveModelConfig();
+    if (config.type === "ollama") {
+      expect(config.apiKey).toBe("rusty-key");
+    }
+  });
+
+  it("ollama prefix wins over RUSTY_LLM_BASE_URL (the openai-compatible path)", () => {
+    process.env.RUSTY_LLM_MODEL = "ollama/llama3.2";
+    process.env.RUSTY_LLM_BASE_URL = "http://litellm.local/v1";
+    process.env.RUSTY_LLM_API_KEY = "litellm-key";
+    const config = resolveModelConfig();
+    expect(config.type).toBe("ollama");
+  });
 });
 
 describe("resolveReviewPassModelConfigs", () => {
@@ -247,6 +311,28 @@ describe("resolveReviewPassModelConfigs", () => {
       "openai/pass-2",
       "anthropic/default",
     ]);
+  });
+
+  it("mixes ollama with router providers across consensus passes", () => {
+    process.env.RUSTY_OLLAMA_BASE_URL = "https://ollama.com";
+    process.env.RUSTY_OLLAMA_API_KEY = "ol-key";
+    process.env.RUSTY_REVIEW_MODELS =
+      "anthropic/claude-sonnet-4-5,ollama/gpt-oss:120b,requesty/google/gemini-3.1-pro";
+
+    const configs = resolveReviewPassModelConfigs(3);
+
+    expect(configs[0].config.type).toBe("router");
+    expect(configs[1].config.type).toBe("ollama");
+    expect(configs[2].config.type).toBe("router");
+    expect(configs.map((c) => c.displayName)).toEqual([
+      "anthropic/claude-sonnet-4-5",
+      "ollama/gpt-oss:120b",
+      "requesty/google/gemini-3.1-pro",
+    ]);
+    if (configs[1].config.type === "ollama") {
+      expect(configs[1].config.baseUrl).toBe("https://ollama.com");
+      expect(configs[1].config.apiKey).toBe("ol-key");
+    }
   });
 
   it("applies per-pass temperature and top-p overrides", () => {
@@ -553,6 +639,29 @@ describe("supportsNativeStructuredOutput", () => {
         deploymentName: "Kimi-K2.6",
       }),
     ).toBe(false);
+  });
+
+  it("returns false for ollama configs (defaults to prompt-injected JSON)", () => {
+    expect(
+      supportsNativeStructuredOutput({
+        type: "ollama",
+        model: "gpt-oss:120b",
+        baseUrl: "https://ollama.com",
+        apiKey: "k",
+      }),
+    ).toBe(false);
+  });
+
+  it("opts ollama into native structured output via RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT", () => {
+    process.env.RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT = "ollama/gpt-oss*";
+    const config = {
+      type: "ollama" as const,
+      model: "gpt-oss:120b",
+      baseUrl: "https://ollama.com",
+    };
+    // resolveJsonPromptInjection inverts supportsNativeStructuredOutput when the
+    // override matches — so the native path becomes active for matched models.
+    expect(resolveJsonPromptInjection(config)).toBe(false);
   });
 });
 
@@ -888,6 +997,17 @@ describe("getModelDisplayName", () => {
         deploymentName: "Kimi-K2.6",
       }),
     ).toBe("azure-foundry/Kimi-K2.6");
+  });
+
+  it("returns ollama/<model> preserving colons for ollama configs", () => {
+    expect(
+      getModelDisplayName({
+        type: "ollama",
+        model: "gpt-oss:120b",
+        baseUrl: "https://ollama.com",
+        apiKey: "k",
+      }),
+    ).toBe("ollama/gpt-oss:120b");
   });
 });
 

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -250,6 +250,24 @@ class FakeApiCallError extends Error {
   }
 }
 
+/** matches the shape thrown by ai-sdk-ollama: an OllamaError wrapping a
+ * ResponseError whose status_code (snake_case, ollama-js convention) is the
+ * upstream HTTP status. set `directStatusCode` to put status_code directly on
+ * the OllamaError instead of via cause — both shapes have been observed. */
+class FakeOllamaError extends Error {
+  cause?: { status_code: number };
+  status_code?: number;
+  constructor(message: string, statusCode: number, options: { directStatusCode?: boolean } = {}) {
+    super(message);
+    this.name = "OllamaError";
+    if (options.directStatusCode) {
+      this.status_code = statusCode;
+    } else {
+      this.cause = { status_code: statusCode };
+    }
+  }
+}
+
 describe("runReview retry on transient LLM errors", () => {
   beforeEach(() => {
     generateMock.mockReset();
@@ -340,6 +358,63 @@ describe("runReview retry on transient LLM errors", () => {
 
     await settle(runReview(config, "diff", prMetadata));
     expect(generateMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retries an OllamaError 503 from cause.status_code (Ollama Cloud overload)", async () => {
+    generateMock
+      .mockRejectedValueOnce(new FakeOllamaError("Server overloaded, please retry shortly", 503))
+      .mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries an OllamaError 429 (rate limited)", async () => {
+    generateMock
+      .mockRejectedValueOnce(new FakeOllamaError("Too many requests", 429))
+      .mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries an OllamaError with status_code set directly on the error (not via cause)", async () => {
+    generateMock
+      .mockRejectedValueOnce(new FakeOllamaError("Bad gateway", 502, { directStatusCode: true }))
+      .mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a ResponseError 503 (the inner ollama-js error name) directly", async () => {
+    const inner = Object.assign(new Error("upstream overloaded"), {
+      name: "ResponseError",
+      status_code: 503,
+    });
+    generateMock.mockRejectedValueOnce(inner).mockResolvedValueOnce(makeValidResponse());
+
+    await settle(runReview(config, "diff", prMetadata));
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry an OllamaError with a non-retryable status (e.g. 400 bad request)", async () => {
+    generateMock.mockRejectedValueOnce(new FakeOllamaError("model not found", 404));
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow("model not found");
+    expect(generateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not retry an OllamaError with no status_code anywhere", async () => {
+    const orphan = Object.assign(new Error("malformed upstream response"), {
+      name: "OllamaError",
+    });
+    generateMock.mockRejectedValueOnce(orphan);
+
+    await expect(settle(runReview(config, "diff", prMetadata))).rejects.toThrow(
+      "malformed upstream response",
+    );
+    expect(generateMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -1,6 +1,7 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createAzure } from "@ai-sdk/azure";
 import { DefaultAzureCredential } from "@azure/identity";
+import { createOllama } from "ai-sdk-ollama";
 
 export type ModelConfig =
   | { type: "router"; model: string }
@@ -10,7 +11,8 @@ export type ModelConfig =
   | { type: "azure-foundry-managed-identity"; resourceName: string; deploymentName: string }
   | { type: "azure-anthropic-api-key"; baseUrl: string; deploymentName: string; apiKey: string }
   | { type: "azure-anthropic-managed-identity"; baseUrl: string; deploymentName: string }
-  | { type: "openai-compatible"; baseUrl: string; model: string; apiKey?: string };
+  | { type: "openai-compatible"; baseUrl: string; model: string; apiKey?: string }
+  | { type: "ollama"; baseUrl?: string; model: string; apiKey?: string };
 
 export function resolveModelConfig(): ModelConfig {
   const model = process.env.RUSTY_LLM_MODEL ?? "anthropic/claude-sonnet-4-20250514";
@@ -76,6 +78,20 @@ export function resolveModelConfig(): ModelConfig {
       type: "azure-anthropic-managed-identity",
       baseUrl: azureAnthropicBaseUrl,
       deploymentName: process.env.RUSTY_AZURE_ANTHROPIC_DEPLOYMENT,
+    };
+  }
+
+  // ollama (local default; cloud when RUSTY_OLLAMA_BASE_URL=https://ollama.com).
+  // routed via the native ai-sdk-ollama provider instead of the openai-compat
+  // path so tool-calling + provider-specific options (mirostat, num_ctx, etc.)
+  // are available, and so consensus passes can mix ollama models with other
+  // providers per-route.
+  if (model.startsWith("ollama/")) {
+    return {
+      type: "ollama",
+      model: model.replace("ollama/", ""),
+      baseUrl: process.env.RUSTY_OLLAMA_BASE_URL,
+      apiKey: process.env.RUSTY_OLLAMA_API_KEY ?? process.env.OLLAMA_API_KEY,
     };
   }
 
@@ -155,7 +171,10 @@ function makeFoundryFetch(opts: FoundryBodyOptions): typeof globalThis.fetch {
 
 export function resolveModel(
   config: ModelConfig,
-): string | ReturnType<ReturnType<typeof createAzure>> {
+):
+  | string
+  | ReturnType<ReturnType<typeof createAzure>>
+    {
   switch (config.type) {
     case "router":
       return config.model;
@@ -251,6 +270,14 @@ export function resolveModel(
 
     case "openai-compatible":
       return config.model;
+
+    case "ollama": {
+      const ollama = createOllama({
+        ...(config.baseUrl && { baseURL: config.baseUrl }),
+        ...(config.apiKey && { apiKey: config.apiKey }),
+      });
+      return ollama(config.model);
+    }
   }
 }
 
@@ -300,6 +327,11 @@ export function supportsNativeStructuredOutput(config: ModelConfig): boolean {
       return false;
     case "openai-compatible":
       return true;
+    case "ollama":
+      // ollama models vary widely in JSON-schema reliability. default to
+      // prompt-injected JSON via the structuring model; opt in per-model with
+      // RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=ollama/gpt-oss* etc.
+      return false;
     case "router":
       return NATIVE_STRUCTURED_OUTPUT_ROUTER_PREFIXES.some((prefix) =>
         config.model.startsWith(prefix),
@@ -322,6 +354,8 @@ function modelMatchKey(config: ModelConfig): string {
     case "azure-anthropic-api-key":
     case "azure-anthropic-managed-identity":
       return `azure-anthropic/${config.deploymentName}`;
+    case "ollama":
+      return `ollama/${config.model}`;
   }
 }
 
@@ -489,5 +523,7 @@ export function getModelDisplayName(config: ModelConfig): string {
       return `azure-anthropic/${config.deploymentName}`;
     case "openai-compatible":
       return `${config.baseUrl}/${config.model}`;
+    case "ollama":
+      return `ollama/${config.model}`;
   }
 }

--- a/packages/core/src/agent/model.ts
+++ b/packages/core/src/agent/model.ts
@@ -171,10 +171,9 @@ function makeFoundryFetch(opts: FoundryBodyOptions): typeof globalThis.fetch {
 
 export function resolveModel(
   config: ModelConfig,
-):
-  | string
-  | ReturnType<ReturnType<typeof createAzure>>
-    {
+): string | ReturnType<ReturnType<typeof createAzure>> {
+  // both createAzure(...)(...) and createOllama(...)(...) return the ai-sdk-v6
+  // LanguageModelV3 shape, so a single ReturnType<...> annotation is enough.
   switch (config.type) {
     case "router":
       return config.model;

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -44,10 +44,35 @@ function isStructuredOutputValidationError(err: unknown): boolean {
 // with isRetryable=true. Mastra's internal pRetry handles per-request retries; this
 // catches the case where its retries exhausted within a single tight timeout window
 // and gives the caller a fresh request budget.
+/** retryable HTTP statuses for upstream LLM calls — 408 (timeout), 425 (early
+ * data), 429 (rate limit), and the 5xx server-side band. matches the ai-sdk's
+ * APICallError convention so other providers downstream of mastra get the
+ * same treatment. */
+function isRetryableStatus(status: unknown): boolean {
+  if (typeof status !== "number") return false;
+  if (status === 408 || status === 425 || status === 429) return true;
+  return status >= 500 && status < 600;
+}
+
+/** ai-sdk-ollama's OllamaError doesn't set ai-sdk's `isRetryable` marker, so
+ * an upstream 503 from Ollama Cloud (e.g. "Server overloaded") falls through
+ * pRetry's filter today. duck-type the error and look for ollama-js's
+ * `status_code` (snake_case) on either the error itself or its `cause`. */
+function isOllamaRetryableError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as { name?: unknown; status_code?: unknown; cause?: unknown };
+  if (e.name !== "OllamaError" && e.name !== "ResponseError") return false;
+  if (isRetryableStatus(e.status_code)) return true;
+  const cause = e.cause as { status_code?: unknown } | undefined;
+  return isRetryableStatus(cause?.status_code);
+}
+
 function isTransientRetryableError(err: unknown): boolean {
-  return (
-    typeof err === "object" && err !== null && "isRetryable" in err && err.isRetryable === true
-  );
+  if (typeof err !== "object" || err === null) return false;
+  if ("isRetryable" in err && (err as { isRetryable?: unknown }).isRetryable === true) {
+    return true;
+  }
+  return isOllamaRetryableError(err);
 }
 
 const TRANSIENT_RETRY_BACKOFF_MS = [500, 2_000];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,7 +28,7 @@ importers:
         version: 8.59.2(eslint@10.3.0(jiti@2.6.1))(typescript@6.0.3)
       vitest:
         specifier: ^4.1.5
-        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
+        version: 4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/azure-devops:
     dependencies:
@@ -71,6 +71,9 @@ importers:
       '@mastra/mcp':
         specifier: ^1.7.0
         version: 1.7.0(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      ai-sdk-ollama:
+        specifier: ^3
+        version: 3.8.3(ai@6.0.177(zod@4.4.3))(zod@4.4.3)
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -232,6 +235,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@3.0.112':
+    resolution: {integrity: sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/openai@3.0.60':
     resolution: {integrity: sha512-vZKqbDSCF1T65gDMG2ILJ2NAEpG45U2VtvEve1Fv/WRLu2i5TPUqxjlGKm+5a7Dd57Yr6CGePxrJhsQJC8LJ3A==}
     engines: {node: '>=18'}
@@ -258,6 +267,12 @@ packages:
 
   '@ai-sdk/provider-utils@4.0.26':
     resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider-utils@4.0.27':
+    resolution: {integrity: sha512-ubkAJ+xODouwtmN1tYlvTPphH1hPOBfZaEQe8U7skGvFAnIRs9PPpsq57bC2+Ky/MB4yzhd6YOsxTAx9sGpazw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -653,6 +668,10 @@ packages:
     resolution: {integrity: sha512-da6KbdNCV5sr1/txD896V+6W0iamFWrvVl8cHkBSPT+YlvmT3DwXa4jxZnQc+gnuTEqSWbBeoSZYTayXH9wXcw==}
     engines: {node: '>= 20'}
 
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
@@ -1044,6 +1063,10 @@ packages:
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -1106,6 +1129,18 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  ai-sdk-ollama@3.8.3:
+    resolution: {integrity: sha512-KId/S++eb0CgTPFTtHzCGCrO73kXZLK+hyyZx5k8LVqU2XOEHYKVbIwDiQ+hm3okHjnsGehn4zR4QNm14SUM3Q==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      ai: ^6.0.154
+
+  ai@6.0.177:
+    resolution: {integrity: sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
 
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
@@ -1786,6 +1821,10 @@ packages:
   json-with-bigint@3.5.8:
     resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
 
+  jsonrepair@3.14.0:
+    resolution: {integrity: sha512-tWPGKMZf/8UPim+fcW2EfcQ/d/7aKUrP6IECz9G3Tu6Q5dX0orSleqJ9z6sSw7qrQkjF8/Edo4DvsWBZ8H+HNg==}
+    hasBin: true
+
   jsonwebtoken@9.0.3:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
@@ -2137,6 +2176,9 @@ packages:
   octokit@5.0.5:
     resolution: {integrity: sha512-4+/OFSqOjoyULo7eN7EA97DE0Xydj/PW5aIckxqQIoFjFwqXKuFCvXUJObyJfBF9Khu4RL/jlDRI9FPaMGfPnw==}
     engines: {node: '>= 20'}
+
+  ollama@0.6.3:
+    resolution: {integrity: sha512-KEWEhIqE5wtfzEIZbDCLH51VFZ6Z3ZSa6sIOg/E/tBV8S51flyqBOXi+bRxlOYKDf8i327zG9eSTb8IJxvm3Zg==}
 
   on-exit-leak-free@2.1.2:
     resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
@@ -2787,6 +2829,9 @@ packages:
   web-tree-sitter@0.26.8:
     resolution: {integrity: sha512-4sUwi7ZyOrIk5KLgYLkc2A/F0LFMQnBhfb+2Cdl7ik4ePJ6JD+fk4ofI2sA5eGawBKBaK4Vntt7Ww5KcEsay4A==}
 
+  whatwg-fetch@3.6.20:
+    resolution: {integrity: sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2881,6 +2926,13 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/gateway@3.0.112(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/openai@3.0.60(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -2909,6 +2961,13 @@ snapshots:
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@4.0.26(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
+  '@ai-sdk/provider-utils@4.0.27(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@standard-schema/spec': 1.1.0
@@ -3446,6 +3505,8 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/webhooks-methods': 6.0.0
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@oxc-project/types@0.127.0': {}
 
   '@pinojs/redact@0.4.0': {}
@@ -3759,6 +3820,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -3819,6 +3882,24 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  ai-sdk-ollama@3.8.3(ai@6.0.177(zod@4.4.3))(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
+      ai: 6.0.177(zod@4.4.3)
+      jsonrepair: 3.14.0
+      ollama: 0.6.3
+    transitivePeerDependencies:
+      - zod
+
+  ai@6.0.177(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.112(zod@4.4.3)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.4.3
 
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
@@ -4459,6 +4540,8 @@ snapshots:
 
   json-with-bigint@3.5.8: {}
 
+  jsonrepair@3.14.0: {}
+
   jsonwebtoken@9.0.3:
     dependencies:
       jws: 4.0.1
@@ -4973,6 +5056,10 @@ snapshots:
       '@octokit/request-error': 7.1.0
       '@octokit/types': 16.0.0
       '@octokit/webhooks': 14.2.0
+
+  ollama@0.6.3:
+    dependencies:
+      whatwg-fetch: 3.6.20
 
   on-exit-leak-free@2.1.2: {}
 
@@ -5543,7 +5630,7 @@ snapshots:
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vitest@4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
+  vitest@4.1.5(@opentelemetry/api@1.9.0)(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.5
       '@vitest/mocker': 4.1.5(vite@8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3))
@@ -5566,6 +5653,7 @@ snapshots:
       vite: 8.0.10(@types/node@25.6.0)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@opentelemetry/api': 1.9.0
       '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
@@ -5573,6 +5661,8 @@ snapshots:
   web-streams-polyfill@3.3.3: {}
 
   web-tree-sitter@0.26.8: {}
+
+  whatwg-fetch@3.6.20: {}
 
   which@2.0.2:
     dependencies:


### PR DESCRIPTION
## Why

Today the only path for Ollama was the openai-compatible escape hatch (`RUSTY_LLM_BASE_URL=http://localhost:11434/v1`). It worked but had two sharp limits:

1. **`RUSTY_LLM_BASE_URL` is global**, so consensus ensembles couldn't mix Ollama with non-Ollama providers — every pass had to use the same base URL.
2. The openai-compatible path doesn't expose Ollama-specific options (mirostat, num_ctx, hybrid-reasoning toggles) and routes via `/v1/chat/completions` instead of Ollama's native `/api/chat`.

You explicitly want both: **use Ollama Cloud** *and* **mix it in the ensemble**. This wires that.

## What changes

Add a first-class `ollama` `ModelConfig` variant routed via [`ai-sdk-ollama@^3`](https://www.npmjs.com/package/ai-sdk-ollama) — the community provider that peer-deps to `ai@^6`, which Mastra 1.32.1 already ships internally as `@ai-sdk/provider-v6`. So the integration plugs directly into the existing dual-API Mastra setup with no upgrade dance.

The variant is recognized by an `ollama/` prefix on `RUSTY_LLM_MODEL` or any entry of `RUSTY_REVIEW_MODELS`. Consensus mixing is automatic:

```bash
RUSTY_OLLAMA_BASE_URL=https://ollama.com
RUSTY_OLLAMA_API_KEY=...   # https://ollama.com/account
RUSTY_REVIEW_MODELS=anthropic/claude-sonnet-4-5,ollama/gpt-oss:120b,requesty/google/gemini-3.1-pro
```

Each pass routes independently through its own provider — Anthropic for pass 1, Ollama Cloud for pass 2, Requesty for pass 3.

## Defaults and overrides

| Env var | Default | Meaning |
|---|---|---|
| `RUSTY_OLLAMA_BASE_URL` | `http://127.0.0.1:11434` (ai-sdk-ollama default) | Set to `https://ollama.com` for Ollama Cloud |
| `RUSTY_OLLAMA_API_KEY` | unset | Bearer token. Required for Cloud, ignored locally. Falls back to `OLLAMA_API_KEY` |

So `RUSTY_LLM_MODEL=ollama/llama3.2` Just Works locally, and `ollama/gpt-oss:120b` + the two cloud env vars routes to Ollama Cloud. Model identifiers with colons (`gpt-oss:120b`, `qwen3-coder:480b`, `deepseek-v3.1:671b`) preserve correctly through the prefix strip.

## Structured output: prompt-injected by default

`supportsNativeStructuredOutput` returns **false** for the Ollama variant. JSON-schema reliability varies wildly across hosted Ollama models — the safe default is to let the structuring model handle JSON, with the reviewer model writing prose:

```bash
RUSTY_LLM_STRUCTURING_MODEL=requesty/google/gemini-3.1-flash-lite-preview
```

Opt into native JSON schema for specific models if they're known good:

```bash
RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=ollama/gpt-oss*
```

## Why ai-sdk-ollama and not the openai-compatible path

Three reasons:

1. **Per-pass routing.** `RUSTY_LLM_BASE_URL` is a single global; the new path resolves baseURL+apiKey per ModelConfig instance. Consensus mixing falls out automatically because `resolveReviewPassModelConfigs` already resolves each `RUSTY_REVIEW_MODELS` entry through `resolveModelConfigWithOverride`, which sees the prefix.
2. **Tool calling.** ai-sdk-ollama uses Ollama's native `/api/chat` endpoint with proper tool-call schemas. The openai-compat shim translates tool calls but loses some semantics on multi-step loops.
3. **Provider-specific options.** Ollama exposes `mirostat`, `num_ctx`, hybrid-reasoning toggles via `providerOptions`. Future PRs can wire those without re-architecting.

## Test plan

- [x] **resolveModelConfig** (7 new cases): `ollama/` prefix → `ollama` variant; preserves colons in model ids; threads `RUSTY_OLLAMA_BASE_URL`/`RUSTY_OLLAMA_API_KEY` correctly; `OLLAMA_API_KEY` fallback works; `RUSTY_OLLAMA_API_KEY` wins over `OLLAMA_API_KEY`; ollama prefix beats `RUSTY_LLM_BASE_URL` even when both set
- [x] **resolveReviewPassModelConfigs** (1 new case): consensus ensemble mixing `anthropic/`, `ollama/`, `requesty/` all resolve correctly per-pass
- [x] **supportsNativeStructuredOutput** (2 new cases): default `false` for Ollama; opt-in `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=ollama/gpt-oss*` flips it
- [x] **getModelDisplayName** (1 new case): preserves `ollama/gpt-oss:120b` through display
- [x] Full suite: **909 tests passing** (899 existing + 10 new)
- [x] `pnpm -r build` clean

## What this doesn't do

- **Not yet exposing Ollama-specific options.** `mirostat`, `num_ctx`, hybrid-reasoning toggles are passthrough-able via `providerOptions` but no env-var surface yet. Easy follow-up if you start tuning specific models.
- **No prompt caching.** Ollama caches via KV internally but exposes no API knob, so `resolveDefaultAgentOptions` skips Ollama (same as Azure paths).
- **No per-Ollama-model temperature locks.** If a specific cloud model has documented quirks (like the existing `moonshot/kimi-k2.5` temp=1 lock), add an entry to `HARD_TEMPERATURE_LOCKS` when you find it.

## Files

- **NEW dep**: `ai-sdk-ollama@^3` on `@rusty-bot/core`
- `packages/core/src/agent/model.ts` — `ollama` variant, prefix detection, `createOllama` resolve case, support tables
- `packages/core/src/__tests__/model.test.ts` — 11 new tests
- `README.md` — dedicated provider section #8 (local + cloud + ensemble examples) + env-var table entries