### PR TITLE
fix: clean subset of bug fixes and API improvements

### DIFF
--- a/packages/core/src/agent/cluster.ts
+++ b/packages/core/src/agent/cluster.ts
@@ -108,7 +108,10 @@ function clusterItems<T extends Clusterable>(
 }
 
 function pickRepresentative<T extends Clusterable>(items: T[]): T {
-  return items.sort((a, b) => {
+  // copy before sorting — Array.prototype.sort mutates in place, and `items`
+  // here is the caller's cluster.items.map() result whose ordering callers
+  // downstream may rely on
+  return [...items].sort((a, b) => {
     const sevDiff = SEVERITY_RANK[b.severity] - SEVERITY_RANK[a.severity];
     if (sevDiff !== 0) return sevDiff;
     return b.message.length - a.message.length;

--- a/packages/core/src/agent/multi-call.ts
+++ b/packages/core/src/agent/multi-call.ts
@@ -168,6 +168,17 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
     return true;
   });
 
+  // observations cross-chunk-dedup mirrors findings — when chunks overlap or
+  // observe the same unchanged code, we'd otherwise emit the same observation
+  // multiple times in the merged result
+  const seenObs = new Set<string>();
+  const dedupedObservations = allObservations.filter((o) => {
+    const key = `${o.file}:${o.line}:${o.message}`;
+    if (seenObs.has(key)) return false;
+    seenObs.add(key);
+    return true;
+  });
+
   const droppedSeen = new Set<string>();
   const dedupedDropped: DroppedFinding[] = [];
   for (const r of results) {
@@ -207,7 +218,7 @@ export function mergeResults(results: ReviewResult[], modelUsed: string): Review
     summary,
     recommendation,
     findings: dedupedFindings,
-    observations: allObservations,
+    observations: dedupedObservations,
     ticketCompliance: mergeTicketCompliance(results),
     missingTests: mergeMissingTests(results),
     filesReviewed: [...allFiles],

--- a/packages/github/src/__tests__/server.test.ts
+++ b/packages/github/src/__tests__/server.test.ts
@@ -26,6 +26,10 @@ vi.mock("../storage.js", async () => {
       const sorted = [...reviews].reverse();
       return sorted.slice(offset, offset + limit);
     }),
+    listReviewsPage: vi.fn(async (limit = 50, offset = 0) => {
+      const sorted = [...reviews].reverse();
+      return { items: sorted.slice(offset, offset + limit), total: reviews.length };
+    }),
     getReview: vi.fn(async (id: string) => reviews.find((r) => r.id === id) ?? null),
     saveReview: vi.fn(async (review: Record<string, unknown>) => {
       reviews.push(review);

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -13,7 +13,7 @@ import {
   listRepoConfigs,
   getRepoConfig,
   setRepoConfig,
-  listReviews,
+  listReviewsPage,
   getReview,
   getSettings,
   setSetting,
@@ -121,6 +121,9 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     focusAreas?: FocusArea[];
     ignorePatterns?: string[];
     generateDescription?: boolean;
+    renameTitleToConventional?: boolean;
+    consensusPasses?: number;
+    consensusThreshold?: number | null;
   } = await c.req.json();
 
   const parsedStyle = ReviewStyleSchema.safeParse(body.style);
@@ -128,15 +131,28 @@ app.put("/api/config/repos/:owner/:repo", async (c) => {
     return c.json({ error: `invalid review style: ${body.style}` }, 400);
   }
 
+  // carry forward existing optional fields not included in this request — PUT
+  // semantics here are PATCH-shaped in practice (clients update one field at a
+  // time), and the prior behavior of falling back to hard-coded defaults wiped
+  // out anything the user had previously set when omitted from the body
+  const existing = await getRepoConfig(owner, repo);
+
   const config: RepoConfig = {
+    ...(existing ?? {}),
     owner,
     repo,
-    style: parsedStyle.success ? parsedStyle.data : "balanced",
-    focusAreas: body.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
-    ignorePatterns: body.ignorePatterns ?? [],
-    ...(typeof body.generateDescription === "boolean" && {
-      generateDescription: body.generateDescription,
-    }),
+    style: parsedStyle.success ? parsedStyle.data : (existing?.style ?? "balanced"),
+    focusAreas: body.focusAreas ??
+      existing?.focusAreas ?? ["security", "performance", "bugs", "style", "tests", "docs"],
+    ignorePatterns: body.ignorePatterns ?? existing?.ignorePatterns ?? [],
+    ...(typeof body.generateDescription === "boolean"
+      ? { generateDescription: body.generateDescription }
+      : {}),
+    ...(typeof body.renameTitleToConventional === "boolean"
+      ? { renameTitleToConventional: body.renameTitleToConventional }
+      : {}),
+    ...(typeof body.consensusPasses === "number" ? { consensusPasses: body.consensusPasses } : {}),
+    ...("consensusThreshold" in body ? { consensusThreshold: body.consensusThreshold } : {}),
   };
 
   await setRepoConfig(owner, repo, config);
@@ -160,9 +176,8 @@ app.put("/api/config/settings", async (c) => {
 app.get("/api/reviews", async (c) => {
   const limit = Number(c.req.query("limit") ?? "50");
   const offset = Number(c.req.query("offset") ?? "0");
-  const allReviews = await listReviews(1000, 0);
-  const items = await listReviews(limit, offset);
-  return c.json({ items, total: allReviews.length });
+  const { items, total } = await listReviewsPage(limit, offset);
+  return c.json({ items, total });
 });
 
 app.get("/api/reviews/:id", async (c) => {

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -100,6 +100,18 @@ export async function listReviews(limit = 50, offset = 0): Promise<ReviewRecord[
   return sorted.slice(offset, offset + limit);
 }
 
+/** like listReviews but returns the total count alongside the page in a single
+ * file read — avoids the read-twice pattern callers were using when they
+ * needed both the items and the total for pagination metadata. */
+export async function listReviewsPage(
+  limit: number,
+  offset: number,
+): Promise<{ items: ReviewRecord[]; total: number }> {
+  const data = await loadData();
+  const sorted = [...data.reviews].reverse();
+  return { items: sorted.slice(offset, offset + limit), total: data.reviews.length };
+}
+
 export async function getReview(id: string): Promise<ReviewRecord | null> {
   const data = await loadData();
   return data.reviews.find((r) => r.id === id) ?? null;


### PR DESCRIPTION
## Summary

The non-controversial slice of the in-flight WIP on `fix/code-review-bugs`. The remaining items in that branch (provider `getPriorState`, consensus `pass0Result`, storage write-lock, webhook dedupe, concurrency semaphore) all have structural questions that should be answered before shipping — captured separately. This PR is just the surgical, ready-to-merge ones.

## What's in

- **`cluster.ts`** — `pickRepresentative` sorts a copy (`[...items].sort(...)`) instead of mutating the caller's array. Caller's `cluster.items.map()` result was being reordered as a side effect.
- **`multi-call.ts`** — `mergeResults` dedupes observations across passes by `file:line:message`, mirroring the existing finding-dedupe logic. Today the same observation can appear N times in a merged consensus result when chunks overlap.
- **`storage.ts`** — new `listReviewsPage(limit, offset)` that returns `{ items, total }` in a single `loadData()` call. Replaces a read-twice pattern callers were doing to get both the page and the total count.
- **`server.ts` `GET /api/reviews`** — uses `listReviewsPage` to drop the duplicate file read.
- **`server.ts` `PUT /api/config/repos/:owner/:repo`** — merges with the existing config instead of overwriting from hard-coded defaults. Previously, omitting a field from the request body silently reset it (so setting `focusAreas` would wipe out a previously-saved `style`, `generateDescription`, etc.). Body now also accepts `renameTitleToConventional`, `consensusPasses`, `consensusThreshold` — explicit additions to match the config fields the dashboard already shows.
- **`server.test.ts`** — adds the `listReviewsPage` mock so the existing tests still pass.

## What's deliberately out of scope

These are NOT in this PR even though they're in the same branch:

- `provider.ts` `getPriorState` consolidation — the new method is public but no caller is updated to use it; today both old methods still each do their own API call. Decide whether to update callers (`github-action/src/cli.ts`) or add per-instance memoization, then ship.
- `consensus.ts` `pass0Result` tracking — traces as a no-op in all execution paths. The underlying problem (ticket compliance dies if pass 0 fails) needs a different fix: extract compliance into its own call, or send `ticketContext` to multiple passes.
- `storage.ts` `withWriteLock` — correct fix for the read-modify-write race, but it's a band-aid on the JSON-file storage layer. Open question whether to ship the lock or migrate the storage to SQLite first (SQLite makes the lock unnecessary and also unlocks indexed queries, real pagination, etc).
- `server.ts` webhook delivery dedupe + concurrency semaphore — both in-memory, single-instance only. Fine for a single-replica deployment; if you scale to multiple instances, both need to move to shared storage (Redis, a DB table, or a queue). Decide on the deployment shape before shipping.

## Test plan

- [x] `pnpm test` — 965 tests across 34 files pass
- [x] `pnpm -r build` — all packages typecheck
- [x] Manual: `GET /api/reviews` returns `{items, total}` with the correct total
- [x] Manual: `PUT /api/config/repos/:owner/:repo` with a single field no longer wipes other config fields