### PR TITLE
fix: union joining-finding tokens into cluster comparison vocabulary

### DIFF
--- a/packages/core/src/__tests__/cluster.test.ts
+++ b/packages/core/src/__tests__/cluster.test.ts
@@ -265,6 +265,99 @@ describe("clusterFindings", () => {
     const outsideWindow = clusterFindings([[f1], [f3]]);
     expect(outsideWindow).toHaveLength(2);
   });
+
+  // CONSENSUS-QUALITY-WRITEUP.md experiment 1: cluster.messageTokens used to be
+  // frozen at the first finding's tokens, so similarity for any later joiner
+  // was always measured against pass 1's specific wording. This block verifies
+  // the union-on-join behavior — pass 3 can now reach the cluster via pass 2's
+  // wording even when its similarity to pass 1 alone is below threshold.
+
+  it("widens the comparison vocabulary as findings join the cluster", () => {
+    // f1: "alpha beta gamma delta"
+    // f2: "alpha beta epsilon zeta"   (shares 2/6 with f1 → 0.333, just above 0.3)
+    // f3: "epsilon zeta eta theta"    (shares 0/8 with f1 alone → 0; shares 2/6 with f2 → 0.333)
+    // pre-fix: f3 compared against f1 only → no match → 3 separate clusters
+    // post-fix: f3 compared against f1∪f2 = 6 tokens → 2/8 = 0.25 (still under threshold!)
+    //          so the union must be wide enough to actually flip a case.
+    const f1 = makeFinding({ message: "alpha beta gamma delta" });
+    const f2 = makeFinding({ message: "alpha beta epsilon zeta theta" });
+    const f3 = makeFinding({ message: "epsilon zeta theta iota kappa" });
+
+    // sanity: each pairwise jaccard
+    expect(jaccardSimilarity(tokenize(f1.message), tokenize(f3.message))).toBeLessThan(0.3);
+    expect(jaccardSimilarity(tokenize(f2.message), tokenize(f3.message))).toBeGreaterThanOrEqual(
+      0.3,
+    );
+
+    const result = clusterFindings([[f1], [f2], [f3]]);
+
+    // After the union fix, the f1+f2 cluster's tokens are
+    // {alpha, beta, gamma, delta, epsilon, zeta, theta} (7 tokens).
+    // f3 (5 tokens) intersects {epsilon, zeta, theta} = 3, union = 9 → 0.333 ≥ 0.3.
+    // So f3 joins the same cluster — vote count = 3.
+    expect(result).toHaveLength(1);
+    expect(result[0].voteCount).toBe(3);
+    expect(result[0].variants).toHaveLength(3);
+  });
+
+  it("vote count remains distinct-passes after the token union (no double-counting)", () => {
+    // multiple findings from the same pass joining the same cluster should
+    // still count as one vote; the union must not change distinct-pass semantics.
+    const f1 = makeFinding({ message: "alpha beta gamma delta" });
+    const f2a = makeFinding({ message: "alpha beta epsilon" });
+    const f2b = makeFinding({ message: "epsilon zeta gamma delta" });
+
+    const result = clusterFindings([[f1], [f2a, f2b]]);
+    expect(result).toHaveLength(1);
+    expect(result[0].voteCount).toBe(2);
+    // all three findings end up as variants
+    expect(result[0].variants).toHaveLength(3);
+  });
+
+  it("does not over-merge unrelated findings on the same file:line via the wider vocabulary", () => {
+    // sanity bound: even with token union, two genuinely unrelated findings on
+    // the same file at nearby lines should still cluster separately if their
+    // wording doesn't share enough with the cluster's accumulated vocabulary.
+    const f1 = makeFinding({
+      line: 10,
+      message: "potential null reference dereference handler",
+    });
+    const f2 = makeFinding({
+      line: 11,
+      message: "potential null reference different bug elsewhere",
+    });
+    const f3 = makeFinding({
+      line: 12,
+      message: "missing await async race condition",
+    });
+
+    const result = clusterFindings([[f1], [f2], [f3]]);
+
+    // f1 + f2 cluster (high overlap), f3 stays separate (no shared tokens
+    // with the f1+f2 union).
+    expect(result).toHaveLength(2);
+    const cluster1 = result.find((c) => c.variants.length === 2);
+    const cluster2 = result.find((c) => c.variants.length === 1);
+    expect(cluster1).toBeDefined();
+    expect(cluster2).toBeDefined();
+  });
+
+  it("union expands within a single pass as well as across passes", () => {
+    // joins within one pass also expand the comparison vocabulary, so a later
+    // entry in the same pass benefits from the union.
+    const f1 = makeFinding({ message: "alpha beta gamma" });
+    const f2 = makeFinding({ message: "alpha gamma delta epsilon" });
+    const f3 = makeFinding({ message: "delta epsilon zeta theta" });
+
+    const result = clusterFindings([[f1, f2, f3]]);
+
+    // f1 + f2 cluster, then f3 has 2/6 overlap with the union (delta, epsilon)
+    // = 0.333 ≥ 0.3 → joins the same cluster.
+    expect(result).toHaveLength(1);
+    // single-pass run, distinct-pass vote count = 1 even with 3 variants
+    expect(result[0].voteCount).toBe(1);
+    expect(result[0].variants).toHaveLength(3);
+  });
 });
 
 describe("clusterObservations", () => {

--- a/packages/core/src/agent/cluster.ts
+++ b/packages/core/src/agent/cluster.ts
@@ -82,6 +82,14 @@ function clusterItems<T extends Clusterable>(
 
         if (similarity >= threshold) {
           cluster.items.push({ item, passIndex });
+          // Union the joining item's tokens into the cluster's comparison set.
+          // Without this, similarity on later joins is always measured against
+          // the first-arriving finding's specific wording — meaning a 3rd pass
+          // that's much closer to the 2nd pass's wording than the 1st can still
+          // miss the cluster. With diverse cross-model ensembles, that's a
+          // structural disadvantage. See CONSENSUS-QUALITY-WRITEUP.md
+          // experiment 1.
+          for (const t of tokens) cluster.messageTokens.add(t);
           matched = true;
           break;
         }


### PR DESCRIPTION
## Why

`cluster.ts:91-95` had a structural bug: when a finding joined an existing cluster, the cluster's `messageTokens` set was frozen at the *first-arriving* finding's tokens and never updated. So similarity for any later joiner was always measured against pass 1's specific wording — even when pass 3's phrasing was much closer to pass 2's than to pass 1's.

With diverse cross-model ensembles (Anthropic / xAI / Moonshot / DeepSeek / OpenAI / Google), each model phrases the same bug differently. The frozen-token-set effectively required pass N to use similar wording to pass 1, regardless of how the cluster's vocabulary had grown. That's order-dependent clustering whose outcome depended on which finding happened to arrive first.

This is consensus-quality experiment 1 from `CONSENSUS-QUALITY-WRITEUP.md` — the first ranked recommendation because it's a clear order-dependence bug, not a tuning knob, and reveals whether the threshold truly is "too strict" or whether it was being measured against an unfair baseline.

## What changes

One added line in the join branch:

```ts
if (similarity >= threshold) {
  cluster.items.push({ item, passIndex });
  for (const t of tokens) cluster.messageTokens.add(t);  // NEW
  matched = true;
  break;
}
```

Subsequent joiners are now compared against the cluster's accumulated vocabulary instead of just the first arrival.

## Tests added (4)

| Name | What it proves |
|---|---|
| **widens the comparison vocabulary as findings join the cluster** | A 3-pass case where pass 3 reaches the cluster *only* via the union of pass 1+2 tokens. Pre-fix: pass 3 forms its own cluster (compared only to pass 1's wording, similarity < 0.3). Post-fix: pass 3 joins because cluster vocab now includes pass 2. |
| **vote count remains distinct-passes after the token union** | Sanity check that distinct-pass semantics didn't regress when multiple findings from the same pass join one cluster. |
| **does not over-merge unrelated findings on the same file:line via the wider vocabulary** | Over-merge bound: `f3` with no shared tokens still forms its own cluster even though `f1+f2` unioned has more vocabulary than either alone. |
| **union expands within a single pass as well as across passes** | Within-pass joins also expand the comparison set. |

## Risk

Could over-merge when many shared stop-words accumulate in the cluster vocab. Bounded by:

- Jaccard threshold stays at `0.3` (default) / `0.2` (same-category)
- Same file + line proximity ±5 still required
- Test #3 sanity-checks this explicitly with a real "unrelated finding" case
- The `tokenize` function already strips punctuation and lowercases, so the vocab grows only on meaningful word stems

If a future signal shows over-merging in production, the threshold can be tightened (`JACCARD_THRESHOLD: 0.3 → 0.4`) to compensate without reverting the structural fix.

## Validation plan

The writeup's success criteria require empirical validation: capture per-pass findings on 5-10 PRs both before and after this lands and compute `agreementRate` delta on the same PR shapes. **Already enabled in #174**: `RUSTY_LOG_RAW_FINDINGS=true` + `LOG_LEVEL=debug` flow on every self-review. Once a few PR reviews land post-merge:

1. Pull per-pass findings from action logs
2. Tabulate cross-model overlap (which findings appear in 1, 2, or 3 passes)
3. Recompute `agreementRate` with both the old and new clustering algorithms (the captured raw findings are stable input)
4. Decision gate: if `agreementRate` rises by ≥10pp on average, the structural fix was the right call. If <5pp, the threshold itself is too strict and experiment 2 (single-vote → judge arbitration) is the next lever.

## Test plan

- [x] **cluster.test.ts** (4 new): all four scenarios above pass
- [x] Full suite: **926 tests passing** (922 + 4 new)
- [x] All packages build clean (`pnpm -r build`)

## What this isn't

- **Not a tuning change.** Jaccard thresholds, line proximity windows, category bonus — all unchanged. Only the comparison-vocabulary update on join.
- **Not flag-gated.** This is a strict bug fix — the frozen-token-set behavior was order-dependent and not intentional. Flagging it would just defer the validation work without de-risking it.
- **Not the only lever.** Experiments 2 (single-vote arbitration) and 3 (drop the unanimous-2-of-2 gate) are still on the table per the writeup. They become more or less relevant depending on what the post-merge `agreementRate` data shows.