### PR TITLE
fix(prior-context): carry forward filesReviewed across incremental re-reviews

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -570,4 +570,29 @@ describe("buildUserMessage with priorContext", () => {
     const msg = buildWithPriorContext({ ...priorContext, findings: [] });
     expect(msg).not.toContain("Issues already surfaced");
   });
+
+  it("renders the files-already-reviewed section when filesReviewed is populated", () => {
+    const msg = buildWithPriorContext({
+      ...priorContext,
+      filesReviewed: [
+        "packages/ui/src/components/StopButton.tsx",
+        "apps/web/src/features/live-viewer/hooks.ts",
+      ],
+    });
+    expect(msg).toContain("Files already covered by the prior review");
+    expect(msg).toContain("`packages/ui/src/components/StopButton.tsx`");
+    expect(msg).toContain("`apps/web/src/features/live-viewer/hooks.ts`");
+    // pin the failure-mode-fix wording so the model knows not to flag missing ticket scope
+    expect(msg).toContain("do NOT flag it as missing");
+  });
+
+  it("omits the files-already-reviewed section when filesReviewed is missing (legacy markers)", () => {
+    const msg = buildWithPriorContext(priorContext);
+    expect(msg).not.toContain("Files already covered by the prior review");
+  });
+
+  it("omits the files-already-reviewed section when filesReviewed is an empty array", () => {
+    const msg = buildWithPriorContext({ ...priorContext, filesReviewed: [] });
+    expect(msg).not.toContain("Files already covered by the prior review");
+  });
 });

--- a/packages/core/src/__tests__/prior-context.test.ts
+++ b/packages/core/src/__tests__/prior-context.test.ts
@@ -43,6 +43,36 @@ describe("encode/extract roundtrip", () => {
     const decoded = extractPriorReviewContext(encodePriorReviewContext(ctx));
     expect(decoded?.recommendation).toBe("looks_good");
   });
+
+  it("roundtrips filesReviewed when present", () => {
+    const ctx = makeContext({ filesReviewed: ["src/a.ts", "src/b.ts"] });
+    const decoded = extractPriorReviewContext(encodePriorReviewContext(ctx));
+    expect(decoded?.filesReviewed).toEqual(["src/a.ts", "src/b.ts"]);
+  });
+
+  it("omits filesReviewed from the encoded payload when empty (keeps markers small)", () => {
+    const ctx = makeContext({ filesReviewed: [] });
+    const marker = encodePriorReviewContext(ctx);
+    // pull the base64 out and inspect the JSON directly — filesReviewed should not be a key
+    const m = /<!-- rusty-bot:context:([A-Za-z0-9+/=]+) -->/.exec(marker);
+    expect(m).not.toBeNull();
+    const json = Buffer.from(m![1], "base64").toString("utf-8");
+    expect(JSON.parse(json)).not.toHaveProperty("filesReviewed");
+  });
+
+  it("decodes legacy markers without filesReviewed as undefined (backward compat)", () => {
+    const legacy = Buffer.from(
+      JSON.stringify({
+        summary: "old marker",
+        recommendation: "looks_good",
+        findings: [],
+      }),
+      "utf-8",
+    ).toString("base64");
+    const decoded = extractPriorReviewContext(`<!-- rusty-bot:context:${legacy} -->`);
+    expect(decoded).not.toBeNull();
+    expect(decoded?.filesReviewed).toBeUndefined();
+  });
 });
 
 describe("encodePriorReviewContext truncation", () => {
@@ -88,6 +118,21 @@ describe("encodePriorReviewContext truncation", () => {
     );
     expect(decoded?.findings[0].message.length).toBeLessThan(huge.length);
     expect(decoded?.findings[0].message.endsWith("…")).toBe(true);
+  });
+
+  it("caps filesReviewed at FILES_REVIEWED_COUNT_CAP entries", () => {
+    const filesReviewed = Array.from(
+      { length: PRIOR_CONTEXT_LIMITS.filesReviewedCountCap + 25 },
+      (_, i) => `src/f${i}.ts`,
+    );
+    const decoded = extractPriorReviewContext(
+      encodePriorReviewContext(makeContext({ filesReviewed })),
+    );
+    expect(decoded?.filesReviewed).toHaveLength(PRIOR_CONTEXT_LIMITS.filesReviewedCountCap);
+    expect(decoded?.filesReviewed?.[0]).toBe("src/f0.ts");
+    expect(decoded?.filesReviewed?.at(-1)).toBe(
+      `src/f${PRIOR_CONTEXT_LIMITS.filesReviewedCountCap - 1}.ts`,
+    );
   });
 });
 
@@ -136,6 +181,32 @@ describe("extractPriorReviewContext failure modes", () => {
     ).toString("base64");
     expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
   });
+
+  it("returns null when filesReviewed is present but not an array", () => {
+    const bad = Buffer.from(
+      JSON.stringify({
+        summary: "x",
+        recommendation: "looks_good",
+        findings: [],
+        filesReviewed: "src/a.ts",
+      }),
+      "utf-8",
+    ).toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
+
+  it("returns null when filesReviewed contains non-strings", () => {
+    const bad = Buffer.from(
+      JSON.stringify({
+        summary: "x",
+        recommendation: "looks_good",
+        findings: [],
+        filesReviewed: ["ok.ts", 42],
+      }),
+      "utf-8",
+    ).toString("base64");
+    expect(extractPriorReviewContext(`<!-- rusty-bot:context:${bad} -->`)).toBeNull();
+  });
 });
 
 describe("buildPriorContextFromReview", () => {
@@ -173,6 +244,7 @@ describe("buildPriorContextFromReview", () => {
         message: "missing csrf check",
       },
     ]);
+    expect(ctx.filesReviewed).toEqual(["src/auth.ts"]);
   });
 
   it("produces an empty findings array when the review has none", () => {
@@ -188,5 +260,26 @@ describe("buildPriorContextFromReview", () => {
       tokenCount: 0,
     };
     expect(buildPriorContextFromReview(review).findings).toEqual([]);
+  });
+
+  it("carries forward filesReviewed verbatim from the review result", () => {
+    const review: ReviewResult = {
+      summary: "PR-wide summary",
+      recommendation: "looks_good",
+      findings: [],
+      observations: [],
+      ticketCompliance: [],
+      missingTests: [],
+      filesReviewed: [
+        "packages/ui/src/components/StopButton.tsx",
+        "apps/web/src/features/live-viewer/hooks.ts",
+      ],
+      modelUsed: "test-model",
+      tokenCount: 0,
+    };
+    expect(buildPriorContextFromReview(review).filesReviewed).toEqual([
+      "packages/ui/src/components/StopButton.tsx",
+      "apps/web/src/features/live-viewer/hooks.ts",
+    ]);
   });
 });

--- a/packages/core/src/agent/prior-context.ts
+++ b/packages/core/src/agent/prior-context.ts
@@ -7,6 +7,7 @@ export const PRIOR_CONTEXT_MARKER_RE = /<!--\s*rusty-bot:context:([A-Za-z0-9+/=]
 const SUMMARY_CHAR_CAP = 4_000;
 const FINDING_MESSAGE_CHAR_CAP = 250;
 const FINDINGS_COUNT_CAP = 50;
+const FILES_REVIEWED_COUNT_CAP = 100;
 const TRUNCATED_SUFFIX = "\n\n[truncated]";
 const ELLIPSIS = "…";
 
@@ -34,6 +35,7 @@ export function buildPriorContextFromReview(review: ReviewResult): PriorReviewCo
       severity: f.severity,
       message: f.message,
     })),
+    filesReviewed: review.filesReviewed,
   };
 }
 
@@ -48,6 +50,9 @@ export function encodePriorReviewContext(ctx: PriorReviewContext): string {
       severity: f.severity,
       message: truncateMessage(f.message),
     })),
+    ...(ctx.filesReviewed && ctx.filesReviewed.length > 0
+      ? { filesReviewed: ctx.filesReviewed.slice(0, FILES_REVIEWED_COUNT_CAP) }
+      : {}),
   };
   const json = JSON.stringify(truncated);
   const b64 = Buffer.from(json, "utf-8").toString("base64");
@@ -73,7 +78,15 @@ function isContext(value: unknown): value is PriorReviewContext {
   if (typeof v.recommendation !== "string") return false;
   if (!RECOMMENDATIONS.has(v.recommendation)) return false;
   if (!Array.isArray(v.findings)) return false;
-  return v.findings.every(isFinding);
+  if (!v.findings.every(isFinding)) return false;
+  // filesReviewed is optional (older markers don't have it); when present must
+  // be an array of strings — anything else means the payload was tampered with
+  // or produced by a buggy encoder, both of which should fall back to null.
+  if (v.filesReviewed !== undefined) {
+    if (!Array.isArray(v.filesReviewed)) return false;
+    if (!v.filesReviewed.every((p) => typeof p === "string")) return false;
+  }
+  return true;
 }
 
 /** extract a prior-context marker from a comment body. returns null on absence or any malformedness. */
@@ -93,4 +106,5 @@ export const PRIOR_CONTEXT_LIMITS = {
   summaryCharCap: SUMMARY_CHAR_CAP,
   findingMessageCharCap: FINDING_MESSAGE_CHAR_CAP,
   findingsCountCap: FINDINGS_COUNT_CAP,
+  filesReviewedCountCap: FILES_REVIEWED_COUNT_CAP,
 } as const;

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -208,6 +208,17 @@ function buildPriorContextSection(ctx: PriorReviewContext): string {
 
   parts.push(`\n**Previous recommendation:** ${ctx.recommendation}`);
 
+  if (ctx.filesReviewed && ctx.filesReviewed.length > 0) {
+    parts.push(
+      "\n**Files already covered by the prior review** (work in these paths has already been evaluated; " +
+        "if a linked ticket describes work in one of them, assume it was reviewed in an earlier commit and " +
+        "do NOT flag it as missing from this PR):",
+    );
+    for (const path of ctx.filesReviewed) {
+      parts.push(`- \`${path}\``);
+    }
+  }
+
   if (ctx.findings.length > 0) {
     parts.push(
       "\n**Issues already surfaced** (do NOT re-raise unless this commit changes the underlying code; " +

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -153,6 +153,12 @@ export interface PriorReviewContext {
   summary: string;
   recommendation: Recommendation;
   findings: PriorReviewContextFinding[];
+  /** file paths covered by the prior review pass. lets the next incremental
+   * re-review know which work was already evaluated, so it doesn't flag features
+   * from linked tickets as "missing" when those features landed in earlier
+   * commits and were already approved. optional for backward compat with markers
+   * encoded before this field existed; decoders treat missing as undefined. */
+  filesReviewed?: string[];
 }
 
 export interface Hunk {


### PR DESCRIPTION
## Summary

`PriorReviewContext` (the payload in the bot's hidden HTML comment marker, read by the next incremental review) only carries summary + recommendation + findings. It does **not** carry the list of files that were reviewed.

This produces a real failure mode on multi-commit PRs:

1. Commit A introduces a feature (e.g. the Stop button), reviewed clean
2. Commit B is small (e.g. a version bump)
3. The bot's incremental re-review only sees commit B's diff
4. With no signal that the Stop button work was already covered, and the linked ticket still describing "Add Stop button", the model concludes **"this PR fails to deliver the ticket"** and writes that into the summary
5. The contaminated summary becomes the prior context for the next re-review → propagates

Observed in the wild on a follow-up commit. Surface symptom: a `looks_good` recommendation paired with a summary saying *"fails to include the 'Stop button' feature … fails to implement requested frontend test infrastructure (Vitest/RTL)"*. The PR had delivered both — in an earlier commit.

## Fix

- Add optional `filesReviewed?: string[]` to `PriorReviewContext` (optional → legacy markers decode as undefined)
- Populate it from `review.filesReviewed` in `buildPriorContextFromReview`
- Cap at 100 entries in the encoder so very large PRs don't blow out the marker
- Strict decoder: when present, must be `Array<string>`; otherwise return null (same posture as the other fields)
- Render a new prompt section listing the files and **explicitly telling the model**: *if a linked ticket describes work in one of these files, assume it was already reviewed and do NOT flag it as missing from this PR*

## Test plan

- [x] `pnpm --filter @rusty-bot/core test prior-context.test.ts agent.test.ts` — 788 tests pass; 10 new
- [x] `pnpm test` — 959 tests across 34 files
- [x] `pnpm -r build` — all packages typecheck
- [ ] Watch a follow-up incremental re-review post-merge: the model should now see the prior file list in its prompt and stop flagging missing ticket scope when the work happened in an earlier commit

## Tests added

- roundtrip with `filesReviewed`
- legacy marker (no field) decodes as `undefined`
- empty `filesReviewed` is omitted from encoded payload (keeps markers small)
- cap at `FILES_REVIEWED_COUNT_CAP`
- decoder rejects: non-array `filesReviewed`, array containing non-strings
- prompt section rendering: present / missing / empty
- prompt section contains the "do NOT flag as missing" anti-pattern wording

## Followup, not in this PR

The complementary fix is a **system-prompt tightening** that treats linked tickets as context (not a per-PR checklist) regardless of incremental state. Easier to ship as a separate, focused change once this lands.