### PR TITLE
fix(review): pin final-step prose voice so the summary isn't the model's investigation log

### DIFF
--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -608,8 +608,29 @@ describe("RUSTY_LLM_MAX_STEPS", () => {
 
     const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
     const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
-    expect(prepareStep({ stepNumber: 4 })).toEqual({ toolChoice: "none", activeTools: [] });
-    expect(prepareStep({ stepNumber: 99 })).toEqual({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 4 })).toMatchObject({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 99 })).toMatchObject({ toolChoice: "none", activeTools: [] });
+  });
+
+  it("prepareStep injects a final-step system addendum to pin review voice", async () => {
+    process.env.RUSTY_LLM_MAX_STEPS = "5";
+    generateMock.mockResolvedValueOnce(makeValidResponse());
+
+    await runReview(config, "diff", prMetadata);
+
+    const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
+    const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
+
+    // non-final steps return undefined → use the agent's default system prompt
+    expect(prepareStep({ stepNumber: 0 })).toBeUndefined();
+
+    // final step replaces the system prompt with one that includes the addendum
+    const finalResult = prepareStep({ stepNumber: 4 }) as { system: string };
+    expect(typeof finalResult.system).toBe("string");
+    expect(finalResult.system).toContain("FINAL STEP");
+    expect(finalResult.system).toContain("tool budget");
+    // pins the failure mode this addendum exists to prevent
+    expect(finalResult.system).toContain("investigation is in progress");
   });
 
   it("prepareStep with maxSteps=1 forces tool-free mode on step 0 (the only step)", async () => {
@@ -620,7 +641,7 @@ describe("RUSTY_LLM_MAX_STEPS", () => {
 
     const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
     const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
-    expect(prepareStep({ stepNumber: 0 })).toEqual({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 0 })).toMatchObject({ toolChoice: "none", activeTools: [] });
   });
 
   it("floors fractional values", async () => {

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -87,6 +87,25 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
+// addendum to the system prompt for the FINAL allowed step. fires together with
+// `toolChoice="none"` + `activeTools: []`. without it, tool-happy models that
+// burned their step budget on verification searches (deepseek-v4-flash on
+// Ollama Cloud, deepseek-v4-pro on Fireworks) emit structured output whose
+// `summary` field reports the model's own investigation state — e.g. "Investigation
+// is currently in progress to verify integration with X and Y" — instead of an
+// actual review summary. the reminder pins the model to the developer-facing
+// review voice for the final emission.
+const FINAL_STEP_PROMPT_ADDENDUM = [
+  "",
+  "## FINAL STEP",
+  "",
+  "Your tool budget is now exhausted. Emit your final structured review based on the investigation already in your message history.",
+  "",
+  'The `summary` field must read as a code review for the developer: describe what the PR does and any concrete issues you found. Do NOT describe your own investigation process. Do NOT write phrases like "investigation is in progress", "verification pending", "I am still checking", or similar — your investigation is over.',
+  "",
+  "If you could not fully verify something, omit that speculative finding. Do not include findings you are unsure about.",
+].join("\n");
+
 // caps how many tool-use rounds an agent can run before mastra forces it to
 // produce a final answer. unset = mastra's default. matters most for Anthropic
 // models, which can otherwise fan out parallel tool calls indefinitely and
@@ -400,12 +419,18 @@ export async function runReview(
   // otherwise tool-happy models (Anthropic in particular) burn the whole budget
   // on tool calls and end with finishReason="tool-calls" and no text — which
   // produces no structured output and the pass fails. stripping tools on the
-  // last allowed step guarantees the model emits a final answer.
+  // last allowed step guarantees the model emits a final answer. the system
+  // override pins the prose voice so the model doesn't emit its own investigation
+  // state as the summary (see FINAL_STEP_PROMPT_ADDENDUM comment).
   const prepareStep =
     maxSteps !== undefined
       ? ({ stepNumber }: { stepNumber: number }) => {
           if (stepNumber >= maxSteps - 1) {
-            return { toolChoice: "none" as const, activeTools: [] };
+            return {
+              toolChoice: "none" as const,
+              activeTools: [],
+              system: `${systemPrompt}${FINAL_STEP_PROMPT_ADDENDUM}`,
+            };
           }
         }
       : undefined;


### PR DESCRIPTION
## Summary

When the reviewer agent hits `RUSTY_LLM_MAX_STEPS` and `prepareStep` forces `toolChoice="none"` on the final step, the model still gets to write whatever prose it wants for the `summary` field. Tool-happy models that burned their budget on verification searches have been emitting **their own investigation state** as the summary — e.g.

> "Investigation is currently in progress to verify integration with useReorderWorkboardColumns and useDndEvents."

…instead of a code review. The structured output JSON still validates and `findings: []` is technically valid, so the failure passes silently through consensus and the user just sees a confusing meta-narrative.

## Fix

Override the system prompt for the final allowed step with the original prompt **plus an addendum** that:

1. Tells the model its tool budget is over (mirroring the `toolChoice="none"` reality)
2. Pins the prose voice to "code review for the developer"
3. Names the failure-mode phrases explicitly (`investigation is in progress`, `verification pending`, `I am still checking`) so the model knows to avoid them
4. Tells the model to omit speculative findings it couldn't verify

Surgical — only fires on the last step when step-capping is enabled. No new env vars, no new agent logic, no change to the consensus or judge layers.

## Test plan

- [x] `pnpm --filter @rusty-bot/core test review.test.ts` — 778 tests pass; new `prepareStep injects a final-step system addendum` test added
- [x] `pnpm test` — 949 tests pass across all 34 files
- [x] `pnpm -r build` — all packages typecheck
- [ ] Watch for the failure mode on subsequent PRs: future occurrences should produce a normal review summary even when a model exhausts MAX_STEPS

## Context

Observed on the downstream PR run that landed shortly after the `ci/mirror-baseline` config rollout: `ollama/deepseek-v4-flash:cloud` consumed 7 of 10 steps on `search-code` verification queries, then emitted the investigation-state summary above. Same pattern previously seen with `deepseek-v4-pro` on Fireworks. The fix is provider-agnostic — anything that can hit the step cap benefits.