### PR TITLE
ci: swap review slot 1 to deepseek-v4-flash

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -42,13 +42,13 @@ jobs:
 
           RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-vendor consensus. deepseek via the official DeepSeek
-          # provider on Requesty (NOT fireworks — fireworks routing
-          # tool-loops on the same model id, see Model + Provider Routing
-          # Notes in README). grok via Requesty. kimi via Ollama Cloud
-          # for direct moonshot routing.
+          # cross-vendor consensus. deepseek-v4-flash via OpenRouter
+          # (cheaper, shallower variant of v4-pro — v4-pro on Novita /
+          # Requesty's fireworks route was 4× direct API price and
+          # tool-looped at MAX_STEPS=10; see Model + Provider Routing
+          # Notes in README). grok via Requesty. kimi via Ollama Cloud.
           RUSTY_REVIEW_MODELS: >-
-            openrouter/deepseek/deepseek-v4-pro,
+            openrouter/deepseek/deepseek-v4-flash,
             requesty/xai/grok-4.3,
             ollama/kimi-k2.6:cloud
           RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
@@ -60,8 +60,9 @@ jobs:
           # the structured-output JSON. see #152.
           RUSTY_LLM_MAX_STEPS: "10"
           RUSTY_JUDGE_ENABLED: "true"
-          # judge has no tools, so requesty/fireworks/deepseek-v4-pro is fine
-          # here even though it tool-loops on the review path.
+          # judge has no tools (single call per PR, no tool-loop risk),
+          # so the Novita-routed v4-pro price premium is bounded — one call
+          # is fine even though slot 1 had to move off v4-pro to v4-flash.
           RUSTY_JUDGE_MODEL: openrouter/deepseek/deepseek-v4-pro
           RUSTY_JUDGE_TEMPERATURE: "0.1"
           RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview


### PR DESCRIPTION
## Why

Real OpenRouter cost data on PR review activity (2026-05-12 sample):

| Metric | Value |
|---|---|
| Total deepseek-v4-pro calls | 340/day |
| Total cost | $9.14/day |
| Cache hit rate | 58% |
| Avg trajectory | 4 LLM calls per invocation |
| Per-PR deepseek cost | **~$0.40** (~€7/day at 23 PRs/day) |
| Monthly projection | **~€210/month** for deepseek slot 1 alone |

Two root causes:

1. **OpenRouter routes to Novita** at ~$1.20/$3 per M — roughly **4× DeepSeek's direct API price** ($0.27/$1.10).
2. **v4-pro tool-loops on tool-using review trajectories** — 256 of 340 daily calls finished `tool_calls` (not `stop`), driving avg ~14 LLM calls per PR for the slot-1 deepseek pass alone.

The combination is what's expensive. Cache saves ~58% of input billing but doesn't fix the call count.

## What changes

Replace slot 1 model from `openrouter/deepseek/deepseek-v4-pro` → `openrouter/deepseek/deepseek-v4-flash`. Same OpenRouter integration, same `data-tool-agent` plumbing, same prompt shape. Just a smaller, faster, cheaper deepseek variant in the review path.

**Judge stays on v4-pro** — single call per PR, no tools, can't tool-loop, deliberation quality matters there. Bounded cost.

```diff
 RUSTY_REVIEW_MODELS: >-
-  openrouter/deepseek/deepseek-v4-pro,
+  openrouter/deepseek/deepseek-v4-flash,
   requesty/xai/grok-4.3,
   ollama/kimi-k2.6:cloud
```

Expected per-PR slot-1 cost: ~$0.04-0.10 (vs current $0.40). **~70-90% reduction** on the deepseek footprint without giving up the cross-vendor ensemble.

## Verification plan

Cheapest way to validate: this PR triggers its own self-review. The self-review uses the workflow file on this branch (via `uses: ./`), so the very first run exercises the new config.

Per the instrumentation shipped in #174, the run will log:
- `passModels` array — confirms `deepseek-v4-flash` is in slot 1
- Per-pass token counts — measurable cost delta vs prior PRs

If the v4-flash pass:
- Completes in 2-3 steps → 🎉 ship as-is
- Tool-loops up to 8+ steps anyway → fallback options remain on the table (gpt-5.4-mini, etc.) but at least we tried the same-vendor cheap variant first

## What this isn't

- **Not a config-only experiment**: this is the real production self-review workflow. If the v4-flash pass produces materially weaker findings than v4-pro on the next few PRs (subjective judgment), the revert is one line.
- **Not affecting downstream consumers**: action.yml still points at `:latest` (rebuilt only on push to main). This config change is self-review-only until you mirror it to your downstream workflow file.

## README + comments

The Model + Provider Routing Notes section in README already documents the v4-pro/Novita situation. Workflow comment on `RUSTY_REVIEW_MODELS` updated to match the new shape and explain why v4-pro got demoted to judge-only.