### PR TITLE
fix(consensus): honest ticket-compliance fallback when pass 0 fails

### DIFF
--- a/packages/core/src/__tests__/consensus.test.ts
+++ b/packages/core/src/__tests__/consensus.test.ts
@@ -499,6 +499,117 @@ describe("runConsensusReview failure tolerance", () => {
   });
 });
 
+describe("runConsensusReview ticket compliance pass-0-only invariant", () => {
+  const ticketContext = [
+    {
+      id: "AUTH-42",
+      title: "JWT auth",
+      description: "Login with JWT",
+      labels: [] as string[],
+      source: "jira",
+    },
+  ];
+
+  beforeEach(() => {
+    callCount = 0;
+    mockBehavior = "default";
+    delete process.env.RUSTY_REVIEW_MODELS;
+    delete process.env.RUSTY_REVIEW_TEMPERATURES;
+    process.env.RUSTY_REVIEW_ADAPTIVE_PASSES = "false";
+    vi.clearAllMocks();
+  });
+
+  it("returns pass 0's ticketCompliance verbatim when pass 0 succeeds", async () => {
+    const { runReview } = await import("../agent/review.js");
+    const pass0Compliance = [
+      {
+        ticketId: "AUTH-42",
+        requirement: "Login endpoint returns JWT",
+        status: "addressed" as const,
+        evidence: "src/auth.ts:42 — returns JWT",
+      },
+    ];
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce(makeResult({ ticketCompliance: pass0Compliance }))
+      .mockResolvedValueOnce(makeResult({ ticketCompliance: [] }))
+      .mockResolvedValueOnce(makeResult({ ticketCompliance: [] }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview(
+      [],
+      consensusConfig,
+      prMetadata,
+      "diff content",
+      ticketContext,
+    );
+
+    expect(result.ticketCompliance).toEqual(pass0Compliance);
+  });
+
+  it("returns EMPTY ticketCompliance (not pass 1's) when pass 0 fails — pass 1 never saw the tickets so its empty array is meaningless", async () => {
+    const { runReview } = await import("../agent/review.js");
+    const pass1Compliance = [
+      {
+        ticketId: "AUTH-42",
+        requirement: "should never appear in output",
+        status: "addressed" as const,
+        evidence: "this came from a pass that never saw the ticket",
+      },
+    ];
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("pass 0 transient failure"))
+      .mockResolvedValueOnce(makeResult({ ticketCompliance: pass1Compliance }))
+      .mockResolvedValueOnce(makeResult({ ticketCompliance: [] }));
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    const result = await runConsensusReview(
+      [],
+      consensusConfig,
+      prMetadata,
+      "diff content",
+      ticketContext,
+    );
+
+    expect(result.ticketCompliance).toEqual([]);
+  });
+
+  it("emits a warn log when pass 0 fails and ticketContext was supplied", async () => {
+    const { runReview } = await import("../agent/review.js");
+    const { logger } = await import("../logger.js");
+    const warnSpy = vi.spyOn(logger, "warn");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("pass 0 fail"))
+      .mockResolvedValueOnce(makeResult())
+      .mockResolvedValueOnce(makeResult());
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    await runConsensusReview([], consensusConfig, prMetadata, "diff content", ticketContext);
+
+    const ticketWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[1] === "string" && call[1].includes("ticket compliance unavailable"),
+    );
+    expect(ticketWarn).toBeDefined();
+  });
+
+  it("does NOT emit the ticket-compliance warn when pass 0 fails but no tickets were linked (no compliance was expected anyway)", async () => {
+    const { runReview } = await import("../agent/review.js");
+    const { logger } = await import("../logger.js");
+    const warnSpy = vi.spyOn(logger, "warn");
+    (runReview as ReturnType<typeof vi.fn>)
+      .mockRejectedValueOnce(new Error("pass 0 fail"))
+      .mockResolvedValueOnce(makeResult())
+      .mockResolvedValueOnce(makeResult());
+
+    const consensusConfig = { ...config, consensusPasses: 3 };
+    await runConsensusReview([], consensusConfig, prMetadata, "diff content"); // no ticketContext
+
+    const ticketWarn = warnSpy.mock.calls.find(
+      (call) => typeof call[1] === "string" && call[1].includes("ticket compliance unavailable"),
+    );
+    expect(ticketWarn).toBeUndefined();
+  });
+});
+
 describe("RUSTY_LOG_RAW_FINDINGS", () => {
   beforeEach(() => {
     callCount = 0;

--- a/packages/core/src/agent/consensus.ts
+++ b/packages/core/src/agent/consensus.ts
@@ -168,6 +168,22 @@ export async function runConsensusReview(
     }
   }
 
+  // ticket compliance comes from pass 0 only — pass 0 is the single pass that
+  // received `ticketContext` (line 140 above; this is a deliberate token-cost
+  // optimization since linked tickets can be 5-10k tokens). settled[0] is
+  // always pass 0 because Promise.allSettled preserves input order. when pass
+  // 0 failed we have NO compliance data — returning a later pass's empty
+  // compliance array would silently read as "no requirements outstanding,"
+  // which is the opposite of the truth. emit an explicit warn and return empty.
+  const pass0Outcome = settled[0];
+  const pass0Result = pass0Outcome.status === "fulfilled" ? pass0Outcome.value : undefined;
+  if (!pass0Result && ticketContext && ticketContext.length > 0) {
+    logger.warn(
+      { prId: prMetadata.id, passes, failedPasses: failures.length },
+      "pass 0 failed; ticket compliance unavailable for this review (no fallback pass receives ticketContext)",
+    );
+  }
+
   if (results.length === 0) {
     throw new AggregateError(failures, `consensus review failed: 0/${passes} passes succeeded`);
   }
@@ -306,7 +322,7 @@ export async function runConsensusReview(
     recommendation,
     findings: survivingFindings,
     observations: survivingObservations,
-    ticketCompliance: results[0]?.ticketCompliance ?? [],
+    ticketCompliance: pass0Result?.ticketCompliance ?? [],
     missingTests: mergeMissingTests(results),
     filesReviewed: [...allFiles],
     modelUsed: results[0]?.modelUsed ?? "unknown",


### PR DESCRIPTION
## Summary

First of the four follow-ups from the radical review of `fix/code-review-bugs`. Replaces the no-op `pass0Result` fix with the actual structural correction.

## The bug

`consensus.ts` line 309 returned `results[0]?.ticketCompliance ?? []`. The flow:

1. Only pass 0 receives `ticketContext` (line 140 — `i === 0 ? ticketContext : undefined`). This is a deliberate token-cost optimization.
2. `results[]` collects fulfilled passes in iteration order — when pass 0 fails, `results[0]` is **pass 1, 2, …**, not pass 0.
3. Pass 1+ has `ticketCompliance: []` because it never saw the tickets.
4. The compliance table in the user-facing summary renders as "no requirements outstanding," which silently misrepresents "we have no compliance data at all" as "compliance passes."

## Why the WIP `pass0Result` fix was a no-op

```ts
let pass0Result: ReviewResult | undefined;
for (let i = 0; i < settled.length; i++) {
  const outcome = settled[i];
  if (outcome.status === "fulfilled") {
    if (i === 0) pass0Result = outcome.value;  // only set when pass 0 succeeds
    results.push(outcome.value);
  }
}
ticketCompliance: (pass0Result ?? results[0])?.ticketCompliance ?? [],
```

- Pass 0 succeeds: `pass0Result === results[0]` (same object). `(pass0Result ?? results[0])` resolves to either — same result.
- Pass 0 fails: `pass0Result === undefined`. Falls back to `results[0]` — which is pass 1's empty compliance. Identical to old behavior.

No execution path changes behavior.

## The fix

Use `settled[0]` directly (Promise.allSettled preserves input order, so `settled[0]` IS always pass 0 regardless of whether earlier passes failed):

```ts
const pass0Outcome = settled[0];
const pass0Result =
  pass0Outcome.status === "fulfilled" ? pass0Outcome.value : undefined;
if (!pass0Result && ticketContext && ticketContext.length > 0) {
  logger.warn({ prId, passes, failedPasses }, "pass 0 failed; ticket compliance unavailable …");
}
// ...
ticketCompliance: pass0Result?.ticketCompliance ?? [],
```

Plus an inline comment explaining the asymmetry so future readers don't try to "fix" it by extracting compliance from later passes.

No fallback to pass 1 is attempted — pass 1 never saw the ticket context, so any non-empty compliance there would be hallucinated. The honest answer is "we don't know."

## Tests

Four new tests in `consensus.test.ts`:

- pass 0 succeeds → `ticketCompliance` returned verbatim
- pass 0 fails + pass 1 has a hypothetically non-empty compliance → still returns empty (pass 1's data must not leak)
- warn log fires when pass 0 fails AND tickets were linked
- warn log does **not** fire when pass 0 fails but no tickets were linked (nothing was lost)

## Test plan

- [x] `pnpm --filter @rusty-bot/core test consensus.test.ts` — 800 pass
- [x] `pnpm test` — 971 across 34 files
- [x] `pnpm -r build` — all packages typecheck

## Future direction

Right now ticket compliance is single-point-of-failure on pass 0. Two structural ways to make it resilient (out of scope, captured for FOLLOWUPS):

1. **Send `ticketContext` to all passes**, merge compliance via the existing `mergeTicketCompliance()` in multi-call.ts. Cost: +5-10k tokens × (N-1) passes per review.
2. **Extract compliance into a separate cheap-model call** independent of the review passes. Cheaper, but adds a sequential step.

Neither lands here. The current PR just makes the failure mode honest.