### PR TITLE
perf(review): retry the structurer on cached prose before rerolling the agent

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -23,6 +23,7 @@
     "@mastra/core": "^1.32.1",
     "@mastra/libsql": "^1.10.0",
     "@mastra/mcp": "^1.7.0",
+    "ai": "^6.0.182",
     "ai-sdk-ollama": "^3",
     "picomatch": "^4.0.4",
     "pino": "^10.3.1",

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -2,11 +2,21 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { ReviewConfig, PRMetadata } from "../types.js";
 
 const generateMock = vi.fn();
+const generateTextMock = vi.fn();
 
 vi.mock("@mastra/core/agent", () => ({
   Agent: vi.fn().mockImplementation(function () {
     return { generate: generateMock };
   }),
+}));
+
+vi.mock("ai", () => ({
+  generateText: generateTextMock,
+  // Output.object({ schema }) — opaque marker the structurer uses. We don't
+  // need to validate its shape here; the structurer-only retry just hands it
+  // off to generateText (which is mocked). Returning a sentinel keeps the
+  // import call working without pulling in the real `ai` runtime.
+  Output: { object: (opts: unknown) => ({ __output: opts }) },
 }));
 
 const resolveJsonPromptInjectionMock = vi.fn(() => false);
@@ -173,6 +183,138 @@ describe("runReview retry on STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED", () => 
     await expect(runReview(config, "diff", prMetadata)).rejects.toThrow(
       /structured output parser returned no object/,
     );
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("runReview structurer-only retry", () => {
+  const validParsedReview = makeValidResponse().object;
+
+  beforeEach(() => {
+    generateMock.mockReset();
+    generateTextMock.mockReset();
+    delete process.env.RUSTY_LLM_STRUCTURING_MODEL;
+  });
+
+  it("uses structurer-only retry on cached prose instead of rerunning the full agent", async () => {
+    process.env.RUSTY_LLM_STRUCTURING_MODEL = "test-structurer";
+    generateMock.mockResolvedValueOnce({
+      object: undefined,
+      text: "the reviewer's prose that the structurer failed to parse",
+      usage: { totalTokens: 100, inputTokens: 80, outputTokens: 20 },
+    });
+    generateTextMock.mockResolvedValueOnce({
+      output: validParsedReview,
+      usage: { totalTokens: 30, inputTokens: 25, outputTokens: 5 },
+    });
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(result.recommendation).toBe("looks_good");
+    // expensive agent.generate called ONCE (not twice as the legacy path did)
+    expect(generateMock).toHaveBeenCalledTimes(1);
+    // cheap generateObject call took over the retry
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the full agent reroll when structurer-only retry also fails", async () => {
+    process.env.RUSTY_LLM_STRUCTURING_MODEL = "test-structurer";
+    generateMock
+      .mockResolvedValueOnce({
+        object: undefined,
+        text: "first-attempt prose",
+        usage: { totalTokens: 100 },
+      })
+      .mockResolvedValueOnce(makeValidResponse());
+    generateTextMock.mockRejectedValueOnce(new Error("structurer threw on retry"));
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(result.recommendation).toBe("looks_good");
+    // structurer-only retry was attempted once
+    expect(generateTextMock).toHaveBeenCalledTimes(1);
+    // when it failed, existing expensive retry path kicked in
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT attempt structurer-only retry when no structuring model is configured", async () => {
+    // legacy path: no RUSTY_LLM_STRUCTURING_MODEL → existing 2-attempt retry only
+    generateMock
+      .mockResolvedValueOnce({
+        object: undefined,
+        text: "some prose",
+        usage: { totalTokens: 50 },
+      })
+      .mockResolvedValueOnce(makeValidResponse());
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(result.recommendation).toBe("looks_good");
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT attempt structurer-only retry when reviewer returned no prose", async () => {
+    process.env.RUSTY_LLM_STRUCTURING_MODEL = "test-structurer";
+    generateMock
+      .mockResolvedValueOnce({
+        object: undefined,
+        text: "",
+        usage: { totalTokens: 30 },
+      })
+      .mockResolvedValueOnce(makeValidResponse());
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    expect(result.recommendation).toBe("looks_good");
+    // no prose → skip structurer-only retry, go straight to expensive reroll
+    expect(generateTextMock).not.toHaveBeenCalled();
+    expect(generateMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("merges structurer-only retry token usage into the reported total", async () => {
+    process.env.RUSTY_LLM_STRUCTURING_MODEL = "test-structurer";
+    generateMock.mockResolvedValueOnce({
+      object: undefined,
+      text: "the reviewer's prose",
+      usage: { totalTokens: 100, inputTokens: 80, outputTokens: 20 },
+    });
+    generateTextMock.mockResolvedValueOnce({
+      output: validParsedReview,
+      usage: { totalTokens: 30, inputTokens: 25, outputTokens: 5 },
+    });
+
+    const result = await runReview(config, "diff", prMetadata);
+
+    // tokenCount should include both the agent's tokens AND the structurer retry's tokens
+    expect(result.tokenCount).toBe(130);
+  });
+
+  it("still throws when structurer-only retry succeeds with a non-schema-conforming object via the validation error path", async () => {
+    // edge case: generateObject succeeds but returns something incompatible.
+    // ai-sdk's generateObject validates against the schema and throws if it
+    // doesn't match, so this case is mostly defensive — but verifies that a
+    // throw from generateObject is caught and falls through to the full retry.
+    process.env.RUSTY_LLM_STRUCTURING_MODEL = "test-structurer";
+    generateMock
+      .mockResolvedValueOnce({
+        object: undefined,
+        text: "prose",
+        usage: { totalTokens: 50 },
+      })
+      .mockResolvedValueOnce({
+        object: undefined,
+        text: "more prose",
+        usage: { totalTokens: 50 },
+      });
+    // both structurer retries fail (one per expensive attempt)
+    generateTextMock.mockRejectedValue(new Error("schema validation failed"));
+
+    await expect(runReview(config, "diff", prMetadata)).rejects.toThrow(
+      /structured output parser returned no object/,
+    );
+    // each expensive attempt should try the cheap structurer retry once
+    expect(generateTextMock).toHaveBeenCalledTimes(2);
     expect(generateMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -1,5 +1,7 @@
 import { Agent } from "@mastra/core/agent";
 import type { ToolsInput } from "@mastra/core/agent";
+import { generateText, Output } from "ai";
+import type { z } from "zod";
 import { ReviewOutputSchema, SkimReviewOutputSchema } from "./schema.js";
 import { buildSystemPrompt, buildUserMessage, buildCachedSystemMessages } from "./prompts.js";
 import {
@@ -182,6 +184,86 @@ function summarizeFailedResponse(r: unknown): Record<string, unknown> {
   };
 }
 
+interface StructurerRetryUsage {
+  totalTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+interface StructurerRetryResult {
+  object: unknown;
+  usage?: StructurerRetryUsage;
+}
+
+/**
+ * Retry just the structuring step on the reviewer's prose. The agent
+ * already produced `prose` (the expensive part — multi-step tool-using
+ * trajectory). When the primary structurer returned no object, retrying
+ * with the same prose at the structurer level is ~$0.005 vs ~$0.10 for a
+ * full reviewer reroll. The agent's tool trajectory and bias toward
+ * extractable prose are preserved across the cheap retry.
+ *
+ * Returns null when the retry itself fails — caller falls through to the
+ * existing expensive retry path so we still get the previous behavior as
+ * a backstop.
+ */
+async function retryStructurerOnProse(
+  prose: string,
+  schema: z.ZodType,
+  structuringConfig: ModelConfig,
+  bindings: Record<string, unknown>,
+): Promise<StructurerRetryResult | null> {
+  try {
+    const result = await generateText({
+      model: resolveModel(structuringConfig),
+      output: Output.object({ schema }),
+      prompt:
+        "Convert the following code review into the requested JSON structure. " +
+        "Preserve every finding, observation, and field exactly as written.\n\n" +
+        prose,
+    });
+    log.info(
+      {
+        ...bindings,
+        structurerRetryTokens: result.usage.totalTokens,
+      },
+      "structurer-only retry succeeded after primary returned no object",
+    );
+    return { object: result.output, usage: result.usage };
+  } catch (err) {
+    log.warn(
+      { ...bindings, err },
+      "structurer-only retry also failed; falling back to full reviewer reroll",
+    );
+    return null;
+  }
+}
+
+/** merge the structurer-only retry's usage into the original Mastra response.
+ * preserves the original response shape so downstream consumers see one
+ * coherent usage object that reflects the actual tokens billed. */
+function augmentResponseWithStructurerRetry<T extends { usage?: StructurerRetryUsage }>(
+  original: T,
+  retry: StructurerRetryResult,
+): T & { object: unknown } {
+  const origUsage = original.usage ?? {};
+  const retryUsage = retry.usage ?? {};
+  const sumOpt = (a?: number, b?: number): number | undefined => {
+    if (a === undefined && b === undefined) return undefined;
+    return (a ?? 0) + (b ?? 0);
+  };
+  return {
+    ...original,
+    object: retry.object,
+    usage: {
+      ...origUsage,
+      totalTokens: sumOpt(origUsage.totalTokens, retryUsage.totalTokens),
+      inputTokens: sumOpt(origUsage.inputTokens, retryUsage.inputTokens),
+      outputTokens: sumOpt(origUsage.outputTokens, retryUsage.outputTokens),
+    },
+  };
+}
+
 async function generateWithStructuredOutputRetry<T>(
   fn: () => Promise<T>,
   bindings: Record<string, unknown> = {},
@@ -356,6 +438,29 @@ export async function runReview(
             { ...logBindings, ...summarizeFailedResponse(r) },
             "structured output produced no object — captured diagnostic snapshot",
           );
+
+          // CHEAP RETRY: structurer-only on the reviewer's prose. The expensive
+          // tool trajectory already ran and produced text — re-running the whole
+          // agent.generate (the existing fallback below) costs ~20× more than
+          // just retrying the structurer on the cached prose. Only fires when
+          // a structuring model is configured AND we actually have prose to
+          // restructure. On failure, falls through to the existing retry path.
+          const proseFromR = (r as { text?: unknown }).text;
+          if (structuringConfig && typeof proseFromR === "string" && proseFromR.length > 0) {
+            const retried = await retryStructurerOnProse(
+              proseFromR,
+              schema,
+              structuringConfig,
+              logBindings,
+            );
+            if (retried) {
+              return augmentResponseWithStructurerRetry(
+                r as { usage?: StructurerRetryUsage },
+                retried,
+              ) as typeof r;
+            }
+          }
+
           const err = new Error(
             "structured output parser returned no object (model likely emitted text outside the JSON block or truncated)",
           );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,12 @@ importers:
       '@mastra/mcp':
         specifier: ^1.7.0
         version: 1.7.0(@mastra/core@1.32.1(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-community/standard-openapi@0.2.9(@standard-community/standard-json@0.3.5(@standard-schema/spec@1.1.0)(@types/json-schema@7.0.15)(quansync@0.2.11)(zod-to-json-schema@3.25.2(zod@4.4.3))(zod@4.4.3))(@standard-schema/spec@1.1.0)(openapi-types@12.1.3)(zod@4.4.3))(@types/json-schema@7.0.15)(express@5.2.1)(openapi-types@12.1.3)(zod@4.4.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(zod@4.4.3)
+      ai:
+        specifier: ^6.0.182
+        version: 6.0.182(zod@4.4.3)
       ai-sdk-ollama:
         specifier: ^3
-        version: 3.8.3(ai@6.0.177(zod@4.4.3))(zod@4.4.3)
+        version: 3.8.3(ai@6.0.182(zod@4.4.3))(zod@4.4.3)
       picomatch:
         specifier: ^4.0.4
         version: 4.0.4
@@ -235,8 +238,8 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
-  '@ai-sdk/gateway@3.0.112':
-    resolution: {integrity: sha512-jiBao9pR4owWyjo0BnuNc7WSQBGOD0thysE4AFgZXaG+zMFbISQXUkJr7ePw/phBvePy7jE5FSA2Lf7lwqUiiQ==}
+  '@ai-sdk/gateway@3.0.114':
+    resolution: {integrity: sha512-MqkZ5sd+qiq6RgIxELkoFQXg2/JwK+WCMaot7U+rtrZpWJl3fSyYvc28SC03b256o4F7OXjQtdjTqs81B2w+dA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -1136,8 +1139,8 @@ packages:
     peerDependencies:
       ai: ^6.0.154
 
-  ai@6.0.177:
-    resolution: {integrity: sha512-1xQtbeWwNcLyyM86ixZhkKvT+WRXc1lvarIKqPVtsyn8F9NDikwUMBqYu+aQKDgMht50SMXh4qboYuU8MeHZZA==}
+  ai@6.0.182:
+    resolution: {integrity: sha512-ooJdziFjYrYRcsCx107roqA8gDTI3P82nUfroNWIhVvwrkYzEN3W1l50YK+XNqkUew8AiimaW0/SLBewRXMuHQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -2926,7 +2929,7 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
       zod: 4.4.3
 
-  '@ai-sdk/gateway@3.0.112(zod@4.4.3)':
+  '@ai-sdk/gateway@3.0.114(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
@@ -3883,19 +3886,19 @@ snapshots:
 
   agent-base@7.1.4: {}
 
-  ai-sdk-ollama@3.8.3(ai@6.0.177(zod@4.4.3))(zod@4.4.3):
+  ai-sdk-ollama@3.8.3(ai@6.0.182(zod@4.4.3))(zod@4.4.3):
     dependencies:
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.26(zod@4.4.3)
-      ai: 6.0.177(zod@4.4.3)
+      ai: 6.0.182(zod@4.4.3)
       jsonrepair: 3.14.0
       ollama: 0.6.3
     transitivePeerDependencies:
       - zod
 
-  ai@6.0.177(zod@4.4.3):
+  ai@6.0.182(zod@4.4.3):
     dependencies:
-      '@ai-sdk/gateway': 3.0.112(zod@4.4.3)
+      '@ai-sdk/gateway': 3.0.114(zod@4.4.3)
       '@ai-sdk/provider': 3.0.10
       '@ai-sdk/provider-utils': 4.0.27(zod@4.4.3)
       '@opentelemetry/api': 1.9.0


### PR DESCRIPTION
## Why

When `agent.generate({structuredOutput: {model: structurer}})` returns with `r.object === undefined` — the failure mode that killed BuildFind PR #510's review — the existing retry path re-runs the **entire agent trajectory**. Reviewer tools, multi-step loop, structurer, all over. The agent's prose (which is fine!) gets thrown away, and we pay ~$0.10 of deepseek-v4-flash time for the chance that next try the structurer parses it.

The reviewer's prose was fine. **Only the structurer step failed.** Retrying just that step on the cached prose is ~$0.005 — **20× cheaper** — and the cheap retry happens *before* the expensive reroll, not in place of it. If the cheap retry works, the expensive one never runs. If the cheap retry fails too, we fall through to the existing behavior. Pure upside.

## The fix

When `r.object` is undefined and a structuring model is configured and `r.text` is non-empty:

1. Call `generateText({model: structurer, output: Output.object({schema}), prompt: r.text})` via ai-sdk directly (`ai` added as a direct dep).
2. If it succeeds: augment the original response with the recovered object + summed token usage, return.
3. If it throws: log warn, fall through to the existing expensive retry path. Worst case is unchanged.

Token accounting: the structurer-only retry's `usage` is summed into the original response's `usage`. Without this you'd lose ~5-30 tokens per retry from the cost dashboards.

## When this fires

| Condition | Behavior |
|---|---|
| Primary structurer succeeds | Unchanged |
| Primary structurer returns no object, **structuring model configured, prose available** | **NEW: cheap retry on cached prose** |
| Primary structurer returns no object, no structuring model (legacy single-model path) | Unchanged (existing 2-attempt retry) |
| Primary structurer returns no object, reviewer emitted empty prose | Unchanged (existing 2-attempt retry) |
| Cheap retry succeeds | Return augmented response, skip expensive reroll |
| Cheap retry fails | Fall through to expensive reroll (existing behavior) |

The cheap path is **strictly additive** — it doesn't replace the existing retry, it inserts a cheaper attempt before it.

## Tests (6 new)

| Test | What it proves |
|---|---|
| uses structurer-only retry on cached prose instead of rerunning the full agent | `agent.generate` called 1×, `generateText` called 1× when structurer recovers |
| falls back to the full agent reroll when structurer-only retry also fails | `agent.generate` called 2×, `generateText` called 1× → succeeds |
| does NOT attempt structurer-only retry when no structuring model is configured | `generateText` never called; legacy 2-attempt retry still works |
| does NOT attempt structurer-only retry when reviewer returned no prose | Empty `r.text` → skip cheap retry |
| merges structurer-only retry token usage into the reported total | `tokenCount` = agent tokens + retry tokens |
| still throws when both structurer-only retries fail across both expensive attempts | Each expensive attempt tries the cheap retry once; both attempts × both retries fail → propagates the structured-output error |

Plus all existing review.test cases continue to pass (51 total in the review test file, 6 new + 45 existing).

## Test plan

- [x] **review.test.ts**: 51 passing
- [x] Full suite: **932 passing**
- [x] All packages build clean (`pnpm -r build`)
- [x] No lint errors (initial commit had two deprecation warnings; switched to `generateText({output: Output.object()})` per ai-sdk v6 conventions)

## Related to

- BuildFind PR #510 production failure (the deepseek-v4-flash STRUCTURED_OUTPUT_SCHEMA_VALIDATION_FAILED that prompted this work)
- #180 (consensus graceful degradation) — pair fix. This PR makes individual passes more likely to succeed; #180 makes the review more likely to complete even when one pass dies. Together, the BuildFind failure mode becomes either invisible (cheap retry succeeds) or non-fatal (one surviving pass still produces a review).

## What this isn't

- **Not a behavior change for healthy runs.** When `agent.generate` returns a valid object on the first try, nothing changes.
- **Not a bypass of the existing retry.** The cheap retry happens BEFORE the expensive one. If the cheap retry fails, the expensive retry still fires, same as before.
- **Not a replacement for the structuring model split.** This PR makes the existing split more cost-efficient by not throwing away the reviewer's prose when the structurer trips.