### PR TITLE
fix(github-storage): serialize concurrent writes through a promise-chain mutex

### DIFF
--- a/packages/github/src/__tests__/storage.test.ts
+++ b/packages/github/src/__tests__/storage.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { ReviewRecord, RepoConfig } from "../storage.js";
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  mkdir: vi.fn(async () => undefined),
+}));
+
+const fs = await import("node:fs/promises");
+const { saveReview, setRepoConfig, setSetting } = await import("../storage.js");
+
+const readFile = vi.mocked(fs.readFile);
+const writeFile = vi.mocked(fs.writeFile);
+
+function makeReview(id: string): ReviewRecord {
+  return {
+    id,
+    owner: "test",
+    repo: "test",
+    prNumber: 1,
+    timestamp: new Date().toISOString(),
+    findingsCount: 0,
+    criticalCount: 0,
+    warningCount: 0,
+    suggestionCount: 0,
+    modelUsed: "test-model",
+    tokenCount: 100,
+    recommendation: "looks_good",
+    prUrl: "https://example.com/pr/1",
+  };
+}
+
+function makeConfig(owner: string, repo: string): RepoConfig {
+  return {
+    owner,
+    repo,
+    style: "balanced",
+    focusAreas: [],
+    ignorePatterns: [],
+  };
+}
+
+describe("storage write-lock serialization", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readFile.mockResolvedValue(JSON.stringify({ configs: {}, reviews: [], settings: {} }));
+    writeFile.mockResolvedValue(undefined);
+  });
+
+  it("serializes two concurrent saveReview calls (no interleaved read/write)", async () => {
+    // record every fs op in call-order so we can verify it never goes
+    // read→read→write→write (which would be the buggy interleave)
+    const events: string[] = [];
+    readFile.mockImplementation(async () => {
+      events.push("read");
+      // give the other concurrent caller a chance to interleave if not serialized
+      await new Promise((r) => setTimeout(r, 5));
+      return JSON.stringify({ configs: {}, reviews: [], settings: {} });
+    });
+    writeFile.mockImplementation(async () => {
+      events.push("write");
+    });
+
+    await Promise.all([saveReview(makeReview("r1")), saveReview(makeReview("r2"))]);
+
+    // serialized: read, write, read, write — never read, read, write, write
+    expect(events).toEqual(["read", "write", "read", "write"]);
+  });
+
+  it("serializes mixed write types (setRepoConfig + saveReview + setSetting)", async () => {
+    const events: string[] = [];
+    readFile.mockImplementation(async () => {
+      events.push("read");
+      await new Promise((r) => setTimeout(r, 2));
+      return JSON.stringify({ configs: {}, reviews: [], settings: {} });
+    });
+    writeFile.mockImplementation(async () => {
+      events.push("write");
+    });
+
+    await Promise.all([
+      setRepoConfig("a", "b", makeConfig("a", "b")),
+      saveReview(makeReview("r1")),
+      setSetting("k", "v"),
+    ]);
+
+    // 3 writes, all serialized — no interleaving regardless of mutation type
+    expect(events.filter((e) => e === "read")).toHaveLength(3);
+    expect(events.filter((e) => e === "write")).toHaveLength(3);
+    // every read should be followed immediately by its own write
+    for (let i = 0; i < events.length; i += 2) {
+      expect(events[i]).toBe("read");
+      expect(events[i + 1]).toBe("write");
+    }
+  });
+
+  it("does not break the serialization chain when a write throws", async () => {
+    // first write rejects on save; the second write must still execute
+    // afterwards (the lock chain has to recover from rejected upstream)
+    let writeCallCount = 0;
+    readFile.mockResolvedValue(JSON.stringify({ configs: {}, reviews: [], settings: {} }));
+    writeFile.mockImplementation(async () => {
+      writeCallCount++;
+      if (writeCallCount === 1) throw new Error("disk full (simulated)");
+    });
+
+    const failing = saveReview(makeReview("r1"));
+    const succeeding = saveReview(makeReview("r2"));
+
+    await expect(failing).rejects.toThrow("disk full");
+    await expect(succeeding).resolves.toBe("r2"); // didn't get stuck behind the rejection
+    expect(writeCallCount).toBe(2);
+  });
+});

--- a/packages/github/src/storage.ts
+++ b/packages/github/src/storage.ts
@@ -66,6 +66,29 @@ async function saveData(data: StorageData): Promise<void> {
   await writeFile(DATA_FILE, JSON.stringify(data, null, 2), "utf-8");
 }
 
+// serialize all writes through a promise chain — every mutating storage call
+// follows a load→mutate→save pattern that isn't atomic. without this, two
+// reviews completing roughly simultaneously can both read the same `data`,
+// each apply their mutation in memory, and the second `saveData` wins —
+// clobbering the first review's record entirely.
+//
+// this is a band-aid on the JSON-file storage choice. atomic row-level writes
+// would eliminate the need for the lock; see FOLLOWUPS.md for the migration
+// note. shipping the band-aid because the race is observable today and the
+// migration is a separate, larger piece of work.
+let writeQueue: Promise<unknown> = Promise.resolve();
+
+function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = writeQueue.then(fn, fn);
+  // keep the chain unbroken even when fn rejects — otherwise an error in one
+  // caller would break serialization for the next
+  writeQueue = next.then(
+    () => undefined,
+    () => undefined,
+  );
+  return next;
+}
+
 export async function getRepoConfig(owner: string, repo: string): Promise<RepoConfig | null> {
   const data = await loadData();
   return data.configs[makeConfigKey(owner, repo)] ?? null;
@@ -76,9 +99,11 @@ export async function setRepoConfig(
   repo: string,
   config: RepoConfig,
 ): Promise<void> {
-  const data = await loadData();
-  data.configs[makeConfigKey(owner, repo)] = config;
-  await saveData(data);
+  await withWriteLock(async () => {
+    const data = await loadData();
+    data.configs[makeConfigKey(owner, repo)] = config;
+    await saveData(data);
+  });
 }
 
 export async function listRepoConfigs(): Promise<RepoConfigWithId[]> {
@@ -87,10 +112,12 @@ export async function listRepoConfigs(): Promise<RepoConfigWithId[]> {
 }
 
 export async function saveReview(review: ReviewRecord): Promise<string> {
-  const data = await loadData();
-  data.reviews.push(review);
-  await saveData(data);
-  return review.id;
+  return withWriteLock(async () => {
+    const data = await loadData();
+    data.reviews.push(review);
+    await saveData(data);
+    return review.id;
+  });
 }
 
 export async function listReviews(limit = 50, offset = 0): Promise<ReviewRecord[]> {
@@ -123,9 +150,11 @@ export async function getSetting(key: string): Promise<string | null> {
 }
 
 export async function setSetting(key: string, value: string): Promise<void> {
-  const data = await loadData();
-  data.settings[key] = value;
-  await saveData(data);
+  await withWriteLock(async () => {
+    const data = await loadData();
+    data.settings[key] = value;
+    await saveData(data);
+  });
 }
 
 export async function getSettings(): Promise<Record<string, string>> {


### PR DESCRIPTION
## Summary

Third of the four follow-ups from the radical review of `fix/code-review-bugs`. Ships the write-lock fix as a deliberate band-aid, with the structural migration tracked in FOLLOWUPS.

## The race

`setRepoConfig`, `saveReview`, and `setSetting` each follow a `load → mutate → save` pattern against a single JSON file (`data/config.json`). There's no atomicity between the read and the write, so two concurrent operations can interleave:

| time | operation A | operation B |
|---|---|---|
| t=0 | `data = await loadData()` (reviews: []) | |
| t=1 | | `data = await loadData()` (reviews: []) |
| t=2 | `data.reviews.push(a)` | |
| t=3 | | `data.reviews.push(b)` |
| t=4 | `await saveData(data)` → reviews: [a] | |
| t=5 | | `await saveData(data)` → reviews: [b] |

Final state: `[b]`. Review `a` is lost. Observable when bursts of webhooks arrive close together.

## Fix

A promise-chain mutex serializes all writes:

```ts
let writeQueue: Promise<unknown> = Promise.resolve();

function withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
  const next = writeQueue.then(fn, fn);
  writeQueue = next.then(
    () => undefined,
    () => undefined,
  );
  return next;
}
```

The `then(fn, fn)` ensures the next operation runs whether the previous one fulfilled or rejected; the second `.then(..., ...)` collapses the queue's tracked state to `void` so a single failing operation doesn't leak its rejection into subsequent callers' chains.

All three write entry points now wrap their body in `withWriteLock`:

- `setRepoConfig` → withWriteLock
- `saveReview` → withWriteLock
- `setSetting` → withWriteLock

Reads (`getRepoConfig`, `getSettings`, `listReviews`, `listReviewsPage`, `getReview`, `getSetting`, `listRepoConfigs`) remain unlocked — read-only paths don't have the race.

## Why this is a band-aid, not the fix

The need for an application-level write lock is a smoke signal that the JSON file is the wrong storage abstraction. The same trajectory will keep accumulating:

- This PR: write lock for atomicity
- Next: an index for fast `getReview(id)` lookups (today: O(N) linear scan)
- After: real pagination (today `listReviewsPage` loads all reviews and reverses in memory)
- Eventually: schema migrations, point-in-time recovery, etc

I added a **FOLLOWUPS entry (#12)** that lays out the migration to SQLite — atomic row writes are free, indexes are free, `listReviewsPage` becomes a real query. That's the right structural answer; this PR just makes the current setup safe enough to keep using until the migration lands.

## Test plan

New `src/__tests__/storage.test.ts` (3 tests):

- Two concurrent `saveReview` calls produce `[read, write, read, write]` event ordering, never `[read, read, write, write]` (which would prove the race)
- Mixed-type concurrent writes (setRepoConfig + saveReview + setSetting) all serialize correctly
- A failing write doesn't break the chain for subsequent writes (deadlock-resistance)

- [x] `pnpm test` — 970 across 35 files
- [x] `pnpm -r build` — all packages typecheck