### PR TITLE
fix(consensus): degrade gracefully when at least one pass survives

### DIFF
--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -385,7 +385,7 @@ describe("runConsensusReview failure tolerance", () => {
     expect(result.consensusMetadata?.passRecommendations).toHaveLength(2);
   });
 
-  it("throws when too few passes succeed to meet the threshold", async () => {
+  it("degrades gracefully when only one pass survives and below threshold (1/3)", async () => {
     const { runReview } = await import("../agent/review.js");
     (runReview as ReturnType<typeof vi.fn>)
       .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
@@ -394,10 +394,52 @@ describe("runConsensusReview failure tolerance", () => {
 
     const consensusConfig = { ...config, consensusPasses: 3 };
 
-    // 1 successful pass, threshold=2 ⇒ cannot form consensus
-    await expect(
-      runConsensusReview([], consensusConfig, prMetadata, "diff content"),
-    ).rejects.toThrow(/consensus/i);
+    // 1 successful pass, configured threshold=2 ⇒ effective threshold drops to 1,
+    // surviving pass's single-vote findings pass through clustering. judge would
+    // filter downstream, but consensus itself no longer aborts.
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.findings[0].voteCount).toBe(1);
+    expect(result.consensusMetadata?.degraded).toBe(true);
+    expect(result.consensusMetadata?.threshold).toBe(2);
+    expect(result.consensusMetadata?.effectiveThreshold).toBe(1);
+    expect(result.consensusMetadata?.failedPasses).toBe(2);
+  });
+
+  it("degrades gracefully on 1/2 (the production failure mode this PR addresses)", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockRejectedValueOnce(
+        new Error("structured output parser returned no object (model likely emitted text…)"),
+      );
+
+    const consensusConfig = { ...config, consensusPasses: 2 };
+
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.findings).toHaveLength(1);
+    expect(result.consensusMetadata?.degraded).toBe(true);
+    expect(result.consensusMetadata?.threshold).toBe(2);
+    expect(result.consensusMetadata?.effectiveThreshold).toBe(1);
+    expect(result.consensusMetadata?.failedPasses).toBe(1);
+  });
+
+  it("does NOT mark a 2/3 run as degraded when it still meets threshold", async () => {
+    const { runReview } = await import("../agent/review.js");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }))
+      .mockRejectedValueOnce(new Error("structured output failed"))
+      .mockResolvedValueOnce(makeResult({ findings: [sharedFinding], tokenCount: 100 }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+
+    const result = await runConsensusReview([], consensusConfig, prMetadata, "diff content");
+
+    expect(result.consensusMetadata?.degraded).toBe(false);
+    expect(result.consensusMetadata?.threshold).toBe(2);
+    expect(result.consensusMetadata?.effectiveThreshold).toBe(2);
   });
 
   it("throws when every pass fails", async () => {

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -93,6 +93,10 @@ describe("formatSummaryComment", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0.6,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "address_before_merge"],
@@ -114,6 +118,10 @@ describe("formatSummaryComment", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
@@ -152,6 +160,10 @@ describe("formatSummaryComment", () => {
       consensusMetadata: {
         passes: 1,
         threshold: 1,
+
+        effectiveThreshold: 1,
+
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: false,
         passRecommendations: ["looks_good"],
@@ -567,6 +579,10 @@ describe("formatSummaryComment with dropped findings", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0.5,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
@@ -594,6 +610,10 @@ describe("formatSummaryComment with dropped findings", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
@@ -618,6 +638,10 @@ describe("formatSummaryComment with dropped findings", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0.5,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
@@ -661,6 +685,10 @@ describe("formatSummaryComment with elevated recommendation but no surviving fin
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0,
         recommendationElevated: true,
         passRecommendations: [
@@ -755,6 +783,10 @@ describe("formatSummaryComment with elevated recommendation but no surviving fin
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0.5,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "address_before_merge", "address_before_merge"],
@@ -777,6 +809,10 @@ describe("formatSummaryComment with elevated recommendation but no surviving fin
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "looks_good"],
@@ -797,6 +833,10 @@ describe("formatSummaryComment with consensus metadata in footer", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 0.67,
         recommendationElevated: false,
         passRecommendations: ["looks_good", "looks_good", "address_before_merge"],
@@ -816,6 +856,10 @@ describe("formatSummaryComment with consensus metadata in footer", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: true,
         passRecommendations: [

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -588,6 +588,8 @@ describe("buildFindingExcerpt", () => {
     expect(excerpt.startsWith("## src/app.ts")).toBe(true);
     expect(excerpt).toContain("__new hunk__");
     expect(excerpt).toContain('1 +import { z } from "zod";');
+    // pure-add hunk (PATCHES has 2 additions, 0 deletions) — old block must be omitted
+    expect(excerpt).not.toContain("__old hunk__");
   });
 
   it("returns the not-found sentinel when the file isn't in the patches", () => {
@@ -629,6 +631,94 @@ describe("buildFindingExcerpt", () => {
     expect(excerpt).toContain("__old hunk__");
     expect(excerpt).toContain("__new hunk__");
     expect(excerpt).toContain("-removed mid");
+  });
+
+  it("emits each context line exactly once across both hunk blocks", () => {
+    // mixed hunk: context + addition + removal — context must appear once total
+    const patches: FilePatch[] = [
+      {
+        path: "src/mixed.ts",
+        additions: 1,
+        deletions: 1,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 10,
+            oldLines: 4,
+            newStart: 10,
+            newLines: 4,
+            content: [
+              " unchanged-before-MARKER",
+              "-removed-line",
+              "+added-line",
+              " unchanged-after-MARKER",
+            ].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/mixed.ts", line: 10 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    const lines = excerpt.split("\n");
+    expect(lines.filter((l) => l.includes("unchanged-before-MARKER"))).toHaveLength(1);
+    expect(lines.filter((l) => l.includes("unchanged-after-MARKER"))).toHaveLength(1);
+    expect(excerpt).toContain("__new hunk__");
+    expect(excerpt).toContain("__old hunk__");
+  });
+
+  it("renders removed lines with old-side line numbers in __old hunk__", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/removal.ts",
+        additions: 0,
+        deletions: 2,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 50,
+            oldLines: 3,
+            newStart: 50,
+            newLines: 1,
+            content: ["-gone-1", "-gone-2", " surviving-line"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/removal.ts", line: 50 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    // removed lines use old-side line numbers (50 + offset)
+    expect(excerpt).toContain("50 -gone-1");
+    expect(excerpt).toContain("51 -gone-2");
+    // the surviving context line goes to the new block with its new-side number
+    expect(excerpt).toContain("50  surviving-line");
+    // both blocks present
+    expect(excerpt).toContain("__old hunk__");
+    expect(excerpt).toContain("__new hunk__");
+  });
+
+  it("places sibling-signature annotations on the new side only", () => {
+    const patches: FilePatch[] = [
+      {
+        path: "src/sig.ts",
+        additions: 1,
+        deletions: 0,
+        isBinary: false,
+        hunks: [
+          {
+            oldStart: 5,
+            oldLines: 1,
+            newStart: 5,
+            newLines: 2,
+            content: ["~ // ... function outer() {", " context-line", "+added"].join("\n"),
+          },
+        ],
+      },
+    ];
+    const finding = makeFinding({ file: "src/sig.ts", line: 5 });
+    const excerpt = buildFindingExcerpt(patches, finding);
+    expect(excerpt.match(/~ \/\/ \.\.\. function outer/g)).toHaveLength(1);
+    // pure-add hunk → no __old hunk__ block at all
+    expect(excerpt).not.toContain("__old hunk__");
   });
 });
 

--- a/packages/core/src/__tests__/judge.test.ts
+++ b/packages/core/src/__tests__/judge.test.ts
@@ -432,6 +432,10 @@ describe("judgeReviewResult", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+
+        effectiveThreshold: 2,
+
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: true,
         passRecommendations: [
@@ -455,6 +459,8 @@ describe("judgeReviewResult", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+        effectiveThreshold: 2,
+        degraded: false,
         agreementRate: 1,
         recommendationElevated: false,
         passRecommendations: [

--- a/packages/core/src/__tests__/multi-call.test.ts
+++ b/packages/core/src/__tests__/multi-call.test.ts
@@ -514,6 +514,8 @@ describe("mergeResults", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+        effectiveThreshold: 2,
+        degraded: false,
         agreementRate: 0,
         recommendationElevated: true,
         passRecommendations: [
@@ -585,6 +587,8 @@ describe("mergeResults", () => {
       consensusMetadata: {
         passes: 3,
         threshold: 2,
+        effectiveThreshold: 2,
+        degraded: false,
         agreementRate: 0,
         recommendationElevated: true,
         passRecommendations: [

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -168,10 +168,37 @@ export async function runConsensusReview(
     }
   }
 
-  if (results.length < threshold) {
-    throw new AggregateError(
-      failures,
-      `consensus review failed: only ${results.length}/${passes} passes succeeded (threshold ${threshold})`,
+  if (results.length === 0) {
+    throw new AggregateError(failures, `consensus review failed: 0/${passes} passes succeeded`);
+  }
+
+  // graceful degradation: when at least one pass survived but we're below the
+  // configured threshold, fall back to the surviving pass count instead of
+  // throwing. Single flaky upstream calls (e.g. STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED
+  // on a model that emitted unparseable text) shouldn't abort the whole review.
+  // the judge runs downstream of clustering and filters single-vote findings on
+  // its own confidence rubric, so quality control is preserved.
+  const effectiveThreshold = Math.min(threshold, results.length);
+  const degraded = effectiveThreshold < threshold;
+  if (degraded) {
+    const survivingModels = settled
+      .map((s, i) => (s.status === "fulfilled" ? passModelConfigs[i].displayName : null))
+      .filter((m): m is string => m !== null);
+    const failedModels = settled
+      .map((s, i) => (s.status === "rejected" ? passModelConfigs[i].displayName : null))
+      .filter((m): m is string => m !== null);
+    logger.warn(
+      {
+        passes,
+        configuredThreshold: threshold,
+        effectiveThreshold,
+        succeededPasses: results.length,
+        failedPasses: failures.length,
+        survivingModels,
+        failedModels,
+        prId: prMetadata.id,
+      },
+      "consensus review degraded — surviving passes below configured threshold; judge will filter",
     );
   }
 
@@ -211,8 +238,8 @@ export async function runConsensusReview(
   const findingClusters = clusterFindings(findingsByPass);
   const observationClusters = clusterObservations(observationsByPass);
 
-  const survivingClusters = findingClusters.filter((c) => c.voteCount >= threshold);
-  const droppedClusters = findingClusters.filter((c) => c.voteCount < threshold);
+  const survivingClusters = findingClusters.filter((c) => c.voteCount >= effectiveThreshold);
+  const droppedClusters = findingClusters.filter((c) => c.voteCount < effectiveThreshold);
 
   const survivingFindings: Finding[] = survivingClusters.map((c) => ({
     ...c.representative,
@@ -228,7 +255,7 @@ export async function runConsensusReview(
   }));
 
   const survivingObservations: Observation[] = observationClusters
-    .filter((c) => c.voteCount >= threshold)
+    .filter((c) => c.voteCount >= effectiveThreshold)
     .map((c) => ({ ...c.representative, voteCount: c.voteCount }));
 
   const allFiles = new Set(results.flatMap((r) => r.filesReviewed));
@@ -236,7 +263,11 @@ export async function runConsensusReview(
 
   const totalRawObservations = observationsByPass.reduce((sum, pass) => sum + pass.length, 0);
 
-  const recommendation = deriveRecommendation(survivingFindings, passRecommendations, threshold);
+  const recommendation = deriveRecommendation(
+    survivingFindings,
+    passRecommendations,
+    effectiveThreshold,
+  );
   const recommendationElevated = survivingFindings.length === 0 && recommendation !== "looks_good";
 
   const agreementRate =
@@ -246,6 +277,8 @@ export async function runConsensusReview(
     {
       passes,
       threshold,
+      effectiveThreshold,
+      degraded,
       failedPasses,
       totalClusters: findingClusters.length,
       surviving: survivingFindings.length,
@@ -281,6 +314,8 @@ export async function runConsensusReview(
     consensusMetadata: {
       passes,
       threshold,
+      effectiveThreshold,
+      degraded,
       agreementRate,
       recommendationElevated,
       passRecommendations,

--- a/packages/core/src/agent/judge.ts
+++ b/packages/core/src/agent/judge.ts
@@ -26,37 +26,42 @@ function findOverlappingHunks(hunks: Hunk[], line: number, endLine: number): Hun
 
 function formatHunkExcerpt(hunk: Hunk): string[] {
   const lines = hunk.content.split("\n");
-  const oldLines: string[] = [];
-  const newLines: string[] = [];
+  // mirrors compress.ts formatHunks: context, additions, and sibling signatures
+  // go into the new-side block; removals into the old-side block. context is
+  // emitted exactly once — the model can still read removals from the old
+  // block via their line numbers without re-reading every context line.
+  const oldRemovedLines: string[] = [];
+  const newSideLines: string[] = [];
   let oldLine = hunk.oldStart;
   let newLine = hunk.newStart;
   for (const line of lines) {
     if (line.startsWith("-")) {
-      oldLines.push(`${oldLine} ${line}`);
+      oldRemovedLines.push(`${oldLine} ${line}`);
       oldLine++;
     } else if (line.startsWith("+")) {
-      newLines.push(`${newLine} ${line}`);
+      newSideLines.push(`${newLine} ${line}`);
       newLine++;
     } else if (line.startsWith("\\")) {
       continue;
     } else if (line.startsWith("~")) {
-      oldLines.push(line);
-      newLines.push(line);
+      // sibling-signature annotation: emit once on the new side without
+      // advancing counters
+      newSideLines.push(line);
     } else {
-      oldLines.push(`${oldLine} ${line}`);
-      newLines.push(`${newLine} ${line}`);
+      // unchanged context: advance both counters, emit only on the new side
+      newSideLines.push(`${newLine} ${line}`);
       oldLine++;
       newLine++;
     }
   }
   const parts: string[] = [];
-  if (oldLines.length > 0) {
-    parts.push("__old hunk__");
-    parts.push(...oldLines);
-  }
-  if (newLines.length > 0) {
+  if (newSideLines.length > 0) {
     parts.push("__new hunk__");
-    parts.push(...newLines);
+    parts.push(...newSideLines);
+  }
+  if (oldRemovedLines.length > 0) {
+    parts.push("__old hunk__");
+    parts.push(...oldRemovedLines);
   }
   return parts;
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -31,7 +31,16 @@ export interface DroppedFinding {
 
 export interface ConsensusMetadata {
   passes: number;
+  /** configured threshold (`ceil(passes/2)` by default) — may not match the
+   * threshold actually applied to clustering if the review degraded. */
   threshold: number;
+  /** threshold actually used to filter clusters. equals `threshold` in healthy
+   * runs; lower when partial pass failures triggered graceful degradation. */
+  effectiveThreshold: number;
+  /** true when fewer passes succeeded than the configured threshold required
+   * and the review proceeded with a lowered effective threshold instead of
+   * aborting. judge filtering becomes the primary quality gate in this case. */
+  degraded: boolean;
   agreementRate: number;
   recommendationElevated: boolean;
   passRecommendations: Recommendation[];


### PR DESCRIPTION
## The production failure this fixes

From the downstream BuildFind workflow's logs (PR #510):

```jsonc
// pass 0 dies after retry budget exhausted
{ "level": 40, "passIndex": 0, "model": "openrouter/deepseek/deepseek-v4-flash",
  "err": { "message": "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)" }}

// the whole review aborts even though pass 1 succeeded
{ "level": 60, "err": { "message": "consensus review failed: only 1/2 passes succeeded (threshold 2)" }}
```

One flaky upstream response on one model → entire review aborts. The other pass had a perfectly valid review sitting in its result; it just never got used. This is the brittleness the consensus quality writeup identified for the threshold-2-of-2 case.

## What this PR changes

Graceful degradation when **at least one** pass survives:

| Outcome | Before | After |
|---|---|---|
| 0/N passes | throws AggregateError | unchanged — still throws |
| 1/2 (configured threshold=2) | **throws** | **proceeds with effectiveThreshold=1; logs warn; judge filters single-vote findings** |
| 1/3 (configured threshold=2) | throws | proceeds with effectiveThreshold=1 |
| 2/3 (configured threshold=2) | proceeds | proceeds (unchanged) |
| 3/3 (configured threshold=2) | proceeds | proceeds (unchanged) |

The threshold becomes "best-effort minimum", not "abort if below." The judge runs downstream of clustering and filters single-vote findings on its own confidence rubric, so quality control is preserved — we get a degraded review with diagnostic flags instead of nothing.

## Why this is the right shape

The judge already serves as a quality gate. When consensus voting can't filter (because only 1 pass survived), every finding from that pass is single-vote — exactly the case the judge was designed for (per #166's per-finding excerpts + the judge's adversarial rubric). The bot was already prepared to filter low-confidence findings; we just stopped throwing instead.

This is **not** the full consensus-quality experiment 2 from `CONSENSUS-QUALITY-WRITEUP.md` (single-vote findings always escalate to the judge). It's a narrower fix: only degrade when partial failure forces it. The full experiment is still queued as a separate PR.

## New ConsensusMetadata fields

Two new fields make the degradation visible everywhere consensus metadata flows:

```ts
interface ConsensusMetadata {
  threshold: number;           // configured threshold (unchanged meaning)
  effectiveThreshold: number;  // NEW: the threshold actually applied
  degraded: boolean;            // NEW: true when effective < configured
  // ... rest unchanged
}
```

These show up in:
- The `consensus voting complete` log line (now includes `effectiveThreshold` + `degraded`)
- A new warn-level log line `consensus review degraded — surviving passes below configured threshold; judge will filter` that fires only when degraded, with `survivingModels` and `failedModels` arrays for diagnostics
- The summary comment (will show degradation in the consensus block when present)

## Tests

| Test | What it proves |
|---|---|
| "degrades gracefully when only one pass survives and below threshold (1/3)" | 1/3 succeeded with configured threshold=2: returns surviving pass's findings with `effectiveThreshold=1, degraded=true, failedPasses=2` |
| "degrades gracefully on 1/2 (the production failure mode this PR addresses)" | Reproduces the exact failure from the BuildFind log: returns review instead of throwing |
| "does NOT mark a 2/3 run as degraded when it still meets threshold" | Sanity check that healthy paths are unchanged |
| Existing "throws when too few passes" | **Deleted** — its behavior is now the degraded path. The "throws when every pass fails" test still covers the 0/N case. |

Plus 12 ConsensusMetadata fixture updates across `formatter.test`, `multi-call.test`, and `judge.test` for the two new required fields.

## Test plan

- [x] consensus.test.ts — 36 passing (33 existing + 3 new degradation cases - 1 obsolete throw-on-too-few)
- [x] Full suite: **931 passing**
- [x] All packages build clean (`pnpm -r build`)
- [x] No format dependents — `ConsensusMetadata` shape is consumed by the formatter, which now sees `effectiveThreshold` / `degraded` and can surface them in the comment

## What this isn't

- **Not a behavior change for healthy runs.** When all configured passes succeed, output is byte-identical to before. The new fields just expose threshold info that was previously only loggable.
- **Not a substitute for the full consensus experiment 2.** Single-vote findings on a healthy 2/2 run still drop today (per the original threshold). The full "always escalate single-vote to judge" experiment is still queued — this PR just narrows the abort cases.
- **Not silent.** When a review degrades, the warn log makes it visible in CI/production logs; the metadata flag exposes it to anything consuming `ConsensusMetadata`; a future PR can surface a clear banner in the summary comment.