### PR TITLE
fix(description): augment existing description on incremental re-reviews instead of rewriting from scratch

### DIFF
--- a/packages/azure-devops/src/cli.ts
+++ b/packages/azure-devops/src/cli.ts
@@ -220,7 +220,9 @@ async function main(): Promise<void> {
   if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
     try {
       if (shouldGenerateDescription(metadata.description)) {
-        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description, {
+          incremental: incrementalUsed,
+        });
         await provider.updatePRDescription(descResult.markdown);
         metadata.description = descResult.markdown;
         log.info(

--- a/packages/core/src/__tests__/description.test.ts
+++ b/packages/core/src/__tests__/description.test.ts
@@ -304,6 +304,41 @@ describe("formatDescription", () => {
     });
     expect(result).not.toContain("Original description");
   });
+
+  it("skips the Original description wrap in augment (incremental) mode even when prior text is provided", () => {
+    const botGenerated =
+      "<!-- rusty-bot-description -->\n\n## Summary\nCovers Stop button + Vitest.";
+    const result = formatDescription(
+      {
+        summary: "Now also bumps the version to 0.4.0.",
+        fileChanges: [],
+        breakingChanges: [],
+        migrationNotes: null,
+      },
+      botGenerated,
+      { incremental: true },
+    );
+    // augmented model output replaces the prior description in-place; re-wrapping
+    // it would double-render the content and accumulate one extra nesting per
+    // incremental push
+    expect(result).not.toContain("Original description");
+    expect(result).not.toContain("Covers Stop button + Vitest.");
+  });
+
+  it("falls back to wrapping in Original description when incremental is false (explicit)", () => {
+    const result = formatDescription(
+      {
+        summary: "Updated.",
+        fileChanges: [],
+        breakingChanges: [],
+        migrationNotes: null,
+      },
+      "user-written prior",
+      { incremental: false },
+    );
+    expect(result).toContain("Original description");
+    expect(result).toContain("user-written prior");
+  });
 });
 
 describe("buildDescriptionUserMessage", () => {
@@ -341,5 +376,37 @@ describe("buildDescriptionUserMessage", () => {
   it("omits existing description section when undefined", () => {
     const msg = buildDescriptionUserMessage("diff", prMetadata);
     expect(msg).not.toContain("Existing Description");
+  });
+
+  it("switches to augment mode when incremental=true and existing description is present", () => {
+    const existing = "<!-- rusty-bot-description -->\n\n## Summary\nCovers Stop button + Vitest.";
+    const msg = buildDescriptionUserMessage("+ version bump diff", prMetadata, existing, {
+      incremental: true,
+    });
+    // augment-mode-specific headings and instructions
+    expect(msg).toContain("Description so far");
+    expect(msg).toContain("AUGMENT this description in place");
+    expect(msg).toContain("Do NOT rewrite from scratch");
+    expect(msg).toContain("New changes since the existing description");
+    // the prior description content is still embedded so the model can preserve it
+    expect(msg).toContain("Covers Stop button + Vitest.");
+    // the non-incremental headings/instructions must NOT appear (no mode bleed)
+    expect(msg).not.toContain("Existing Description");
+    expect(msg).not.toContain("## Diff");
+  });
+
+  it("falls back to non-augment mode when incremental=true but no existing description (degrade gracefully)", () => {
+    // there's nothing to augment, so the augment instructions would be meaningless
+    const msg = buildDescriptionUserMessage("+ diff", prMetadata, "", { incremental: true });
+    expect(msg).not.toContain("Description so far");
+    expect(msg).not.toContain("AUGMENT this description");
+    expect(msg).toContain("## Diff");
+  });
+
+  it("keeps the existing 'Existing Description' wording when incremental is omitted (backward compat)", () => {
+    const existing = "<!-- rusty-bot-description -->\n\nPrior content";
+    const msg = buildDescriptionUserMessage("diff", prMetadata, existing);
+    expect(msg).toContain("Existing Description");
+    expect(msg).not.toContain("Description so far");
   });
 });

--- a/packages/core/src/description/generate.ts
+++ b/packages/core/src/description/generate.ts
@@ -39,9 +39,18 @@ function stripBotMarker(description: string): string {
   return description.replace(DESCRIPTION_MARKER, "").trim();
 }
 
+export interface FormatDescriptionOptions {
+  /** when true, the model has already folded the previous description into its
+   * output → skip the <details>"Original description" wrap so we don't end up
+   * with the same content rendered twice (and the wrap itself accumulating
+   * one extra nesting level on every incremental re-review). */
+  incremental?: boolean;
+}
+
 export function formatDescription(
   output: PRDescriptionOutput,
   originalDescription?: string,
+  options?: FormatDescriptionOptions,
 ): string {
   const lines: string[] = [DESCRIPTION_MARKER, ""];
 
@@ -79,7 +88,12 @@ export function formatDescription(
     lines.push("");
   }
 
-  const stripped = originalDescription ? stripBotMarker(originalDescription) : "";
+  // augment mode skips the wrap entirely: the model's output already merged the
+  // prior description's content, so re-attaching it would duplicate everything
+  // AND keep growing one nested <details> deeper on every incremental push.
+  const skipOriginalWrap = options?.incremental === true;
+  const stripped =
+    !skipOriginalWrap && originalDescription ? stripBotMarker(originalDescription) : "";
   if (stripped.length > 0) {
     lines.push("<details>");
     lines.push("<summary>Original description</summary>");
@@ -93,10 +107,19 @@ export function formatDescription(
   return lines.join("\n");
 }
 
+export interface GeneratePRDescriptionOptions {
+  /** when true, the patches above represent ONLY the diff since the existing
+   * description was generated. The generator runs in augment-in-place mode and
+   * skips the <details>"Original description" wrap on output. Only meaningful
+   * when an existingDescription is provided. */
+  incremental?: boolean;
+}
+
 export async function generatePRDescription(
   patches: FilePatch[],
   prMetadata: PRMetadata,
   existingDescription?: string,
+  options?: GeneratePRDescriptionOptions,
 ): Promise<GenerateDescriptionResult> {
   const { compressed } = compressDiff(patches, MAX_DESCRIPTION_TOKENS);
 
@@ -110,7 +133,10 @@ export async function generatePRDescription(
     model: () => resolveModel(modelConfig),
   });
 
-  const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription);
+  const incremental = options?.incremental === true;
+  const userMessage = buildDescriptionUserMessage(compressed, prMetadata, existingDescription, {
+    incremental,
+  });
 
   const modelSettings = applyModelConstraints(modelConfig, resolveModelSettings("description"));
   const jsonPromptInjection = resolveJsonPromptInjection(modelConfig);
@@ -123,7 +149,7 @@ export async function generatePRDescription(
   const tokenCount = response.usage.totalTokens ?? 0;
 
   return {
-    markdown: formatDescription(parsed, existingDescription),
+    markdown: formatDescription(parsed, existingDescription, { incremental }),
     modelUsed: modelName,
     tokenCount,
   };

--- a/packages/core/src/description/prompt.ts
+++ b/packages/core/src/description/prompt.ts
@@ -17,10 +17,20 @@ export function buildDescriptionSystemPrompt(): string {
   return SYSTEM_PROMPT;
 }
 
+export interface BuildDescriptionUserMessageOptions {
+  /** when true, the diff represents ONLY the changes since the existing description
+   * was generated. the model is told to augment the existing description in-place
+   * (preserving sections that still apply, folding in the new commit's changes)
+   * rather than rewrite from scratch. only meaningful when an existingDescription
+   * is also provided. */
+  incremental?: boolean;
+}
+
 export function buildDescriptionUserMessage(
   diff: string,
   prMetadata: PRMetadata,
   existingDescription?: string,
+  options?: BuildDescriptionUserMessageOptions,
 ): string {
   const parts: string[] = [];
 
@@ -29,16 +39,35 @@ export function buildDescriptionUserMessage(
   parts.push(`**Author:** ${prMetadata.author}`);
   parts.push(`**Branch:** ${prMetadata.sourceBranch} → ${prMetadata.targetBranch}`);
 
-  if (existingDescription?.trim()) {
-    parts.push("\n## Existing Description");
-    parts.push(
-      "The PR currently has the following description. Preserve any useful human-added " +
-        "context (rationale, rollout notes, linked issues) when generating the new description.\n",
-    );
-    parts.push(existingDescription.trim());
+  const trimmedExisting = existingDescription?.trim() ?? "";
+  // augment mode only fires when there's an existing description to augment;
+  // an `incremental: true` flag with no prior text degrades to a normal full-diff
+  // generation since there's nothing to merge into.
+  const augmentMode = options?.incremental === true && trimmedExisting.length > 0;
+
+  if (trimmedExisting.length > 0) {
+    if (augmentMode) {
+      parts.push("\n## Description so far");
+      parts.push(
+        "This description was generated for an earlier commit on the same PR and currently " +
+          "describes the FULL PR scope up to that point. The diff in the next section is ONLY " +
+          "the changes pushed since then — NOT the whole PR. Your job is to AUGMENT this " +
+          "description in place: preserve every section, paragraph, and bullet that still " +
+          "applies, modify what changed, and add only what's strictly new. Do NOT rewrite from " +
+          "scratch and do NOT drop coverage of earlier work just because it isn't visible in " +
+          "the diff below.\n",
+      );
+    } else {
+      parts.push("\n## Existing Description");
+      parts.push(
+        "The PR currently has the following description. Preserve any useful human-added " +
+          "context (rationale, rollout notes, linked issues) when generating the new description.\n",
+      );
+    }
+    parts.push(trimmedExisting);
   }
 
-  parts.push("\n## Diff\n");
+  parts.push(augmentMode ? "\n## New changes since the existing description\n" : "\n## Diff\n");
   parts.push(diff);
 
   return parts.join("\n");

--- a/packages/github-action/src/cli.ts
+++ b/packages/github-action/src/cli.ts
@@ -319,7 +319,9 @@ export async function runAction(config: ActionConfig): Promise<number> {
   if (config.generateDescription) {
     try {
       if (shouldGenerateDescription(metadata.description)) {
-        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description, {
+          incremental: incrementalUsed,
+        });
         await provider.updatePRDescription(descResult.markdown);
         metadata.description = descResult.markdown;
         log.info(

--- a/packages/gitlab/src/cli.ts
+++ b/packages/gitlab/src/cli.ts
@@ -306,7 +306,9 @@ export async function runReview(config: GitLabCliConfig): Promise<number> {
   if (process.env.RUSTY_GENERATE_DESCRIPTION === "true") {
     try {
       if (shouldGenerateDescription(metadata.description)) {
-        const descResult = await generatePRDescription(reviewable, metadata, metadata.description);
+        const descResult = await generatePRDescription(reviewable, metadata, metadata.description, {
+          incremental: incrementalUsed,
+        });
         await provider.updatePRDescription(descResult.markdown);
         metadata.description = descResult.markdown;
         log.info(


### PR DESCRIPTION
## Summary

Same coverage gap class as #187 but for **PR description generation** — your suggestion of "pass the previous description and augment with new changes" is the right shape, so that's what this implements.

Today on an incremental re-review:

1. `getDiffSinceSha` produces only the diff since the last reviewed SHA
2. `shouldGenerateDescription` returns true (the prior description still has the bot marker)
3. `generatePRDescription` is called with the **incremental** diff but with no signal that the diff is incremental → the model writes a description of just the new commit
4. `formatDescription` wraps the prior description inside a `<details><summary>Original description</summary>` block

Result: the top-level visible description becomes narrow (e.g. "this PR bumps version to 0.4.0") and the actual PR-wide narrative (Stop button + Vitest) is buried in `<details>`. Worse — every incremental push wraps the previous description in **another** `<details>`, so nesting accumulates one deeper per push.

## Fix

Pass the existing bot description to the model as **authoritative prior scope** and ask it to AUGMENT in place with the new commit's changes, instead of rewriting from scratch.

- New optional `incremental: boolean` plumbed through `generatePRDescription` → `buildDescriptionUserMessage` / `formatDescription`. Additive, backward-compatible — omitting the flag preserves old behavior
- In augment mode the user message uses a `## Description so far` heading and tells the model explicitly: *"this is the FULL PR scope; the diff below is ONLY what's new; AUGMENT this description in place; do NOT rewrite from scratch"*
- In augment mode `formatDescription` skips the `<details>` wrap because the model has already folded the prior content into its output — re-wrapping would double-render AND accumulate one extra nesting per push
- Graceful degrade: if `incremental: true` is passed but there's no prior description to augment, falls back to normal full-diff generation
- The three CLI callers (github-action, gitlab, azure-devops) pass `incremental: incrementalUsed` from their existing flag
- GitHub webhook orchestrator unchanged (it always uses the full diff)

## Test plan

- [x] `pnpm --filter @rusty-bot/core test description.test.ts` — 793 pass (5 new tests)
- [x] `pnpm test` — 964 across 34 files
- [x] `pnpm -r build` — all packages typecheck
- [ ] On a multi-commit PR post-merge: the description should be augmented in place on incremental re-reviews, NOT nested into `<details>` and not narrowed to just the latest commit's scope

## New tests

- `formatDescription` skips the wrap in augment mode even when prior text is provided
- `formatDescription` keeps wrapping when incremental is false (explicit) — backward compat
- `buildDescriptionUserMessage` switches to augment-mode heading + instructions when incremental + existing description both present
- `buildDescriptionUserMessage` falls back to non-augment mode when incremental=true but no existing description (graceful degrade)
- `buildDescriptionUserMessage` keeps the original "Existing Description" wording when incremental flag is omitted (backward compat)

## Cleanup

This PR doesn't strip already-nested `<details>` blocks from previously-broken descriptions — those will work themselves out as users edit / the bot regenerates. A `stripNestedOriginalDescriptions` helper could be added if the visual residue from prior runs is a problem; out of scope for this surgical fix.