### PR TITLE
perf(github): cache PR-comments fetch within a provider instance

### DIFF
--- a/packages/github/src/__tests__/provider.test.ts
+++ b/packages/github/src/__tests__/provider.test.ts
@@ -283,6 +283,82 @@ describe("GitHubProvider", () => {
     });
   });
 
+  describe("comment-fetch memoization", () => {
+    const ctx: PriorReviewContext = {
+      summary: "earlier review",
+      recommendation: "looks_good",
+      findings: [],
+    };
+
+    it("calls the comments API once even when both getLastReviewedSha and getPriorReviewContext are invoked", async () => {
+      // single mock response — if the second method were uncached it would
+      // hit a fresh `request` slot and get `undefined`, breaking the test
+      octokit.request.mockResolvedValueOnce({
+        data: [
+          {
+            id: 1,
+            body:
+              "<!-- rusty-bot-review -->\n" +
+              "<!-- rusty-bot:last-sha:abc123def4560000000000000000000000000000 -->\n" +
+              encodePriorReviewContext(ctx),
+          },
+        ],
+      });
+
+      const sha = await provider.getLastReviewedSha();
+      const decoded = await provider.getPriorReviewContext();
+
+      expect(sha).toBe("abc123def4560000000000000000000000000000");
+      expect(decoded).toEqual(ctx);
+
+      const commentFetchCalls = octokit.request.mock.calls.filter(
+        (call) => call[0] === "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      );
+      expect(commentFetchCalls).toHaveLength(1);
+    });
+
+    it("dedupes concurrent in-flight fetches into one API call", async () => {
+      // both calls fire before the request resolves; both must await the same
+      // in-flight promise so we still hit the API only once
+      let resolveFetch!: (value: { data: unknown[] }) => void;
+      octokit.request.mockReturnValueOnce(
+        new Promise((r) => {
+          resolveFetch = r;
+        }),
+      );
+
+      const shaPromise = provider.getLastReviewedSha();
+      const ctxPromise = provider.getPriorReviewContext();
+
+      resolveFetch({ data: [] });
+
+      await Promise.all([shaPromise, ctxPromise]);
+
+      const commentFetchCalls = octokit.request.mock.calls.filter(
+        (call) => call[0] === "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      );
+      expect(commentFetchCalls).toHaveLength(1);
+    });
+
+    it("re-fetches when a fresh provider instance is constructed (cache is per-instance)", async () => {
+      octokit.request.mockResolvedValueOnce({ data: [] }).mockResolvedValueOnce({ data: [] });
+
+      await provider.getLastReviewedSha();
+      const provider2 = new GitHubProvider({
+        octokit,
+        owner: OWNER,
+        repo: REPO,
+        pullNumber: PULL_NUMBER,
+      });
+      await provider2.getLastReviewedSha();
+
+      const commentFetchCalls = octokit.request.mock.calls.filter(
+        (call) => call[0] === "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
+      );
+      expect(commentFetchCalls).toHaveLength(2);
+    });
+  });
+
   describe("getDiffSinceSha", () => {
     const HEAD_SHA = "feedface0000000000000000000000000000face";
     const SINCE_SHA = "deadbeef0000000000000000000000000000beef";

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -167,7 +167,9 @@ function parseDiff(rawDiff: string): FilePatch[] {
 
 /** subset of github's IssueComment shape we actually read — we only care about
  * the body text, which carries the hidden bot markers. */
-interface CachedPRComment { body?: string | null }
+interface CachedPRComment {
+  body?: string | null;
+}
 
 export class GitHubProvider implements GitProvider {
   private readonly octokit: Octokit;

--- a/packages/github/src/provider.ts
+++ b/packages/github/src/provider.ts
@@ -165,17 +165,43 @@ function parseDiff(rawDiff: string): FilePatch[] {
   return patches;
 }
 
+/** subset of github's IssueComment shape we actually read — we only care about
+ * the body text, which carries the hidden bot markers. */
+interface CachedPRComment { body?: string | null }
+
 export class GitHubProvider implements GitProvider {
   private readonly octokit: Octokit;
   private readonly owner: string;
   private readonly repo: string;
   private readonly pullNumber: number;
+  /** in-flight (or resolved) promise for the PR comments fetch, scoped to the
+   * lifetime of this provider instance. `getLastReviewedSha` and
+   * `getPriorReviewContext` both walk the same comment list — without this
+   * cache, an incremental re-review fires two identical API calls for the
+   * same data. provider instances are constructed per-review (see cli.ts and
+   * orchestrator.ts) so the cache lifetime matches what we want: one fetch
+   * per review, never stale across reviews. */
+  private commentsPromise: Promise<CachedPRComment[]> | null = null;
 
   constructor(config: GitHubProviderConfig) {
     this.octokit = config.octokit;
     this.owner = config.owner;
     this.repo = config.repo;
     this.pullNumber = config.pullNumber;
+  }
+
+  /** fetch the issue comments list once per provider instance. concurrent
+   * callers that hit this before the fetch resolves all await the same
+   * in-flight promise. */
+  private async fetchPRCommentsCached(): Promise<CachedPRComment[]> {
+    this.commentsPromise ??= this.octokit
+      .request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", {
+        owner: this.owner,
+        repo: this.repo,
+        issue_number: this.pullNumber,
+      })
+      .then((response) => response.data as CachedPRComment[]);
+    return this.commentsPromise;
   }
 
   async getRawDiff(): Promise<string> {
@@ -218,14 +244,7 @@ export class GitHubProvider implements GitProvider {
   }
 
   async getLastReviewedSha(): Promise<string | null> {
-    const { data: comments } = await this.octokit.request(
-      "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
-      {
-        owner: this.owner,
-        repo: this.repo,
-        issue_number: this.pullNumber,
-      },
-    );
+    const comments = await this.fetchPRCommentsCached();
 
     // walk newest-first so a fresher marker wins if multiple bot comments survive
     for (let i = comments.length - 1; i >= 0; i--) {
@@ -238,14 +257,7 @@ export class GitHubProvider implements GitProvider {
   }
 
   async getPriorReviewContext(): Promise<PriorReviewContext | null> {
-    const { data: comments } = await this.octokit.request(
-      "GET /repos/{owner}/{repo}/issues/{issue_number}/comments",
-      {
-        owner: this.owner,
-        repo: this.repo,
-        issue_number: this.pullNumber,
-      },
-    );
+    const comments = await this.fetchPRCommentsCached();
 
     // walk newest-first; only return the most recent prior context
     for (let i = comments.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary

Second of the four follow-ups from the radical review of `fix/code-review-bugs`. Replaces the unused-public-method approach with actual memoization at the fetch layer.

## The bug

`getLastReviewedSha()` and `getPriorReviewContext()` both walk the **same** issue-comments list to extract their respective hidden bot markers (`<!-- rusty-bot:last-sha:... -->` and `<!-- rusty-bot:context:... -->`). On every incremental re-review, `github-action/src/cli.ts` calls both in sequence:

```ts
lastReviewedSha = await provider.getLastReviewedSha();
if (lastReviewedSha) {
  priorContext = await provider.getPriorReviewContext();
}
```

Before this change, that's **two identical `GET /repos/{owner}/{repo}/issues/{n}/comments` requests** to fetch the same payload, then parse it twice.

## Why the WIP `getPriorState` approach didn't ship

The WIP added a public `getPriorState()` that internally fetched once and extracted both markers — but kept the two old methods as public delegates that **each called `getPriorState`** independently. So a caller invoking both old methods still triggered two API calls. The "perf" gain was only available to callers updated to use `getPriorState` directly, and no caller in the stash was updated.

## The fix in this PR

Cache at the fetch layer instead. The class now holds a `commentsPromise: Promise<CachedPRComment[]> | null` field; both methods call a private `fetchPRCommentsCached()` that lazily populates the promise. Concurrent callers all await the same in-flight promise.

```ts
private commentsPromise: Promise<CachedPRComment[]> | null = null;

private async fetchPRCommentsCached(): Promise<CachedPRComment[]> {
  this.commentsPromise ??= this.octokit
    .request("GET /repos/{owner}/{repo}/issues/{issue_number}/comments", { ... })
    .then((r) => r.data as CachedPRComment[]);
  return this.commentsPromise;
}
```

- **No public API changes** — callers don't have to update anything to benefit.
- **Per-instance lifetime** — provider instances are constructed per-review in `cli.ts` and `orchestrator.ts`, so the cache lifetime is exactly "one review." No risk of stale data across reviews.
- **Concurrent-safe** — multiple callers hitting the method before the fetch resolves share the same in-flight promise.

## Test plan

- [x] Existing `getLastReviewedSha` and `getPriorReviewContext` tests still pass (the cache is initialized fresh in `beforeEach`, so per-test mocks behave as before)
- [x] New tests cover:
  - sequential calls on the same instance → 1 API call
  - concurrent calls before the in-flight fetch resolves → still 1 API call
  - two fresh provider instances → 2 API calls (cache is per-instance, not process-global)
- [x] `pnpm test` — 970 across 34 files
- [x] `pnpm -r build` — all packages typecheck