### PR TITLE
ci: realign self-review workflow with downstream baseline

### DIFF
--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -28,11 +28,9 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
         env:
-          # mastra's native requesty provider reads this directly; no base-url
-          # wiring needed when the model id already starts with "requesty/"
+          # provider keys — each gateway reads its own
           REQUESTY_API_KEY: ${{ secrets.REQUESTY_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
-
           # ollama cloud — bearer auth via Authorization header. set
           # RUSTY_OLLAMA_BASE_URL=https://ollama.com so any `ollama/*` model
           # in RUSTY_REVIEW_MODELS routes via the hosted endpoint instead of
@@ -40,32 +38,32 @@ jobs:
           RUSTY_OLLAMA_BASE_URL: https://ollama.com
           RUSTY_OLLAMA_API_KEY: ${{ secrets.OLLAMA_API_KEY }}
 
-          RUSTY_LLM_MODEL: requesty/google/gemini-3.1-flash-lite-preview
+          RUSTY_LLM_MODEL: openrouter/google/gemini-3.1-flash-lite-preview
           RUSTY_REVIEW_TEMPERATURE: "1"
-          # cross-vendor consensus. deepseek-v4-flash via OpenRouter
-          # (cheaper, shallower variant of v4-pro — v4-pro on Novita /
-          # Requesty's fireworks route was 4× direct API price and
-          # tool-looped at MAX_STEPS=10; see Model + Provider Routing
-          # Notes in README). grok via Requesty. kimi via Ollama Cloud.
+          # cross-vendor consensus mirroring the downstream BuildFind baseline.
+          # deepseek-v4-flash + kimi via Ollama Cloud (direct routing, no
+          # proxy markup), grok via OpenRouter (`x-ai/...` is OpenRouter's
+          # naming convention; Requesty uses `xai/...` — they're not
+          # interchangeable, see Model + Provider Routing Notes in README).
           RUSTY_REVIEW_MODELS: >-
-            openrouter/deepseek/deepseek-v4-flash,
-            requesty/xai/grok-4.3,
+            ollama/deepseek-v4-flash:cloud,
+            openrouter/x-ai/grok-4.3,
             ollama/kimi-k2.6:cloud
           RUSTY_REVIEW_TEMPERATURES: "0.3,0.3,1"
           RUSTY_REVIEW_ADAPTIVE_PASSES: "true"
-          RUSTY_LLM_STRUCTURING_MODEL: requesty/google/gemini-3.1-flash-lite-preview
+          RUSTY_LLM_STRUCTURING_MODEL: openrouter/google/gemini-3.1-flash-lite-preview
           # cap tool-using trajectories so tool-happy models (Kimi/Anthropic)
           # can't terminate with finishReason="tool-calls" and zero text. the
           # final allowed step gets toolChoice="none" so the model has to emit
           # the structured-output JSON. see #152.
           RUSTY_LLM_MAX_STEPS: "10"
           RUSTY_JUDGE_ENABLED: "true"
-          # judge has no tools (single call per PR, no tool-loop risk),
-          # so the Novita-routed v4-pro price premium is bounded — one call
-          # is fine even though slot 1 had to move off v4-pro to v4-flash.
-          RUSTY_JUDGE_MODEL: openrouter/deepseek/deepseek-v4-pro
+          # judge has no tools (single call per PR, no tool-loop risk). using
+          # deepseek-v4-flash on Ollama Cloud — cheaper than the v4-pro route
+          # and the flash variant is plenty for the structured-scoring task.
+          RUSTY_JUDGE_MODEL: ollama/deepseek-v4-flash:cloud
           RUSTY_JUDGE_TEMPERATURE: "0.1"
-          RUSTY_LLM_TRIAGE_MODEL: requesty/google/gemini-3.1-flash-lite-preview
+          RUSTY_LLM_TRIAGE_MODEL: openrouter/google/gemini-3.1-flash-lite-preview
           RUSTY_TRIAGE_TEMPERATURE: "0"
           RUSTY_REVIEW_STYLE: balanced
           RUSTY_FAIL_ON_CRITICAL: "true"
@@ -74,12 +72,8 @@ jobs:
           RUSTY_GRAPH_CONTEXT: "true"
           RUSTY_GRAPH_CONTEXT_TOKEN_BUDGET: "2000"
           RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES: "8"
-          # collect cross-model overlap data on every self-review. each
-          # consensus pass logs its raw findings (file/line/severity/
-          # message) before clustering, so we can measure agreementRate
-          # empirically and tune cluster.ts thresholds. needs LOG_LEVEL=debug
-          # because the per-pass payload is bigger than info-level deserves.
-          # see CONSENSUS-QUALITY-WRITEUP.md for the experiments this
-          # unblocks.
-          RUSTY_LOG_RAW_FINDINGS: "true"
-          LOG_LEVEL: debug
+          # per-step finishReason / toolCallCount logging. Surfaces tool-loop
+          # behavior (e.g. the deepseek-v4-pro on Fireworks pathology that
+          # exhausted MAX_STEPS=10 with verification searches). emits at info
+          # level so no LOG_LEVEL override needed.
+          RUSTY_LOG_AGENT_STEPS: "true"

--- a/.github/workflows/rusty-bot-review.yml
+++ b/.github/workflows/rusty-bot-review.yml
@@ -74,6 +74,11 @@ jobs:
           RUSTY_GRAPH_CONTEXT_MAX_CANDIDATES: "8"
           # per-step finishReason / toolCallCount logging. Surfaces tool-loop
           # behavior (e.g. the deepseek-v4-pro on Fireworks pathology that
-          # exhausted MAX_STEPS=10 with verification searches). emits at info
-          # level so no LOG_LEVEL override needed.
+          # exhausted MAX_STEPS=10 with verification searches).
           RUSTY_LOG_AGENT_STEPS: "true"
+          # consensus-quality experiment: dump per-pass raw findings BEFORE
+          # clustering so we can tell whether models are producing different
+          # findings (hard clustering job) vs. the same ones (easy job).
+          # see CONSENSUS-QUALITY-WRITEUP.md.
+          RUSTY_LOG_RAW_FINDINGS: "true"
+          LOG_LEVEL: debug

--- a/packages/core/src/__tests__/formatter.test.ts
+++ b/packages/core/src/__tests__/formatter.test.ts
@@ -177,6 +177,95 @@ describe("formatSummaryComment", () => {
     expect(result).toContain("Reviewed by openai/gpt-5-mini · 12345 tokens");
   });
 
+  it("credits only successfulPassModels when a configured pass failed", () => {
+    // exactly the BuildFind #527 case: configured 3 passes, openrouter/xai/grok-4.3
+    // is an invalid model id → pass 2 dies. The summary should NOT credit grok.
+    const review = makeReview({
+      modelUsed: "ollama/deepseek-v4-flash:cloud",
+      tokenCount: 112622,
+      consensusMetadata: {
+        passes: 3,
+        threshold: 2,
+        effectiveThreshold: 2,
+        degraded: false,
+        agreementRate: 0,
+        recommendationElevated: false,
+        passRecommendations: ["address_before_merge", "address_before_merge"],
+        passModels: [
+          "ollama/deepseek-v4-flash:cloud",
+          "openrouter/xai/grok-4.3",
+          "ollama/kimi-k2.6:cloud",
+        ],
+        successfulPassModels: ["ollama/deepseek-v4-flash:cloud", "ollama/kimi-k2.6:cloud"],
+        failedPasses: 1,
+      },
+    });
+
+    const footerLine = formatSummaryComment(review)
+      .split("\n")
+      .find((l) => l.startsWith("Reviewed by "));
+    expect(footerLine).toBeDefined();
+    expect(footerLine).toContain("ollama/deepseek-v4-flash:cloud");
+    expect(footerLine).toContain("ollama/kimi-k2.6:cloud");
+    // the failed model must NOT appear in the credit line
+    expect(footerLine).not.toContain("openrouter/xai/grok-4.3");
+    // and the consensus annotation should note the failure
+    expect(footerLine).toContain("consensus 3 passes (1 failed)");
+  });
+
+  it("falls back to passModels for older metadata without successfulPassModels", () => {
+    // backward-compat: existing serialized metadata predating the new field
+    // should still render — fall back to passModels (current behavior preserved).
+    const review = makeReview({
+      modelUsed: "openai/gpt-5-mini",
+      tokenCount: 30000,
+      consensusMetadata: {
+        passes: 2,
+        threshold: 2,
+        effectiveThreshold: 2,
+        degraded: false,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good", "looks_good"],
+        passModels: ["openai/gpt-5-mini", "anthropic/claude-sonnet-4-6"],
+        // successfulPassModels intentionally absent
+        failedPasses: 0,
+      },
+    });
+
+    const result = formatSummaryComment(review);
+
+    expect(result).toContain("Reviewed by openai/gpt-5-mini, anthropic/claude-sonnet-4-6");
+  });
+
+  it("annotates degraded reviews in the consensus footer line", () => {
+    const review = makeReview({
+      modelUsed: "openai/gpt-5-mini",
+      tokenCount: 20000,
+      consensusMetadata: {
+        passes: 2,
+        threshold: 2,
+        effectiveThreshold: 1,
+        degraded: true,
+        agreementRate: 1,
+        recommendationElevated: false,
+        passRecommendations: ["looks_good"],
+        passModels: ["openai/gpt-5-mini", "anthropic/claude-sonnet-4-6"],
+        successfulPassModels: ["openai/gpt-5-mini"],
+        failedPasses: 1,
+      },
+    });
+
+    const footerLine = formatSummaryComment(review)
+      .split("\n")
+      .find((l) => l.startsWith("Reviewed by "));
+    expect(footerLine).toBeDefined();
+    expect(footerLine).toContain("Reviewed by openai/gpt-5-mini");
+    expect(footerLine).not.toContain("claude-sonnet");
+    expect(footerLine).toContain("consensus 2 passes (1 failed)");
+    expect(footerLine).toContain("degraded — judge filtering only");
+  });
+
   it("renders a clean review with zero findings", () => {
     const review = makeReview({
       recommendation: "looks_good",

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -320,6 +320,14 @@ export async function runConsensusReview(
       recommendationElevated,
       passRecommendations,
       passModels: passModelConfigs.map((m) => m.displayName),
+      // only credit models whose pass actually produced a result. an upstream
+      // failure (e.g. an invalid model id on openrouter, a 422 from the
+      // provider, a timeout) leaves the slot in `settled` as rejected — we
+      // omit those from successfulPassModels so the formatter doesn't
+      // attribute the review to a model that never ran.
+      successfulPassModels: settled
+        .map((s, i) => (s.status === "fulfilled" ? passModelConfigs[i].displayName : null))
+        .filter((m): m is string => m !== null),
       ...(passPlan.reason ? { passPlanReason: passPlan.reason } : {}),
       failedPasses,
     },

--- a/packages/core/src/formatter/summary.ts
+++ b/packages/core/src/formatter/summary.ts
@@ -333,11 +333,15 @@ export function formatSummaryComment(
   lines.push("");
   lines.push("---");
   lines.push("");
-  const passModels = review.consensusMetadata?.passModels;
+  // prefer successfulPassModels (only models whose pass actually returned a
+  // result) so failed passes aren't credited. fall back to passModels for
+  // historical metadata that pre-dates the field, then to review.modelUsed.
+  const successfulModels = review.consensusMetadata?.successfulPassModels;
+  const configuredModels = review.consensusMetadata?.passModels;
+  const reviewerSource =
+    successfulModels && successfulModels.length > 0 ? successfulModels : (configuredModels ?? []);
   const reviewerLabel =
-    passModels && passModels.length > 0
-      ? Array.from(new Set(passModels)).join(", ")
-      : review.modelUsed;
+    reviewerSource.length > 0 ? Array.from(new Set(reviewerSource)).join(", ") : review.modelUsed;
   const parts = [`Reviewed by ${reviewerLabel} · ${review.tokenCount} tokens (review)`];
   if (review.judgeTokenCount !== undefined) {
     parts.push(`${review.judgeTokenCount} tokens (judge)`);
@@ -347,10 +351,17 @@ export function formatSummaryComment(
   }
   if (review.consensusMetadata) {
     const cm = review.consensusMetadata;
-    parts.push(`consensus ${cm.passes} passes`);
+    parts.push(
+      cm.failedPasses > 0
+        ? `consensus ${cm.passes} passes (${cm.failedPasses} failed)`
+        : `consensus ${cm.passes} passes`,
+    );
     parts.push(`${Math.round(cm.agreementRate * 100)}% agreement`);
     if (cm.recommendationElevated) {
       parts.push("recommendation elevated from pass votes");
+    }
+    if (cm.degraded) {
+      parts.push("degraded — judge filtering only");
     }
   }
   if (review.openGrepStats?.available && review.openGrepStats.findingCount > 0) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -44,7 +44,16 @@ export interface ConsensusMetadata {
   agreementRate: number;
   recommendationElevated: boolean;
   passRecommendations: Recommendation[];
+  /** display names of every configured pass model, in slot order — includes
+   * models whose pass failed. Use `successfulPassModels` for user-facing
+   * attribution where credit should reflect what actually ran. */
   passModels?: string[];
+  /** display names of pass models that produced a result (subset of
+   * `passModels` in the same relative order). When `failedPasses > 0`, this
+   * is what consumers should render as "reviewers" — `passModels` alone
+   * would credit models whose call threw. Optional for backward compat with
+   * older serialized metadata; consensus.ts always populates it. */
+  successfulPassModels?: string[];
   passPlanReason?: string;
   /** number of consensus passes that threw before producing a result */
   failedPasses: number;


### PR DESCRIPTION
## Summary

Align the bot's self-review workflow with the downstream baseline so the two environments exercise the same model routing.

- Slot 1 review pass: `openrouter/deepseek/deepseek-v4-flash` → `ollama/deepseek-v4-flash:cloud` (direct route, no OpenRouter→Novita markup)
- Slot 2 review pass: `requesty/xai/grok-4.3` → `openrouter/x-ai/grok-4.3` (OpenRouter uses `x-ai/`, Requesty uses `xai/` — not interchangeable)
- Slot 3 review pass: `ollama/kimi-k2.6:cloud` (unchanged)
- Judge: `openrouter/deepseek/deepseek-v4-pro` → `ollama/deepseek-v4-flash:cloud` (flash variant is enough for structured scoring; cheaper)
- Structuring / triage / single-pass model: Requesty gemini-flash → `openrouter/google/gemini-3.1-flash-lite-preview`
- Adds `RUSTY_LOG_AGENT_STEPS=true` so per-step `finishReason` / `toolCallCount` data keeps flowing for the Kimi/tool-loop diagnosis
- Keeps `RUSTY_LOG_RAW_FINDINGS=true` and `LOG_LEVEL=debug` for the ongoing consensus-quality experiment

## Test plan

- [ ] Open a PR after merge and confirm the review posts successfully with the three new reviewer models attributed in "Reviewed by"
- [ ] Confirm `RUSTY_LOG_AGENT_STEPS` and raw-findings output appears in workflow logs
- [ ] Confirm no `not a valid model ID` errors (verifies the `x-ai/grok-4.3` slug works on OpenRouter)