### PR TITLE
perf(judge): emit per-finding excerpt context once

### DIFF
--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -588,6 +588,8 @@ describe("buildFindingExcerpt", () => {
     expect(excerpt.startsWith("## src/app.ts")).toBe(true);
     expect(excerpt).toContain("__new hunk__");
     expect(excerpt).toContain('1 +import { z } from "zod";');
+    // pure-add hunk (PATCHES has 2 additions, 0 deletions) — old block must be omitted
+    expect(excerpt).not.toContain("__old hunk__");
   });
 
   it("returns the not-found sentinel when the file isn't in the patches", () => {
@@ -629,6 +631,94 @@ describe("buildFindingExcerpt", () => {
     expect(excerpt).toContain("__old hunk__");
     expect(excerpt).toContain("__new hunk__");
     expect(excerpt).toContain("-removed mid");
+  });
+
+  it("emits each context line exactly once across both hunk blocks", () => {
+    // mixed hunk: context + addition + removal — context must appear once total
+    const patches: FilePatch[] = [
+      {
+        path: "src/mixed.ts",
+        additions: 1,
+        deletions: 1,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 10,
+            oldLines: 4,
+            newStart: 10,
+            newLines: 4,
+            content: [
+              " unchanged-before-MARKER",
+              "-removed-line",
+              "+added-line",
+              " unchanged-after-MARKER",
+            ].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/mixed.ts", line: 10 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    const lines = excerpt.split("\n");
+    expect(lines.filter((l) => l.includes("unchanged-before-MARKER"))).toHaveLength(1);
+    expect(lines.filter((l) => l.includes("unchanged-after-MARKER"))).toHaveLength(1);
+    expect(excerpt).toContain("__new hunk__");
+    expect(excerpt).toContain("__old hunk__");
+  });
+
+  it("renders removed lines with old-side line numbers in __old hunk__", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/removal.ts",
+        additions: 0,
+        deletions: 2,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 50,
+            oldLines: 3,
+            newStart: 50,
+            newLines: 1,
+            content: ["-gone-1", "-gone-2", " surviving-line"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/removal.ts", line: 50 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    // removed lines use old-side line numbers (50 + offset)
+    expect(excerpt).toContain("50 -gone-1");
+    expect(excerpt).toContain("51 -gone-2");
+    // the surviving context line goes to the new block with its new-side number
+    expect(excerpt).toContain("50  surviving-line");
+    // both blocks present
+    expect(excerpt).toContain("__old hunk__");
+    expect(excerpt).toContain("__new hunk__");
+  });
+
+  it("places sibling-signature annotations on the new side only", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/sig.ts",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 5,
+            oldLines: 1,
+            newStart: 5,
+            newLines: 2,
+            content: ["~ // ... function outer() {", " context-line", "+added"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/sig.ts", line: 5 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    expect(excerpt.match(/~ \/\/ \.\.\. function outer/g)).toHaveLength(1);
+    // pure-add hunk → no __old hunk__ block at all
+    expect(excerpt).not.toContain("__old hunk__");
   });
 });
 

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -26,37 +26,42 @@ function findOverlappingHunks(hunks: Hunk[], line: number, endLine: number): Hun
 
 function formatHunkExcerpt(hunk: Hunk): string[] {
   const lines = hunk.content.split("\n");
-  const oldLines: string[] = [];
-  const newLines: string[] = [];
+  // mirrors compress.ts formatHunks: context, additions, and sibling signatures
+  // go into the new-side block; removals into the old-side block. context is
+  // emitted exactly once — the model can still read removals from the old
+  // block via their line numbers without re-reading every context line.
+  const oldRemovedLines: string[] = [];
+  const newSideLines: string[] = [];
   let oldLine = hunk.oldStart;
   let newLine = hunk.newStart;
   for (const line of lines) {
     if (line.startsWith("-")) {
-      oldLines.push(`${oldLine} ${line}`);
+      oldRemovedLines.push(`${oldLine} ${line}`);
       oldLine++;
     } else if (line.startsWith("+")) {
-      newLines.push(`${newLine} ${line}`);
+      newSideLines.push(`${newLine} ${line}`);
       newLine++;
     } else if (line.startsWith("\\")) {
       continue;
     } else if (line.startsWith("~")) {
-      oldLines.push(line);
-      newLines.push(line);
+      // sibling-signature annotation: emit once on the new side without
+      // advancing counters
+      newSideLines.push(line);
     } else {
-      oldLines.push(`${oldLine} ${line}`);
-      newLines.push(`${newLine} ${line}`);
+      // unchanged context: advance both counters, emit only on the new side
+      newSideLines.push(`${newLine} ${line}`);
       oldLine++;
       newLine++;
     }
   }
   const parts: string[] = [];
-  if (oldLines.length > 0) {
-    parts.push("__old hunk__");
-    parts.push(...oldLines);
-  }
-  if (newLines.length > 0) {
+  if (newSideLines.length > 0) {
     parts.push("__new hunk__");
-    parts.push(...newLines);
+    parts.push(...newSideLines);
+  }
+  if (oldRemovedLines.length > 0) {
+    parts.push("__old hunk__");
+    parts.push(...oldRemovedLines);
   }
   return parts;
 }


### PR DESCRIPTION
## Why

`formatHunkExcerpt` in `packages/core/src/agent/judge.ts` had the **same dual-emit antipattern** we fixed in `compress.ts` via #169. The judge's per-finding excerpts emitted every unchanged context line twice — once inside `__old hunk__`, once inside `__new hunk__` — even though the model already infers "before / after" from `+`/`-` prefixes alone.

This was flagged as a follow-up in `FOLLOWUPS.md` item #6 when #169 landed. With #166's per-finding excerpt scoping shipped and #169's compress.ts fix proven, this PR closes the loop on the duplicate emission pattern wherever it lives.

## What changes

Mechanical port of the proven fix to `formatHunkExcerpt`. Same shape:

```
__new hunk__         ← context + adds + sibling signatures (each once)
10  unchanged context
11 +added
12  more context
__old hunk__         ← removals only, omitted if empty
11 -removed
```

Rules unchanged from compress.ts:

1. Context (` `) → `__new hunk__`, new-side line number, emitted once
2. Additions (`+`) → `__new hunk__`, new-side line number
3. Removals (`-`) → `__old hunk__`, old-side line number
4. Sibling signatures (`~`) → `__new hunk__` only (scope hints, not historical state)
5. `__old hunk__` omitted entirely on pure-add hunks
6. `__new hunk__` omitted entirely if the side is empty

## Impact

Per-finding judge excerpt body shrinks ~50% on typical mixed hunks (90 context + 5 add + 5 remove). The judge runs once per PR, so this multiplies across review volume — particularly meaningful now that you're on `openrouter/deepseek/deepseek-v4-pro` as judge (where every kilotoken matters at Novita's pricing).

## Tests

**Existing tests strengthened**: the "emits the file header plus the hunk that contains the finding line" case (pure-add fixture) now also asserts `__old hunk__` is absent.

**Three new edge cases** mirroring `diff.test.ts` coverage:

| Case | What it proves |
|---|---|
| "emits each context line exactly once across both hunk blocks" | Mixed hunk with context + add + remove — context tokens appear only once total |
| "renders removed lines with old-side line numbers in __old hunk__" | `-` lines anchor to OLD-side line numbers, surviving context to NEW-side |
| "places sibling-signature annotations on the new side only" | `~` rows appear once, in the new block, regardless of how many siblings the tree-sitter expansion adds |

A "pure-removal" test case was considered but isn't reachable through `buildFindingExcerpt` — `findOverlappingHunks` filters by new-side line numbers, so a hunk with `newLines: 0` can never anchor a finding. The pure-removal property is verified instead in `diff.test.ts` (#169) for compress.ts, which uses the same algorithm.

## Test plan

- [x] judge.test.ts — 40 passing (previous 36 + 4 new/strengthened)
- [x] Full suite: **929 passing** (926 + 3 net new)
- [x] All packages build clean (`pnpm -r build`)
- [x] No format dependents (`buildFindingExcerpt` is consumed inline by `formatFindingsForJudge` only — opaque string)

## What this isn't

- **Not a behavior change for the judge's verdicts** — the excerpt content is the same, just emitted once instead of twice. Models that previously inferred "before/after" from the redundant emission have no problem inferring it from `+`/`-` prefixes alone (this was already proven in #169 for the reviewer prompt).
- **Not a token win on the same order as #169** — judge excerpts are already small (one hunk × number of findings). But it's free and the judge runs every PR, so the cumulative win across reviews adds up.