### PR TITLE
fix(review): move anti-meta-narrative rules into base system prompt

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -52,6 +52,21 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("Severity-inflated findings");
   });
 
+  it("includes anti-meta-narrative summary rules and the failure-mode phrases to avoid", () => {
+    const prompt = buildSystemPrompt(baseConfig);
+    expect(prompt).toContain("Summary writing rules");
+    // pin the specific failure-mode phrases observed in production runs so future
+    // edits to the prompt don't accidentally drop them
+    expect(prompt).toContain("investigation is in progress");
+    expect(prompt).toContain("tool call history shows");
+    expect(prompt).toContain("no input was provided");
+    // anti-pattern guidance the model must follow
+    expect(prompt).toContain("Do NOT describe your own investigation process");
+    // counter-hallucination: if the model thinks the diff is missing, treat the
+    // prompt as source of truth instead of writing "no diff was provided"
+    expect(prompt).toContain("treat the diff as the source of truth");
+  });
+
   it("includes lenient style instructions", () => {
     const prompt = buildSystemPrompt({ ...baseConfig, style: "lenient" });
     expect(prompt).toContain("LENIENT");

--- a/packages/core/src/__tests__/review.test.ts
+++ b/packages/core/src/__tests__/review.test.ts
@@ -608,11 +608,11 @@ describe("RUSTY_LLM_MAX_STEPS", () => {
 
     const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
     const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
-    expect(prepareStep({ stepNumber: 4 })).toMatchObject({ toolChoice: "none", activeTools: [] });
-    expect(prepareStep({ stepNumber: 99 })).toMatchObject({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 4 })).toEqual({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 99 })).toEqual({ toolChoice: "none", activeTools: [] });
   });
 
-  it("prepareStep injects a final-step system addendum to pin review voice", async () => {
+  it("prepareStep does NOT override the system prompt — the anti-meta-narrative rules live in base.txt so they apply at every step (not just the forced-termination one)", async () => {
     process.env.RUSTY_LLM_MAX_STEPS = "5";
     generateMock.mockResolvedValueOnce(makeValidResponse());
 
@@ -621,16 +621,8 @@ describe("RUSTY_LLM_MAX_STEPS", () => {
     const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
     const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
 
-    // non-final steps return undefined → use the agent's default system prompt
     expect(prepareStep({ stepNumber: 0 })).toBeUndefined();
-
-    // final step replaces the system prompt with one that includes the addendum
-    const finalResult = prepareStep({ stepNumber: 4 }) as { system: string };
-    expect(typeof finalResult.system).toBe("string");
-    expect(finalResult.system).toContain("FINAL STEP");
-    expect(finalResult.system).toContain("tool budget");
-    // pins the failure mode this addendum exists to prevent
-    expect(finalResult.system).toContain("investigation is in progress");
+    expect(prepareStep({ stepNumber: 4 })).not.toHaveProperty("system");
   });
 
   it("prepareStep with maxSteps=1 forces tool-free mode on step 0 (the only step)", async () => {
@@ -641,7 +633,7 @@ describe("RUSTY_LLM_MAX_STEPS", () => {
 
     const opts = generateMock.mock.calls[0][1] as Record<string, unknown>;
     const prepareStep = opts.prepareStep as (a: { stepNumber: number }) => unknown;
-    expect(prepareStep({ stepNumber: 0 })).toMatchObject({ toolChoice: "none", activeTools: [] });
+    expect(prepareStep({ stepNumber: 0 })).toEqual({ toolChoice: "none", activeTools: [] });
   });
 
   it("floors fractional values", async () => {

--- a/packages/core/src/agent/review.ts
+++ b/packages/core/src/agent/review.ts
@@ -87,25 +87,6 @@ function readMaxTransientRetries(): number {
   return Math.min(Math.floor(n), TRANSIENT_RETRY_BACKOFF_MS.length);
 }
 
-// addendum to the system prompt for the FINAL allowed step. fires together with
-// `toolChoice="none"` + `activeTools: []`. without it, tool-happy models that
-// burned their step budget on verification searches (deepseek-v4-flash on
-// Ollama Cloud, deepseek-v4-pro on Fireworks) emit structured output whose
-// `summary` field reports the model's own investigation state — e.g. "Investigation
-// is currently in progress to verify integration with X and Y" — instead of an
-// actual review summary. the reminder pins the model to the developer-facing
-// review voice for the final emission.
-const FINAL_STEP_PROMPT_ADDENDUM = [
-  "",
-  "## FINAL STEP",
-  "",
-  "Your tool budget is now exhausted. Emit your final structured review based on the investigation already in your message history.",
-  "",
-  'The `summary` field must read as a code review for the developer: describe what the PR does and any concrete issues you found. Do NOT describe your own investigation process. Do NOT write phrases like "investigation is in progress", "verification pending", "I am still checking", or similar — your investigation is over.',
-  "",
-  "If you could not fully verify something, omit that speculative finding. Do not include findings you are unsure about.",
-].join("\n");
-
 // caps how many tool-use rounds an agent can run before mastra forces it to
 // produce a final answer. unset = mastra's default. matters most for Anthropic
 // models, which can otherwise fan out parallel tool calls indefinitely and
@@ -419,18 +400,16 @@ export async function runReview(
   // otherwise tool-happy models (Anthropic in particular) burn the whole budget
   // on tool calls and end with finishReason="tool-calls" and no text — which
   // produces no structured output and the pass fails. stripping tools on the
-  // last allowed step guarantees the model emits a final answer. the system
-  // override pins the prose voice so the model doesn't emit its own investigation
-  // state as the summary (see FINAL_STEP_PROMPT_ADDENDUM comment).
+  // last allowed step guarantees the model emits a final answer. the anti-meta-
+  // narrative rules that prevent "investigation is in progress" / "no input was
+  // provided" summaries live in the base system prompt (see prompts/base.txt)
+  // so they apply at every step, not just the forced-termination one — the
+  // failure mode also fires when the model stops voluntarily.
   const prepareStep =
     maxSteps !== undefined
       ? ({ stepNumber }: { stepNumber: number }) => {
           if (stepNumber >= maxSteps - 1) {
-            return {
-              toolChoice: "none" as const,
-              activeTools: [],
-              system: `${systemPrompt}${FINAL_STEP_PROMPT_ADDENDUM}`,
-            };
+            return { toolChoice: "none" as const, activeTools: [] };
           }
         }
       : undefined;

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -43,6 +43,13 @@ Do not report:
 - Do not comment on formatting or trivial style issues unless specifically asked to review code style.
 - For ticket compliance, use "not_addressed" only when the visible changes clearly fail to satisfy a requirement; use "unclear" when the diff does not contain enough evidence to decide.
 - When an "Other Files Changed in This PR" section is present, those files are being modified in this PR and reviewed separately. Do not flag them as issues in unchanged code. Note that searchCode results for those files may reflect pre-merge content.
+
+Summary writing rules:
+- The `summary` field must describe what the PR does and what (if any) issues you found, written as a code review for the developer.
+- Do NOT describe your own investigation process, tool calls, or internal reasoning state. The developer does not need a transcript of what you searched for.
+- Do NOT write phrases such as "investigation is in progress", "verification pending", "I am still checking", "the provided tool call history shows", "no input was provided", "no diff was provided", "the request appears to be based on empty tool output", or any similar self-referential statement about how you formed your conclusions.
+- If you could not fully verify something, simply omit that speculative finding and write the summary based on what you did review.
+- The diff and PR metadata ARE provided in this prompt below. If you believe they are not, the failure is in your processing of the prompt, not in the prompt itself — treat the diff as the source of truth.
 {{style_instructions}}
 {{focus_instructions}}
 {{convention_instructions}}


### PR DESCRIPTION
## Summary

#185 injected the anti-meta-narrative addendum only at `MAX_STEPS-1` (the **forced-termination** step). The bot's own self-review on #187 just produced the same failure mode anyway — *"The provided input contained no specific code review findings, file changes, or ticket information. The request appears to be based on empty tool output results."* — but with only 64k tokens and no MAX_STEPS hit. The model terminated **voluntarily mid-budget**, so the addendum never fired.

**Coverage gap:** #185 catches forced terminations, misses voluntary ones.

## Fix

Move the rules out of `prepareStep` and into `base.txt` so they're part of the system prompt from step 0. They now apply regardless of how or when the model terminates. `prepareStep` still strips tools + forces `toolChoice="none"` on the final step (that part is unchanged and still needed to prevent `finishReason="tool-calls"` with zero text).

## Rules also extended to cover the new failure-mode phrasing

- `"the provided tool call history shows"`
- `"no input was provided"` / `"no diff was provided"`
- `"the request appears to be based on empty tool output"`

Plus a counter-hallucination clause: *"The diff and PR metadata ARE provided in this prompt below. If you believe they are not, the failure is in your processing of the prompt, not in the prompt itself — treat the diff as the source of truth."*

## Coverage matrix

| Run | Surface | Caught after this PR? |
|-----|---------|----------------------|
| BuildFind #539 ("investigation in progress") — forced stop | ✓ |
| Workboard SQL fix ("tool call history shows…") — forced stop | ✓ |
| **#187 self-review ("no input was provided") — voluntary stop** | ✓ (this is the new case) |
| rusty-gantry version bump (ticket-as-checklist) | partial; needs separate prompt work |

## Test plan

- [x] `pnpm --filter @rusty-bot/core test review.test.ts agent.test.ts` — 789 pass
- [x] `pnpm test` — 960 across 34 files
- [x] `pnpm -r build` — all packages typecheck
- [ ] Watch the bot's self-review on this very PR: the deepseek pass should produce a normal review summary, not a meta-narrative

## Followup (still pending, deferred to a later PR)

The **consistency detector** ("Tier-2 item B" / fix B): regex-match the failure-mode phrases at consensus-merge time and drop the offending pass from the summary aggregation. Belt-and-suspenders. Keep this PR focused on the prompt-side fix.