### PR TITLE
feat(github-server): webhook delivery dedupe + concurrency semaphore

### DIFF
--- a/packages/github/src/__tests__/server.test.ts
+++ b/packages/github/src/__tests__/server.test.ts
@@ -217,6 +217,93 @@ describe("server", () => {
     });
   });
 
+  describe("webhook delivery dedupe", () => {
+    it("returns duplicate:true on a second request with the same X-GitHub-Delivery", async () => {
+      const { orchestrateReview } = await import("../orchestrator.js");
+      const orchestrateMock = vi.mocked(orchestrateReview);
+      orchestrateMock.mockClear();
+
+      // make orchestrateReview hang so the in-flight set still has the
+      // delivery id when the duplicate comes in
+      let resolveOrchestrate!: () => void;
+      orchestrateMock.mockImplementationOnce(
+        () =>
+          new Promise<void>((r) => {
+            resolveOrchestrate = r;
+          }),
+      );
+
+      const body = JSON.stringify(makePRPayload({ number: 7 }));
+      const deliveryId = "11111111-1111-1111-1111-111111111111";
+      const headers = {
+        "Content-Type": "application/json",
+        "x-github-event": "pull_request",
+        "x-github-delivery": deliveryId,
+        "x-hub-signature-256": sign(body, WEBHOOK_SECRET),
+      };
+
+      const first = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+      expect(await first.json()).toMatchObject({ ok: true });
+
+      const second = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+      expect(await second.json()).toMatchObject({ ok: true, duplicate: true });
+
+      // free the in-flight review so the test can finish
+      resolveOrchestrate();
+      // let the microtask queue drain so the dedupe set is cleaned up before
+      // any subsequent tests reuse the id
+      await new Promise<void>((r) => setTimeout(r, 0));
+    });
+
+    it("does not flag duplicates when the X-GitHub-Delivery header is missing", async () => {
+      // without the header, every request is treated as unique — matches
+      // legacy clients that don't set the header
+      const { orchestrateReview } = await import("../orchestrator.js");
+      (orchestrateReview as ReturnType<typeof vi.fn>).mockReset();
+      (orchestrateReview as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      const body = JSON.stringify(makePRPayload({ number: 8 }));
+      const headers = {
+        "Content-Type": "application/json",
+        "x-github-event": "pull_request",
+        "x-hub-signature-256": sign(body, WEBHOOK_SECRET),
+      };
+
+      const first = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+      const second = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+
+      expect(await first.json()).not.toMatchObject({ duplicate: true });
+      expect(await second.json()).not.toMatchObject({ duplicate: true });
+    });
+
+    it("allows the same delivery id to be processed again after the first completes", async () => {
+      const { orchestrateReview } = await import("../orchestrator.js");
+      (orchestrateReview as ReturnType<typeof vi.fn>).mockReset();
+      (orchestrateReview as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+
+      const body = JSON.stringify(makePRPayload({ number: 9 }));
+      const deliveryId = "22222222-2222-2222-2222-222222222222";
+      const headers = {
+        "Content-Type": "application/json",
+        "x-github-event": "pull_request",
+        "x-github-delivery": deliveryId,
+        "x-hub-signature-256": sign(body, WEBHOOK_SECRET),
+      };
+
+      const first = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+      expect(await first.json()).toMatchObject({ ok: true });
+
+      // wait for the fire-and-forget runReview to clean up the delivery id
+      await new Promise<void>((r) => setTimeout(r, 10));
+
+      const second = await app.request("/api/webhooks/github", { method: "POST", headers, body });
+      // not flagged as duplicate because the first run already completed and
+      // removed the id from the in-flight set
+      expect(await second.json()).toMatchObject({ ok: true });
+      expect(await second.json().catch(() => ({}))).not.toMatchObject({ duplicate: true });
+    });
+  });
+
   describe("config CRUD", () => {
     it("returns empty list initially", async () => {
       const res = await app.request("/api/config/repos");

--- a/packages/github/src/server.ts
+++ b/packages/github/src/server.ts
@@ -22,6 +22,42 @@ import {
 
 const log = logger.child({ package: "github" });
 
+// in-memory webhook delivery dedupe. github retries webhooks on timeout, and
+// a slow review dispatch would otherwise trigger a second full review for the
+// same delivery. NOTE: this set is per-process — multi-instance deployments
+// behind a load balancer need a shared-storage replacement (see FOLLOWUPS).
+const inFlightDeliveries = new Set<string>();
+
+// concurrency semaphore so a burst of webhooks doesn't exhaust the LLM rate
+// limit or OOM the node process. NOTE: also per-process — see FOLLOWUPS.
+const MAX_CONCURRENT_REVIEWS = (() => {
+  const raw = process.env.RUSTY_MAX_CONCURRENT_REVIEWS;
+  if (raw === undefined || raw === "") return 5;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 5;
+})();
+let activeReviews = 0;
+const reviewQueue: (() => void)[] = [];
+
+function acquireReviewSlot(): Promise<void> {
+  if (activeReviews < MAX_CONCURRENT_REVIEWS) {
+    activeReviews++;
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => reviewQueue.push(resolve));
+}
+
+function releaseReviewSlot(): void {
+  const next = reviewQueue.shift();
+  if (next) {
+    // hand the slot directly to the next waiter — keeps activeReviews stable
+    // at MAX_CONCURRENT_REVIEWS so we don't transiently exceed it
+    next();
+  } else {
+    activeReviews--;
+  }
+}
+
 export const app = new Hono();
 
 app.use("*", cors());
@@ -42,6 +78,7 @@ function redactSettings(settings: Record<string, string>): Record<string, string
 app.post("/api/webhooks/github", async (c) => {
   const secret = process.env.GITHUB_WEBHOOK_SECRET ?? "";
   const signature = c.req.header("x-hub-signature-256") ?? "";
+  const deliveryId = c.req.header("x-github-delivery") ?? "";
   const rawBody = await c.req.text();
 
   if (!validateWebhookSignature(rawBody, signature, secret)) {
@@ -78,6 +115,15 @@ app.post("/api/webhooks/github", async (c) => {
     return c.json({ ignored: true, reason: "bot PR" });
   }
 
+  // dedupe duplicate webhook deliveries (same X-GitHub-Delivery). github
+  // retries on timeout; returning 200 fast prevents most retries, but this
+  // guards the cases where the retry races our reply.
+  if (deliveryId && inFlightDeliveries.has(deliveryId)) {
+    log.info({ deliveryId }, "duplicate webhook delivery, ignoring");
+    return c.json({ ok: true, duplicate: true });
+  }
+  if (deliveryId) inFlightDeliveries.add(deliveryId);
+
   const installation = payload.installation as Record<string, unknown> | undefined;
   const installationId = Number(installation?.id);
   const repoData = payload.repository as Record<string, unknown>;
@@ -92,10 +138,24 @@ app.post("/api/webhooks/github", async (c) => {
     privateKey = await readFile(process.env.GITHUB_PRIVATE_KEY_PATH, "utf-8");
   }
 
-  // dispatch review async so we return 200 immediately
-  createAppOctokit(appId, privateKey, installationId)
-    .then((octokit) => orchestrateReview({ octokit, owner, repo, pullNumber, installationId }))
-    .catch((err: unknown) => log.error({ err }, "failed to dispatch review"));
+  // dispatch review async so we return 200 immediately; acquire a slot from
+  // the concurrency semaphore before starting so bursts don't OOM or get
+  // rate-limited by the LLM provider. release in finally so a thrown review
+  // doesn't leak the slot.
+  const runReview = async () => {
+    await acquireReviewSlot();
+    try {
+      const octokit = await createAppOctokit(appId, privateKey, installationId);
+      await orchestrateReview({ octokit, owner, repo, pullNumber, installationId });
+    } catch (err: unknown) {
+      log.error({ err }, "review failed");
+    } finally {
+      releaseReviewSlot();
+      if (deliveryId) inFlightDeliveries.delete(deliveryId);
+    }
+  };
+
+  runReview().catch((err: unknown) => log.error({ err }, "failed to dispatch review"));
 
   return c.json({ ok: true });
 });


### PR DESCRIPTION
## Summary

Fourth and final follow-up from the radical review of `fix/code-review-bugs`. Ships two in-process safety mechanisms for the GitHub App webhook server, with the single-instance limitation called out explicitly in FOLLOWUPS.

## What this fixes

**1. Webhook delivery dedupe**

GitHub retries webhook deliveries when the server doesn't ACK within 10s. If a review dispatch takes longer (or the response races a retry), the same `X-GitHub-Delivery` ID can hit the server twice — without dedupe, both retries kick off independent full reviews of the same PR.

The new `inFlightDeliveries: Set<string>` tracks deliveries currently being processed. On the second request with the same ID, the handler returns `{ok: true, duplicate: true}` and bails. Entries are added before dispatch and removed in the `runReview` finally block — so a thrown review still cleans up its slot (no leak).

**2. Concurrency semaphore**

A burst of webhook events (e.g. someone force-pushes a stack of 10 PRs) used to fan out into 10 concurrent reviews, each grabbing LLM rate limits and memory. The semaphore caps concurrent reviews at `MAX_CONCURRENT_REVIEWS` (configurable via `RUSTY_MAX_CONCURRENT_REVIEWS`, default 5). Excess reviews queue and pick up slots as they free.

Slot release hands the slot **directly** to the next waiter without going through `activeReviews--` first, so the cap is never transiently exceeded by races.

## Why this is single-instance only

Both mechanisms live in module-local memory. They work correctly for one server replica. The moment the server is scaled to multiple instances behind a load balancer:

- A duplicate delivery routed to a different replica is no longer detected as a duplicate.
- The semaphore caps per-instance, not in aggregate. 5 replicas × cap of 5 = 25 reviews concurrently in the cluster.

That's explicitly fine for the current deployment shape, and explicitly flagged in **FOLLOWUPS #13** so the scaling story has a written migration plan (Redis-based dedupe + a real queue) when it becomes relevant.

## Tests (in `server.test.ts`)

- Duplicate delivery id returns `{ok: true, duplicate: true}` on the second request
- Missing `X-GitHub-Delivery` header → every request is treated as unique (legacy clients won't all set the header; the dedupe is opportunistic, not mandatory)
- Delivery id is re-allowed after the first review completes (the in-flight set cleans up correctly on success)

## Test plan

- [x] `pnpm test` — 970 across 34 files
- [x] `pnpm -r build` — all packages typecheck

## Note on the WIP origin

The earlier WIP in `fix/code-review-bugs` had both of these mechanisms bundled with the storage write-lock and several other unrelated changes. This PR ships just the server-side concurrency-safety pair, with FOLLOWUPS-#13 capturing the structural ceiling. The storage write-lock shipped separately in PR #196, with its own structural ceiling captured in FOLLOWUPS-#12.