### PR TITLE
fix(prompt): treat linked tickets as context, not a per-PR checklist

### DIFF
--- a/packages/core/src/__tests__/agent.test.ts
+++ b/packages/core/src/__tests__/agent.test.ts
@@ -52,6 +52,19 @@ describe("buildSystemPrompt", () => {
     expect(prompt).toContain("Severity-inflated findings");
   });
 
+  it("frames linked tickets as context (not a per-PR checklist) at the system level", () => {
+    const prompt = buildSystemPrompt(baseConfig);
+    // system-level guidance matches the user-message-level ticket section so
+    // there's a single consistent rule whether or not tickets are linked in a given PR
+    expect(prompt).toContain("Linked tickets are CONTEXT");
+    expect(prompt).toContain("not a per-PR checklist");
+    expect(prompt).toContain("one slice of a larger ticket");
+    expect(prompt).toContain("contradicts or breaks a requirement");
+    // pin the regression phrase: the system prompt must explicitly forbid the
+    // "fails to include …" framing that caused the rusty-gantry false complaint
+    expect(prompt).toContain("fails to include");
+  });
+
   it("includes anti-meta-narrative summary rules and the failure-mode phrases to avoid", () => {
     const prompt = buildSystemPrompt(baseConfig);
     expect(prompt).toContain("Summary writing rules");
@@ -234,11 +247,39 @@ describe("buildUserMessage", () => {
     expect(msg).toContain("Implement JWT authentication");
     expect(msg).toContain("Acceptance Criteria");
     expect(msg).toContain("feature, auth");
-    expect(msg).toContain("structured ticketCompliance output");
-    expect(msg).toContain(
-      "use `not_addressed` only when the visible changes clearly do not satisfy the requirement",
-    );
-    expect(msg).toContain("use `unclear`");
+    expect(msg).toContain("structured `ticketCompliance` output");
+    // pin the four-grade rubric so future prompt edits don't accidentally collapse it
+    expect(msg).toContain("`addressed`");
+    expect(msg).toContain("`partially_addressed`");
+    expect(msg).toContain("`not_addressed`");
+    expect(msg).toContain("`unclear`");
+  });
+
+  it("frames linked tickets as context, not a per-PR checklist (closes the 'fails to include' false-flag class)", () => {
+    const tickets: TicketInfo[] = [
+      {
+        id: "AUTH-42",
+        title: "Stop button for the live viewer",
+        description: "Add a Stop button users can click to halt playback.",
+        labels: [],
+        source: "jira",
+      },
+    ];
+    const msg = buildUserMessage("diff", prMetadata, tickets);
+    // tickets are CONTEXT, not a checklist
+    expect(msg).toContain("CONTEXT for this PR");
+    expect(msg).toContain("NOT a checklist");
+    expect(msg).toContain("one slice of a larger ticket");
+    // tighten not_addressed semantics — only when the diff CONTRADICTS the requirement
+    expect(msg).toContain("CONTRADICTS or BREAKS");
+    // unclear is the default for silent diffs (no positive or negative evidence)
+    expect(msg).toContain("default when this PR's diff is silent");
+    // pin the exact failure-mode phrase from the rusty-gantry version-bump regression
+    expect(msg).toContain("fails to include");
+    // explicit cross-reference to the filesReviewed carry-forward from PR #187 —
+    // when the prior review's coverage list is present, requirements in those files
+    // were already evaluated and must not get re-flagged as not_addressed here
+    expect(msg).toContain("Files already covered by the prior review");
   });
 
   it("omits ticket section when no tickets provided", () => {

--- a/packages/core/src/agent/prompts.ts
+++ b/packages/core/src/agent/prompts.ts
@@ -150,13 +150,40 @@ export function buildUserMessage(
       }
     }
     parts.push(
-      "\nPlease extract the concrete requirements or acceptance criteria from each linked ticket " +
-        "into the structured ticketCompliance output. Evaluate each requirement individually, " +
-        "keep requirement wording stable across equivalent checks so later passes can merge into the same checklist, " +
-        "and prefer adding evidence to an existing requirement rather than restating it with different phrasing. " +
-        "set ticketId when you can, cite diff evidence when available, use `not_addressed` " +
-        "only when the visible changes clearly do not satisfy the requirement, and use `unclear` " +
-        "when the visible changes are insufficient to decide.",
+      "\nThe linked tickets above are CONTEXT for this PR — they describe the work the change " +
+        "fits into, NOT a checklist that must be fully delivered by this PR. PRs commonly implement " +
+        "one slice of a larger ticket; earlier commits on this branch, sibling PRs, or later work may " +
+        "handle the rest. Do NOT flag missing scope as a problem just because it isn't visible in this diff, " +
+        "and do NOT write summary prose claiming the PR 'fails to include' work that the ticket describes " +
+        "but this diff doesn't show.",
+    );
+    parts.push(
+      "\nExtract each concrete requirement into the structured `ticketCompliance` output and grade it:",
+    );
+    parts.push(
+      "- `addressed` — this PR's diff contains positive evidence the requirement is now met.",
+    );
+    parts.push(
+      "- `partially_addressed` — this PR clearly advances the requirement but doesn't fully close it.",
+    );
+    parts.push(
+      "- `not_addressed` — reserved for cases where this PR actively CONTRADICTS or BREAKS the " +
+        "requirement (e.g. the diff removes a check the ticket asked for, or implements the opposite " +
+        "of the requested behavior). Do NOT use this just because the diff is silent — use `unclear` instead.",
+    );
+    parts.push(
+      "- `unclear` — the default when this PR's diff is silent on the requirement (no positive or " +
+        "negative evidence). Use this freely; it carries no negative judgment.",
+    );
+    parts.push(
+      "\nIf a 'Files already covered by the prior review' section is present, assume requirements that " +
+        "map to those files were already evaluated in the prior pass and do NOT re-grade them as " +
+        "`not_addressed` from this incremental diff alone.",
+    );
+    parts.push(
+      "\nKeep requirement wording stable across equivalent checks so later passes can merge into the " +
+        "same checklist. Prefer adding evidence to an existing requirement over restating it with " +
+        "different phrasing. Set `ticketId` when you can, and cite diff evidence when available.",
     );
   }
 

--- a/packages/core/src/prompts/base.txt
+++ b/packages/core/src/prompts/base.txt
@@ -41,7 +41,7 @@ Do not report:
 
 - Do not speculate about broken imports or unused exports without using searchCode to verify.
 - Do not comment on formatting or trivial style issues unless specifically asked to review code style.
-- For ticket compliance, use "not_addressed" only when the visible changes clearly fail to satisfy a requirement; use "unclear" when the diff does not contain enough evidence to decide.
+- Linked tickets are CONTEXT, not a per-PR checklist. PRs commonly implement one slice of a larger ticket; do not flag missing scope as a problem just because it isn't visible in this diff. Reserve `not_addressed` for cases where the diff actively contradicts or breaks a requirement; use `unclear` when the diff is silent (no positive or negative evidence) — never write a summary saying the PR "fails to include" work the ticket describes but this diff doesn't show.
 - When an "Other Files Changed in This PR" section is present, those files are being modified in this PR and reviewed separately. Do not flag them as issues in unchanged code. Note that searchCode results for those files may reflect pre-merge content.
 
 Summary writing rules:


### PR DESCRIPTION
## Summary

Pairs with **#187** (filesReviewed carry-forward). That PR gave the model the data showing which files prior reviews covered; this PR teaches it the right interpretation.

The rusty-gantry version-bump regression — *"this PR fails to include the 'Stop button' feature… and it also fails to implement requested frontend test infrastructure (Vitest/RTL)"* — was caused by the existing ticket-compliance prompt telling the model to enumerate ticket requirements and grade each one. On multi-PR features that naturally produces `not_addressed` for ticket scope that landed in **earlier** commits — even when prior reviews already approved that work.

## Fix

Re-frame ticket compliance at two layers so the rule is consistent whether or not tickets happen to be linked in a given PR.

**1. Base system prompt (`prompts/base.txt`)**

The existing line:
```
- For ticket compliance, use "not_addressed" only when the visible changes clearly fail to satisfy a requirement; use "unclear" when the diff does not contain enough evidence to decide.
```

becomes:
```
- Linked tickets are CONTEXT, not a per-PR checklist. PRs commonly implement one slice of a larger ticket; do not flag missing scope as a problem just because it isn't visible in this diff. Reserve `not_addressed` for cases where the diff actively contradicts or breaks a requirement; use `unclear` when the diff is silent (no positive or negative evidence) — never write a summary saying the PR "fails to include" work the ticket describes but this diff doesn't show.
```

**2. Linked-tickets user-message section (`agent/prompts.ts`)**

The "evaluate each requirement individually" paragraph becomes a structured four-grade rubric:

- `addressed` — diff contains positive evidence
- `partially_addressed` — diff advances but doesn't fully close
- `not_addressed` — **reserved for CONTRADICTS or BREAKS** (e.g. diff removes a check the ticket asked for); explicitly NOT for "the diff is silent"
- `unclear` — the default for silent diffs (no positive or negative evidence)

Plus an explicit cross-reference to the `Files already covered by the prior review` section from #187: if a requirement maps to a previously-reviewed file, do not re-grade as `not_addressed` from this incremental diff alone.

## Test plan

- [x] `pnpm --filter @rusty-bot/core test agent.test.ts` — 796 pass; existing ticket-context test updated, two new regression tests pin the failure-mode wording (`fails to include`, `CONTRADICTS or BREAKS`, etc.) at both the user-message and system-prompt layers
- [x] `pnpm test` — 967 across 34 files
- [x] `pnpm -r build` — all packages typecheck
- [ ] On the next multi-commit PR linked to large tickets, the bot should stop emitting "this PR fails to include X" when X was already in a prior commit

## Coverage matrix (rusty-gantry version-bump regression)

| Surface | Before this PR | After this PR |
|---------|----------------|---------------|
| Bot has the prior-coverage data | #187 (shipped) | #187 (shipped) |
| Bot knows tickets are context not checklist | ❌ told to enumerate + grade | ✅ rubric explicitly forbids the "fails to include" framing |
| `not_addressed` semantics | "doesn't satisfy" (loose) | "contradicts or breaks" (tight) |
| `unclear` semantics | "insufficient evidence to decide" | "default for silent diff" (encourages use) |

The legacy *"only when the visible changes clearly do not satisfy the requirement"* wording was the source of the bug — the model was free to interpret "doesn't satisfy" as "isn't visible." This PR removes that latitude.