### PR TITLE
feat: instrument per-pass findings + per-step finishReason behind debug flags

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -68,3 +68,12 @@ jobs:
           RUSTY_GRAPH_CONTEXT: "true"
           RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET: "2000"
           RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES: "8"
+          # collect cross-model overlap data on every self-review. each
+          # consensus pass logs its raw findings (file/line/severity/
+          # message) before clustering, so we can measure agreementRate
+          # empirically and tune cluster.ts thresholds. needs LOG_LEVEL=debug
+          # because the per-pass payload is bigger than info-level deserves.
+          # see CONSENSUS-QUALITY-WRITEUP.md for the experiments this
+          # unblocks.
+          RUSTY_LOG_RAW_FINDINGS: "true"
+          LOG_LEVEL: debug

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -31,24 +31,17 @@ jobs:
           # mastra's native requesty provider reads this directly; no base-url
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
-          # ollama cloud — bearer auth via Authorization header. set
-          # RUSTY_OLLAMA_BASE_URL=https://ollama.com so any `ollama/*` model
-          # in RUSTY_REVIEW_MODELS routes via the hosted endpoint instead of
-          # the local default (http://127.0.0.1:11434).
-          RUSTY_OLLAMA_BASE_URL: https://ollama.com
-          RUSTY_OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-provider consensus. deepseek-v4-pro routed through
-          # Requesty because Ollama Cloud's deepseek-v4-pro:cloud has been
-          # observed sustaining 503 "Server overloaded" through all retries
-          # (3 attempts, 3 distinct upstream refs — not a transient blip).
-          # kimi stays on ollama cloud where it serves reliably.
+          # cross-vendor consensus on Requesty: deepseek (official deepseek
+          # provider, not fireworks — fireworks routing tool-loops on the
+          # same model id), grok, kimi (fireworks). vendor diversity comes
+          # from the underlying model providers, not the proxy.
           RUSTY_REVIEW_MODELS: >-
             requesty/deepseek/deepseek-v4-pro,
             requesty/xai/grok-4.3,
-            ollama/kimi-k2.6:cloud
+            requesty/fireworks/kimi-k2.6
           RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview
@@ -58,7 +51,9 @@ jobs:
           # the structured-output JSON. see #152.
           RUSTY_LLM_MAX_STEPS: "10"
           RUSTY_JUDGE_ENABLED: "true"
-          RUSTY_JUDGE_MODEL: requesty/deepseek/deepseek-v4-pro
+          # judge has no tools, so requesty/fireworks/deepseek-v4-pro is fine
+          # here even though it tool-loops on the review path.
+          RUSTY_JUDGE_MODEL: requesty/fireworks/deepseek-v4-pro
           RUSTY_JUDGE_TEMPERATURE: "0.1"
           RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_TRIAGE_TEMPERATURE: "0"

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -40,12 +40,13 @@ jobs:
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-provider consensus: deepseek + kimi via ollama cloud,
-          # grok via requesty. transient Ollama Cloud 5xx/429s are now
-          # retried by isTransientRetryableError (see review.ts) so we
-          # don't have to defensively reorder around them.
+          # cross-provider consensus. deepseek-v4-pro routed through
+          # Requesty because Ollama Cloud's deepseek-v4-pro:cloud has been
+          # observed sustaining 503 "Server overloaded" through all retries
+          # (3 attempts, 3 distinct upstream refs — not a transient blip).
+          # kimi stays on ollama cloud where it serves reliably.
           RUSTY_REVIEW_MODELS: >-
-            ollama/deepseek-v4-pro:cloud,
+            requesty/deepseek/deepseek-v4-pro,
             requesty/xai/grok-4.3,
             ollama/kimi-k2.6:cloud
           RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
@@ -57,7 +58,7 @@ jobs:
           # the structured-output JSON. see #152.
           RUSTY_LLM_MAX_STEPS: "10"
           RUSTY_JUDGE_ENABLED: "true"
-          RUSTY_JUDGE_MODEL: ollama/deepseek-v4-pro:cloud
+          RUSTY_JUDGE_MODEL: requesty/deepseek/deepseek-v4-pro
           RUSTY_JUDGE_TEMPERATURE: "0.1"
           RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_TRIAGE_TEMPERATURE: "0"

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -31,17 +31,24 @@ jobs:
           # mastra's native requesty provider reads this directly; no base-url
           # wiring needed when the model id already starts with "requesty/"
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
+          # ollama cloud — bearer auth via Authorization header. set
+          # RUSTY_OLLAMA_BASE_URL=https://ollama.com so any `ollama/*` model
+          # in RUSTY_REVIEW_MODELS routes via the hosted endpoint instead of
+          # the local default (http://127.0.0.1:11434).
+          RUSTY_OLLAMA_BASE_URL: https://ollama.com
+          RUSTY_OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-vendor consensus on Requesty: deepseek (official deepseek
-          # provider, not fireworks — fireworks routing tool-loops on the
-          # same model id), grok, kimi (fireworks). vendor diversity comes
-          # from the underlying model providers, not the proxy.
+          # cross-vendor consensus. deepseek via the official DeepSeek
+          # provider on Requesty (NOT fireworks — fireworks routing
+          # tool-loops on the same model id, see Model + Provider Routing
+          # Notes in README). grok via Requesty. kimi via Ollama Cloud
+          # for direct moonshot routing.
           RUSTY_REVIEW_MODELS: >-
             requesty/deepseek/deepseek-v4-pro,
             requesty/xai/grok-4.3,
-            requesty/fireworks/kimi-k2.6
+            ollama/kimi-k2.6:cloud
           RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
           RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview

--- a/README.md
+++ b/README.md
@@ -275,6 +275,8 @@ The CLI reads the same env vars as the other harnesses — `RUSTY_LLM_MODEL`, th
 | `RUSTY_LLM_BODY_TIMEOUT_MS` | undici body timeout for outbound `fetch`; resets per chunk so generations longer than this still complete as long as chunks keep arriving | `600000` |
 | `RUSTY_OLLAMA_BASE_URL` | base URL for the `ollama/*` provider — set to `https://ollama.com` for [Ollama Cloud](https://ollama.com), or a remote host for self-hosted Ollama | `http://127.0.0.1:11434` |
 | `RUSTY_OLLAMA_API_KEY` | bearer token for the `ollama/*` provider (required for Ollama Cloud, ignored for unauthenticated local instances); falls back to `OLLAMA_API_KEY` | — |
+| `RUSTY_LOG_AGENT_STEPS` | when `true`, log a line per agent step (`stepNumber`, `finishReason`, `toolCallCount`, token usage); diagnostic for slow / tool-looping passes | `false` |
+| `RUSTY_LOG_RAW_FINDINGS` | when `true`, log each consensus pass's findings before clustering (file/line/severity/category/message); diagnostic for tuning Jaccard / line-proximity thresholds | `false` |
 | `RUSTY_JIRA_BASE_URL` | Jira instance URL | — |
 | `RUSTY_JIRA_EMAIL` | Jira auth email | — |
 | `RUSTY_JIRA_API_TOKEN` | Jira API token | — |
@@ -572,6 +574,32 @@ Each CLI entry point calls `configureGlobalHttp()` at startup, which installs an
 These apply to **all** outbound `fetch` calls (LLM routes + GitHub/GitLab/ADO APIs). Raising the timeout never harms a fast request — it only delays the failure mode for slow ones.
 
 If you keep seeing headers-timeout failures on a specific consensus pass, bump `RUSTY_LLM_HEADERS_TIMEOUT_MS` to `900000` or `1200000`. If the failure persists past 15 minutes, the upstream model is genuinely stuck (not slow) — the right fix is to drop that model from `RUSTY_REVIEW_MODELS` rather than extend the timeout further.
+
+### Diagnostic Logging
+
+Two opt-in flags surface internal state for debugging slow consensus runs and tuning ensemble behavior. Both default off so production cost is zero.
+
+**`RUSTY_LOG_AGENT_STEPS=true`** — one log line per agent step inside every `runReview` call:
+
+```jsonc
+{ "stepNumber": 0, "finishReason": "tool-calls", "toolCallCount": 3, "totalTokens": 12450, ... }
+{ "stepNumber": 1, "finishReason": "tool-calls", "toolCallCount": 1, "totalTokens": 8200, ... }
+{ "stepNumber": 2, "finishReason": "stop", "toolCallCount": 0, "totalTokens": 6100, ... }
+```
+
+Useful when a pass takes minutes and you can't tell whether the model is making forward progress (decreasing tool calls, reasonable token counts per step) or spinning in a tool-call loop (constant or growing tool calls, no `"stop"` ever). Particularly diagnostic for the `finishReason: "tool-calls"` failure mode where a tool-happy model burns its step budget without emitting a final answer — the per-step trace tells you whether `RUSTY_LLM_MAX_STEPS` saved the day or got hit.
+
+**`RUSTY_LOG_RAW_FINDINGS=true`** — emits each consensus pass's findings list **before clustering**, at debug level:
+
+```jsonc
+{ "passIndex": 0, "model": "ollama/deepseek-v4-pro:cloud", "findingCount": 4, "findings": [ ... ], ... }
+{ "passIndex": 1, "model": "requesty/xai/grok-4.3", "findingCount": 6, "findings": [ ... ], ... }
+{ "passIndex": 2, "model": "ollama/kimi-k2.6:cloud", "findingCount": 3, "findings": [ ... ], ... }
+```
+
+Lets you tell whether the models are actually disagreeing (different findings → clustering's job is hard, threshold may be too strict) vs. saying the same thing in different words (overlap exists but Jaccard threshold may be missing it). Prerequisite for tuning `cluster.ts` — see `CONSENSUS-QUALITY-WRITEUP.md` for proposed experiments.
+
+The pino logger has to be at `debug` level for this one — set `LOG_LEVEL=debug` alongside the flag if you're not seeing the output.
 
 ### OpenGrep Pre-scan
 

--- a/README.md
+++ b/README.md
@@ -420,8 +420,26 @@ Empirically observed gotchas:
 - **`ollama/deepseek-v4-pro:cloud` (Ollama Cloud) was observed sustaining 503 "Server overloaded" through full retry budget** during peak load. The 503 is genuinely retried by `isTransientRetryableError`, but if all attempts fail you've lost the pass. Capacity has fluctuated; flip to a Requesty-backed deepseek if Ollama Cloud's hosted instance is congested.
 - **`moonshot/kimi-k2.5` requires `temperature=1`.** Lower values are rejected by the upstream and the call fails. The `HARD_TEMPERATURE_LOCKS` table in `model.ts` rewrites the temperature on this exact pattern; it does NOT catch `kimi-k2.6` or proxy variants like `requesty/fireworks/kimi-k2.6`. Empirically the k2.x series benefits from `temperature=1` regardless of the route — set it explicitly via `RUSTY_REVIEW_TEMPERATURES` for any kimi-shaped pass.
 - **Single-provider ensembles defeat consensus diversity.** If you set `RUSTY_REVIEW_MODELS` to three Anthropic models, the cluster algorithm has very little signal to filter — different sizes of the same model agree more than different vendors. Mix providers (Anthropic / xAI / Moonshot / DeepSeek / OpenAI / Google) for the consensus path to be useful.
+- **Skim tier inherits `RUSTY_REVIEW_MODELS[0]`.** When the cascade triages a file as "skim" rather than "deep-review", the skim pass uses a single-pass review with the **first** entry in `RUSTY_REVIEW_MODELS` (`consensus.ts:113-120`). If slot 1 is a slow model (`deepseek-v4-pro` reasoning takes minutes per call), skim becomes slow too — even though the skim tier is supposed to be the fast triage path. Put a quick model (grok, kimi, gemini) in slot 1 and let the slower / more analytical models live in slots 2-3 where they only fire on consensus deep-review chunks.
 
 If you observe a new failure pattern tied to a specific provider+model combination, add an entry here so the next person doesn't burn an afternoon on the same shape.
+
+### OpenRouter as an alternative gateway
+
+Same shape as Requesty — Mastra's router fallback handles `openrouter/*` model ids automatically when `OPENROUTER_API_KEY` is set. No code change needed.
+
+```bash
+OPENROUTER_API_KEY=sk-or-v1-...
+RUSTY_LLM_MODEL=openrouter/anthropic/claude-sonnet-4-5
+RUSTY_REVIEW_MODELS=openrouter/x-ai/grok-4.3,openrouter/moonshotai/kimi-k2.6,openrouter/deepseek/deepseek-v4-pro
+```
+
+You can mix gateways in one ensemble — `requesty/...`, `openrouter/...`, `ollama/...`, and direct provider ids all resolve per-pass through their own routes.
+
+Caveats:
+- **Native structured output is off by default for OpenRouter.** `supportsNativeStructuredOutput` doesn't include `openrouter/` in its allow-list because OpenRouter's proxying of `response_format: json_schema` varies by underlying model. Route through the structuring model (`RUSTY_LLM_STRUCTURING_MODEL`) instead, or opt in per-pattern with `RUSTY_LLM_NATIVE_STRUCTURED_OUTPUT=openrouter/anthropic/*` if you've verified the upstream honors it.
+- **OpenRouter's load balancer picks an inference backend per request**, so the same `openrouter/deepseek/deepseek-v4-pro` request can land on Fireworks, DeepSeek's own API, Together, etc. — bringing the same provider-routing-matters lesson with it. Pin a specific backend with the `:nitro` suffix (fastest available) or the OpenRouter-native `provider` parameter if you need determinism.
+- **No bot-level prompt-cache integration**, the way `requesty/*` gets `auto_cache: true`. OpenRouter has its own caching for some models — handled upstream, no env var to flip on the bot side.
 
 ### Model Inference Settings
 

--- a/README.md
+++ b/README.md
@@ -410,6 +410,19 @@ ANTHROPIC_API_KEY=sk-ant-...
 
 Supports 99+ providers: `openai/gpt-4o`, `google/gemini-2.5-flash`, `openrouter/...`, etc.
 
+### Model + Provider Routing Notes
+
+The same model id can route through different inference providers (e.g. `requesty/deepseek/deepseek-v4-pro` vs. `requesty/fireworks/deepseek-v4-pro`). They are **not interchangeable** — different provider backends serve the same model with different latency profiles, tool-calling reliability, and rate limits. When picking a route for `RUSTY_REVIEW_MODELS` or `RUSTY_JUDGE_MODEL`, the choice between proxy backends matters as much as the choice between models.
+
+Empirically observed gotchas:
+
+- **`requesty/fireworks/deepseek-v4-pro` tool-loops on review-tier calls.** With `RUSTY_LLM_MAX_STEPS=10` and active `searchCode` / `getFileContext` tools, observed reviewer passes hanging for 10-15 minutes before the step cap fires. Use `requesty/deepseek/deepseek-v4-pro` (the official DeepSeek provider on Requesty) for the review path instead. Fireworks-routed deepseek is fine for the **judge** because the judge has no tools and can't tool-loop.
+- **`ollama/deepseek-v4-pro:cloud` (Ollama Cloud) was observed sustaining 503 "Server overloaded" through full retry budget** during peak load. The 503 is genuinely retried by `isTransientRetryableError`, but if all attempts fail you've lost the pass. Capacity has fluctuated; flip to a Requesty-backed deepseek if Ollama Cloud's hosted instance is congested.
+- **`moonshot/kimi-k2.5` requires `temperature=1`.** Lower values are rejected by the upstream and the call fails. The `HARD_TEMPERATURE_LOCKS` table in `model.ts` rewrites the temperature on this exact pattern; it does NOT catch `kimi-k2.6` or proxy variants like `requesty/fireworks/kimi-k2.6`. Empirically the k2.x series benefits from `temperature=1` regardless of the route — set it explicitly via `RUSTY_REVIEW_TEMPERATURES` for any kimi-shaped pass.
+- **Single-provider ensembles defeat consensus diversity.** If you set `RUSTY_REVIEW_MODELS` to three Anthropic models, the cluster algorithm has very little signal to filter — different sizes of the same model agree more than different vendors. Mix providers (Anthropic / xAI / Moonshot / DeepSeek / OpenAI / Google) for the consensus path to be useful.
+
+If you observe a new failure pattern tied to a specific provider+model combination, add an entry here so the next person doesn't burn an afternoon on the same shape.
+
 ### Model Inference Settings
 
 Set a global temperature/top-p for all agents, or override per agent. Per-agent values take priority over the global fallback.

--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -456,3 +456,75 @@ describe("runConsensusReview failure tolerance", () => {
     }
   });
 });
+
+describe("RUSTY_LOG_RAW_FINDINGS", () => {
+  beforeEach(() => {
+    callCount = 0;
+    mockBehavior = "default";
+    delete process.env.RUSTY_REVIEW_MODELS;
+    delete process.env.RUSTY_LOG_RAW_FINDINGS;
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "false";
+    vi.clearAllMocks();
+  });
+
+  it("does not emit raw-findings logs by default", async () => {
+    const { logger } = await import("../logger.js");
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    await runConsensusReview([], { ...config, consensusPasses: 3 }, prMetadata, "diff content");
+
+    const rawFindingCalls = debugSpy.mock.calls.filter(
+      (c) =>
+        typeof c[1] === "string" && c[1].includes("raw consensus pass findings before clustering"),
+    );
+    expect(rawFindingCalls).toHaveLength(0);
+    debugSpy.mockRestore();
+  });
+
+  it("emits one debug log per pass with file/line/severity/category/message when flag is 'true'", async () => {
+    process.env.RUSTY_LOG_RAW_FINDINGS = "true";
+    const { logger } = await import("../logger.js");
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    await runConsensusReview([], { ...config, consensusPasses: 3 }, prMetadata, "diff content");
+
+    const rawFindingCalls = debugSpy.mock.calls.filter(
+      (c) =>
+        typeof c[1] === "string" && c[1].includes("raw consensus pass findings before clustering"),
+    );
+    expect(rawFindingCalls).toHaveLength(3);
+
+    for (let i = 0; i < 3; i++) {
+      const bindings = rawFindingCalls[i][0] as Record<string, unknown>;
+      expect(bindings.passIndex).toBe(i);
+      expect(bindings.prId).toBe("42");
+      expect(bindings.findingCount).toBeTypeOf("number");
+      const findings = bindings.findings as Record<string, unknown>[];
+      expect(findings).toBeInstanceOf(Array);
+      // each finding entry must carry exactly the documented redacted fields
+      for (const f of findings) {
+        expect(f).toHaveProperty("file");
+        expect(f).toHaveProperty("line");
+        expect(f).toHaveProperty("severity");
+        expect(f).toHaveProperty("category");
+        expect(f).toHaveProperty("message");
+      }
+    }
+    debugSpy.mockRestore();
+  });
+
+  it("treats values other than the literal string 'true' as off", async () => {
+    process.env.RUSTY_LOG_RAW_FINDINGS = "1"; // not 'true'
+    const { logger } = await import("../logger.js");
+    const debugSpy = vi.spyOn(logger, "debug");
+
+    await runConsensusReview([], { ...config, consensusPasses: 3 }, prMetadata, "diff content");
+
+    const rawFindingCalls = debugSpy.mock.calls.filter(
+      (c) =>
+        typeof c[1] === "string" && c[1].includes("raw consensus pass findings before clustering"),
+    );
+    expect(rawFindingCalls).toHaveLength(0);
+    debugSpy.mockRestore();
+  });
+});

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -593,3 +593,63 @@ describe("RUSTY_LLM_STRUCTURING_MODEL", () => {
     expect(structured.model).toBeUndefined();
   });
 });
+
+describe("RUSTY_LOG_AGENT_STEPS", () => {
+  beforeEach(() => {
+    generateMock.mockReset();
+    delete process.env.RUSTY_LOG_AGENT_STEPS;
+  });
+
+  it("does NOT pass onStepFinish when the flag is unset (no perf cost in production)", async () => {
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.onStepFinish).toBeUndefined();
+  });
+
+  it("does NOT pass onStepFinish when the flag is set to anything other than 'true'", async () => {
+    process.env.RUSTY_LOG_AGENT_STEPS = "1"; // not 'true' literally
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.onStepFinish).toBeUndefined();
+  });
+
+  it("passes a function-typed onStepFinish callback when the flag is exactly 'true'", async () => {
+    process.env.RUSTY_LOG_AGENT_STEPS = "true";
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
+    expect(opts.onStepFinish).toBeTypeOf("function");
+  });
+
+  it("the onStepFinish callback increments stepNumber across calls", async () => {
+    process.env.RUSTY_LOG_AGENT_STEPS = "true";
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
+    const onStepFinish = opts.onStepFinish as (step: unknown) => void;
+
+    // exercising the callback should not throw on any of: well-shaped step,
+    // step with missing optional fields, non-object step, null step.
+    expect(() =>
+      onStepFinish({
+        finishReason: "tool-calls",
+        toolCalls: [{}, {}],
+        usage: { totalTokens: 1234, inputTokens: 1000, outputTokens: 234 },
+        warnings: [],
+      }),
+    ).not.toThrow();
+    expect(() => onStepFinish({ finishReason: "stop" })).not.toThrow();
+    expect(() => onStepFinish(null)).not.toThrow();
+    expect(() => onStepFinish("not an object")).not.toThrow();
+  });
+});

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -181,6 +181,33 @@ export async function runConsensusReview(
   const observationsByPass = results.map((r) => r.observations);
   const passRecommendations = results.map((r) => r.recommendation);
 
+  // gated by RUSTY_LOG_RAW_FINDINGS=true. emits per-pass finding lists
+  // BEFORE clustering so we can tell whether models are actually
+  // producing different findings (clustering's job is hard) vs. all
+  // saying the same thing (clustering's job is easy). prerequisite for
+  // tuning the consensus threshold / Jaccard similarity / line proximity
+  // window — see CONSENSUS-QUALITY-WRITEUP.md. defaults to no-op.
+  if (process.env.RUSTY_LOG_RAW_FINDINGS === "true") {
+    for (let i = 0; i < results.length; i++) {
+      logger.debug(
+        {
+          prId: prMetadata.id,
+          passIndex: i,
+          model: passModelConfigs[i].displayName,
+          findingCount: results[i].findings.length,
+          findings: results[i].findings.map((f) => ({
+            file: f.file,
+            line: f.line,
+            severity: f.severity,
+            category: f.category,
+            message: f.message,
+          })),
+        },
+        "raw consensus pass findings before clustering",
+      );
+    }
+  }
+
   const findingClusters = clusterFindings(findingsByPass);
   const observationClusters = clusterObservations(observationsByPass);
 

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -98,6 +98,45 @@ function readLlmMaxSteps(): number | undefined {
   return Math.floor(n);
 }
 
+/**
+ * gated by `RUSTY_LOG_AGENT_STEPS=true`. when on, every agent step emits a
+ * log line with `stepNumber`, `finishReason`, `toolCallCount`, and token
+ * usage. lets us tell whether a long-running pass is making forward progress
+ * (steady stream of `finishReason="tool-calls"` then a final `"stop"`) or
+ * spinning in a tool-call loop without ever stopping. defaults to no-op so
+ * the perf cost in production is zero.
+ *
+ * see FOLLOWUPS #3 (the Kimi tool-call termination diagnosis) and the
+ * consensus quality writeup — this is the missing diagnostic for both.
+ */
+function buildStepLogger(bindings: Record<string, unknown>): ((step: unknown) => void) | undefined {
+  if (process.env.RUSTY_LOG_AGENT_STEPS !== "true") return undefined;
+  let stepNumber = 0;
+  return (step) => {
+    if (typeof step !== "object" || step === null) return;
+    const s = step as {
+      finishReason?: unknown;
+      toolCalls?: { length?: number };
+      usage?: { totalTokens?: number; inputTokens?: number; outputTokens?: number };
+      warnings?: unknown[];
+    };
+    log.info(
+      {
+        ...bindings,
+        stepNumber,
+        finishReason: s.finishReason,
+        toolCallCount: s.toolCalls?.length ?? 0,
+        totalTokens: s.usage?.totalTokens,
+        inputTokens: s.usage?.inputTokens,
+        outputTokens: s.usage?.outputTokens,
+        warningCount: Array.isArray(s.warnings) ? s.warnings.length : 0,
+      },
+      "agent step finished",
+    );
+    stepNumber++;
+  };
+}
+
 // when set, mastra runs a separate structuring agent on top of the main
 // review agent's output: the main agent produces freeform prose (with tools
 // available, no schema pressure) and a cheap structuring model translates
@@ -293,6 +332,7 @@ export async function runReview(
     tier,
     ...(structuringConfig && { structuringModel: getModelDisplayName(structuringConfig) }),
   };
+  const onStepFinish = buildStepLogger(logBindings);
   const response = await generateWithTransientRetry(
     () =>
       generateWithStructuredOutputRetry(async () => {
@@ -305,6 +345,7 @@ export async function runReview(
           ...(Object.keys(modelSettings).length > 0 && { modelSettings }),
           ...(maxSteps !== undefined && { maxSteps }),
           ...(prepareStep && { prepareStep }),
+          ...(onStepFinish && { onStepFinish }),
         });
         // mastra's prompt-injected JSON path can silently return object:undefined
         // when the model emits unparseable text instead of throwing the schema


### PR DESCRIPTION
## Why

Two diagnostic gaps that have been blocking real work:

1. **Consensus quality (FOLLOWUPS #1, `CONSENSUS-QUALITY-WRITEUP.md`)** — we know consensus rarely produces inline comments and instead falls through to the elevated-concern rollup. The writeup proposes 3 experiments to fix it, but **all of them need data first**: are the models actually disagreeing, or are they finding the same thing in different words and clustering is missing the overlap? Today we have no way to see per-pass findings before clustering.

2. **Kimi tool-call termination (FOLLOWUPS #3)** — `RUSTY_LLM_MAX_STEPS=10` was supposed to prevent the `finishReason: "tool-calls"` failure mode but didn't. Two competing hypotheses (input bloat killed the trajectory before step 9 fired, vs. requesty doesn't honor `activeTools: []`), and we have no way to disambiguate them because mastra only logs the *final* step's `finishReason`.

This PR ships the instrumentation that unblocks both, behind opt-in flags so production cost is zero.

## What changes

Two new env-var flags. Both default off; both require the literal string `"true"`.

### `RUSTY_LOG_AGENT_STEPS=true`

Wires Mastra's `onStepFinish` callback inside `runReview`. Every agent step emits a log line:

```jsonc
{ "stepNumber": 0, "finishReason": "tool-calls", "toolCallCount": 3, "totalTokens": 12450, ... }
{ "stepNumber": 1, "finishReason": "tool-calls", "toolCallCount": 1, "totalTokens": 8200,  ... }
{ "stepNumber": 2, "finishReason": "stop",       "toolCallCount": 0, "totalTokens": 6100,  ... }
```

When `RUSTY_LOG_AGENT_STEPS` isn't `"true"`, `buildStepLogger` returns `undefined` and the `agent.generate` options object doesn't even carry an `onStepFinish` property. **Zero allocation, zero overhead in production.**

Reading the trace tells us:
- **Decreasing `toolCallCount` then `finishReason: "stop"`** = healthy progress, model converging
- **Constant or growing `toolCallCount`, never reaches `"stop"`** = tool-call loop, hypothesis 2 confirmed
- **`finishReason: "length"` early** = context overflow, hypothesis 1 confirmed

### `RUSTY_LOG_RAW_FINDINGS=true`

Logs each consensus pass's findings list at debug level **before clustering**:

```jsonc
{ "passIndex": 0, "model": "ollama/deepseek-v4-pro:cloud", "findingCount": 4, "findings": [...] }
{ "passIndex": 1, "model": "requesty/xai/grok-4.3",        "findingCount": 6, "findings": [...] }
{ "passIndex": 2, "model": "ollama/kimi-k2.6:cloud",       "findingCount": 3, "findings": [...] }
```

Per-finding fields are `file`, `line`, `severity`, `category`, `message`. With these we can finally tabulate cross-model overlap on real PRs and answer the consensus-quality question empirically. Behind `LOG_LEVEL=debug` plus the flag — the bigger payload doesn't deserve `info` level, only flips on when investigating.

## Why these specific fields

`onStepFinish` step shape: ai-sdk-v6 `StepResult<TOOLS>` (verified at `node_modules/.../ai/dist/index.d.ts:875-919`). Duck-typed for `finishReason`, `toolCalls.length`, `usage.{totalTokens,inputTokens,outputTokens}`, and `warnings.length`. Robust to missing fields — the test suite exercises `null`, non-objects, and partial shapes without throwing.

Per-pass findings: just `file`, `line`, `severity`, `category`, `message`. **Not** `suggestedFix` or full content — those balloon log size and aren't relevant for measuring overlap. Caps the per-pass payload to roughly the same as the summary comment.

## Test plan

- [x] **review.ts** (4 new): off-by-default; not-`"true"`-stays-off; on-passes-callback; callback robust to malformed step shapes
- [x] **consensus.ts** (3 new): off-by-default-no-debug-logs; on-emits-one-per-pass-with-correct-shape; not-`"true"`-stays-off
- [x] Full suite: **922 passing** (915 + 7 new)
- [x] All packages build clean (`pnpm -r build`)

## Documentation

- README: new `### Diagnostic Logging` subsection with sample log lines for both flags + table entries
- `FOLLOWUPS.md`: items #1 and #3 marked as instrumented; the next-action guidance now points to shipping experiment 1 (the cluster.ts token-set fix) with measurement enabled

## Suggested usage on a real PR

To collect data for the consensus-quality writeup's experiment 1:

```yaml
env:
  RUSTY_LOG_RAW_FINDINGS: "true"
  LOG_LEVEL: "debug"   # required for the raw-findings logs to flush
```

Run once with the flag on across 4-6 PRs; tabulate the per-pass findings to compute true overlap. Then ship the cluster.ts token-set fix and re-run on the same PRs to measure `agreementRate` delta.

To investigate a slow / hung Kimi pass:

```yaml
env:
  RUSTY_LOG_AGENT_STEPS: "true"
```

Next time it stalls, the log shows whether step 9 ever fired (hypothesis 2: it didn't), or whether earlier steps already exhausted the context budget (hypothesis 1).

## Out of scope

- The actual cluster.ts fix (experiment 1) — separate PR after this lands and we have a few PRs of `RUSTY_LOG_RAW_FINDINGS` data to compute the baseline.
- Per-pass findings as **structured** (queryable) output — current shape is just log lines, which is what we need to measure but not the right thing to keep on indefinitely. Future work could pipe to a structured trace store.